### PR TITLE
feat(upgrade): package-manager-aware amq upgrade with companion --all

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,19 +167,23 @@ not install it. Install it the same way, then see
 [amq-acp](cmd/amq-acp/README.md).
 
 Once the companions sit next to a direct-install `amq` or in `~/.local/bin`,
-`amq upgrade --all` upgrades one distinct canonical target for each companion
-from the same release tag with checksum verification, and skips any that are
-absent with a line. Multiple distinct copies refuse the companion upgrade and
-list their paths. A running `amq-keepalive` is never killed: the atomic rename
-swaps the path while the running process keeps the old image, and a running
-supervisor picks up the new image on its next supervise pass (self-upgrade); a
-supervisor started with `--no-self-upgrade` is restarted with
-`amq-keepalive install-launchd`. `amq upgrade` itself detects a Homebrew or
-Scoop install of `amq` and delegates to the matched package-manager executable
-(`brew update && brew upgrade amq` / `scoop update amq`; `-y` runs the
-delegate without an AMQ prompt, while the package manager may still prompt)
-instead of overwriting it, so companions upgrade through `--all` only from a
-direct `amq` install.
+`amq upgrade --all` plans one verified target per companion, unique across all
+companions, before any replacement. It verifies each target's Go build identity,
+uses the same release tag with checksum verification, and skips any absent
+companion with a line. Aliases, wrong builds, and multiple distinct copies
+refuse the companion upgrade and give a repair action. A running
+`amq-keepalive` is never killed: the atomic rename swaps the path while the
+running process keeps the old image, and a running supervisor picks up the new
+image on its next supervise pass (self-upgrade); a supervisor started with
+`--no-self-upgrade` is restarted with `amq-keepalive install-launchd`.
+`amq upgrade` itself detects a Homebrew or Scoop install of `amq` and delegates
+to the matched package-manager executable (`brew update && brew upgrade amq` /
+`scoop update amq`; `-y` runs the delegate without an AMQ prompt, while the
+package manager may still prompt) instead of overwriting it, so companions
+upgrade through `--all` only from a direct `amq` install. The version cache is
+written only after the core `amq` replacement succeeds; a later companion
+failure still leaves that cache truthful. On Windows, `--all` skips companions
+because they are not published there, then continues with the core upgrade.
 
 ### Platform capability matrix
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -169,7 +169,8 @@ published as `amq-acp_*_{linux,darwin}_{amd64,arm64}.tar.gz`. Homebrew does
 not install it. Install it the same way, then see
 [amq-acp](cmd/amq-acp/README.md).
 
-Once the companions sit next to a direct-install `amq` or in `~/.local/bin`,
+Once the companions sit in the raw or resolved executable directory of a
+direct-install `amq`, or in `~/.local/bin`,
 `amq upgrade --all` plans one verified target per companion, unique across all
 companions, before any companion replacement. It verifies each target's Go
 build identity, uses the same release tag with checksum verification, and
@@ -185,12 +186,18 @@ use `amq-keepalive install-launchd`, and on Linux restart the service unit, for
 example `systemctl --user restart amq-keepalive.service`.
 `amq upgrade` itself detects a Homebrew or Scoop install of `amq` and delegates
 to the matched package-manager executable (`brew update && brew upgrade amq` /
-`scoop update amq`; `-y` runs the delegate without an AMQ prompt, while the
-package manager may still prompt) instead of overwriting it, so companions
-upgrade through `--all` only from a direct `amq` install. The version cache is
-written only after the core `amq` replacement succeeds; a later companion
-failure still leaves that cache truthful. On Windows, `--all` skips companions
-because they are not published there, then continues with the core upgrade.
+`scoop update amq` for user scope / `scoop update -g amq` for global scope;
+`-y` runs the delegate without an AMQ prompt, while the package manager may
+still prompt) instead of overwriting it, so companions upgrade through
+`--all` only from a direct `amq` install. Scoop user scope comes from `$SCOOP`
+or the default `%USERPROFILE%\scoop`; global scope comes from
+`$SCOOP_GLOBAL` or `C:\ProgramData\scoop`. The version cache is refreshed
+after an authoritative direct check confirms the latest version (already
+current, or after a successful immediate replacement). A scheduled replacement
+is refreshed on the next successful check (best-effort). On Windows, `--all`
+skips companions because they are not published there, then continues with the
+core upgrade. Companion links are revalidated by their primary path; a
+secondary same-name alias repointed during download is not detected.
 
 ### Platform capability matrix
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,16 +167,19 @@ not install it. Install it the same way, then see
 [amq-acp](cmd/amq-acp/README.md).
 
 Once the companions sit next to a direct-install `amq` or in `~/.local/bin`,
-`amq upgrade --all` refreshes every present companion from the same release
-tag with checksum verification, and skips any that are absent with a line. A
-running `amq-keepalive` is never killed: the atomic rename swaps the path
-while the running process keeps the old image, and a running supervisor picks
-up the new image on its next supervise pass (self-upgrade); a supervisor
-started with `--no-self-upgrade` is restarted with `amq-keepalive install-launchd`.
-`amq upgrade` itself detects a Homebrew or Scoop install of `amq` and
-delegates to the package manager (`brew upgrade amq` / `scoop update amq`;
-`-y` runs the delegate) instead of overwriting it, so the companions upgrade
-through `--all` only from a direct `amq` install.
+`amq upgrade --all` upgrades one distinct canonical target for each companion
+from the same release tag with checksum verification, and skips any that are
+absent with a line. Multiple distinct copies refuse the companion upgrade and
+list their paths. A running `amq-keepalive` is never killed: the atomic rename
+swaps the path while the running process keeps the old image, and a running
+supervisor picks up the new image on its next supervise pass (self-upgrade); a
+supervisor started with `--no-self-upgrade` is restarted with
+`amq-keepalive install-launchd`. `amq upgrade` itself detects a Homebrew or
+Scoop install of `amq` and delegates to the matched package-manager executable
+(`brew update && brew upgrade amq` / `scoop update amq`; `-y` runs the
+delegate without an AMQ prompt, while the package manager may still prompt)
+instead of overwriting it, so companions upgrade through `--all` only from a
+direct `amq` install.
 
 ### Platform capability matrix
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,11 +150,14 @@ mv -f "$HOME/.local/bin/.amq-keepalive.new" "$HOME/.local/bin/amq-keepalive"
 ```
 
 Use that same path for `attach`, `install-launchd`, and `install-hook`. Upgrades
-and rollbacks replace the file at the stable path; a running supervisor picks
-up the new image on its next supervise pass (self-upgrade), and a supervisor
-started with `--no-self-upgrade` is restarted with
-`amq-keepalive install-launchd`. The registry is
-retained; do not move the executable while registered wakes still identify it.
+and rollbacks replace the file at the stable path. A running supervisor picks
+up a strictly newer image on its next supervise pass (self-upgrade); it does
+not pick up an older rollback or an equal-version replacement. Restart a
+supervisor through its service manager for those cases, or when it was started
+with `--no-self-upgrade`. On macOS use `amq-keepalive install-launchd`; on
+Linux restart the service unit, for example
+`systemctl --user restart amq-keepalive.service`. The registry is retained; do
+not move the executable while registered wakes still identify it.
 
 The optional cross-host courier is published separately as
 `amq-bridge_*_{linux,darwin}_{amd64,arm64}.tar.gz`. Homebrew does not install
@@ -168,14 +171,18 @@ not install it. Install it the same way, then see
 
 Once the companions sit next to a direct-install `amq` or in `~/.local/bin`,
 `amq upgrade --all` plans one verified target per companion, unique across all
-companions, before any replacement. It verifies each target's Go build identity,
-uses the same release tag with checksum verification, and skips any absent
-companion with a line. Aliases, wrong builds, and multiple distinct copies
-refuse the companion upgrade and give a repair action. A running
+companions, before any companion replacement. It verifies each target's Go
+build identity, uses the same release tag with checksum verification, and
+skips any absent companion with a line. Cross-companion aliases, wrong builds,
+and multiple distinct targets refuse the companion upgrade and give a repair
+action. Same-name symlink aliases to one canonical target are accepted;
+same-name hardlinks refuse. A running
 `amq-keepalive` is never killed: the atomic rename swaps the path while the
-running process keeps the old image, and a running supervisor picks up the new
-image on its next supervise pass (self-upgrade); a supervisor started with
-`--no-self-upgrade` is restarted with `amq-keepalive install-launchd`.
+running process keeps the old image, and a running supervisor picks up a
+strictly newer image on its next supervise pass (self-upgrade). A supervisor started with
+`--no-self-upgrade` must be restarted through its service manager; on macOS
+use `amq-keepalive install-launchd`, and on Linux restart the service unit, for
+example `systemctl --user restart amq-keepalive.service`.
 `amq upgrade` itself detects a Homebrew or Scoop install of `amq` and delegates
 to the matched package-manager executable (`brew update && brew upgrade amq` /
 `scoop update amq`; `-y` runs the delegate without an AMQ prompt, while the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,8 +150,10 @@ mv -f "$HOME/.local/bin/.amq-keepalive.new" "$HOME/.local/bin/amq-keepalive"
 ```
 
 Use that same path for `attach`, `install-launchd`, and `install-hook`. Upgrades
-and rollbacks replace the file at the stable path, then rerun
-`amq-keepalive install-launchd` to restart the supervisor. The registry is
+and rollbacks replace the file at the stable path; a running supervisor picks
+up the new image on its next supervise pass (self-upgrade), and a supervisor
+started with `--no-self-upgrade` is restarted with
+`amq-keepalive install-launchd`. The registry is
 retained; do not move the executable while registered wakes still identify it.
 
 The optional cross-host courier is published separately as
@@ -163,6 +165,18 @@ See [amq-bridge](cmd/amq-bridge/README.md). The preview ACP v1 companion is
 published as `amq-acp_*_{linux,darwin}_{amd64,arm64}.tar.gz`. Homebrew does
 not install it. Install it the same way, then see
 [amq-acp](cmd/amq-acp/README.md).
+
+Once the companions sit next to a direct-install `amq` or in `~/.local/bin`,
+`amq upgrade --all` refreshes every present companion from the same release
+tag with checksum verification, and skips any that are absent with a line. A
+running `amq-keepalive` is never killed: the atomic rename swaps the path
+while the running process keeps the old image, and a running supervisor picks
+up the new image on its next supervise pass (self-upgrade); a supervisor
+started with `--no-self-upgrade` is restarted with `amq-keepalive install-launchd`.
+`amq upgrade` itself detects a Homebrew or Scoop install of `amq` and
+delegates to the package manager (`brew upgrade amq` / `scoop update amq`;
+`-y` runs the delegate) instead of overwriting it, so the companions upgrade
+through `--all` only from a direct `amq` install.
 
 ### Platform capability matrix
 

--- a/README.md
+++ b/README.md
@@ -215,26 +215,33 @@ amq upgrade --all
 ```
 
 The command plans one verified target per companion, unique across all
-companions, before any replacement. It verifies each target's Go build
-identity. Missing companions are skipped with a line; aliases, wrong builds,
-and multiple distinct copies refuse the upgrade and give a repair action. A
+companions, before any companion replacement. It verifies each target's Go
+build identity. Missing companions are skipped with a line; cross-companion
+aliases, wrong builds, and multiple distinct targets refuse the upgrade and
+give a repair action. Same-name symlink aliases to one canonical target are
+accepted; same-name hardlinks refuse. A
 running `amq-keepalive` is never killed: the atomic rename swaps the path
 while the running process keeps the old image.
 When the upgraded path is the supervisor's path, `amq upgrade --all` notes
-that self-upgrade can pick up the new image on its next supervise pass; a
-supervisor started with `--no-self-upgrade` is restarted with
-`amq-keepalive install-launchd`. Companions are direct-installed only; the
+that self-upgrade can pick up a strictly newer image on its next supervise pass. A
+supervisor started with `--no-self-upgrade` must be restarted through its
+service manager; on macOS use `amq-keepalive install-launchd`, and on Linux
+restart the service unit, for example
+`systemctl --user restart amq-keepalive.service`. Companions are
+direct-installed only; the
 Homebrew formula and Scoop manifest ship `amq` itself, so `--all` under a
 package-managed install is a no-op with an explanatory line.
 
 `AMQ_CACHE_DIR` overrides the update cache location used by `amq upgrade` and
 the background update notifier. When unset, the platform cache
-(`~/Library/Caches` on macOS, `XDG_CACHE_HOME` or `~/.cache` elsewhere) is
-used. For the direct-upgrade cache-writing path, a set override must resolve
-to an absolute path; AMQ fails before replacement rather than silently
-falling back to the platform cache. The version cache is written only after
-the core `amq` replacement succeeds; a later companion failure still leaves
-that cache truthful.
+(`~/Library/Caches` on macOS, `XDG_CACHE_HOME` or `~/.cache` on Linux and
+other Unix systems, and the user's Local AppData cache on Windows) is used.
+`internal/update.DefaultCachePath` is the sole authority for the platform
+update-cache path. For the direct-upgrade cache-writing path, a set override
+must resolve to an absolute path; AMQ fails before replacement rather than
+silently falling back to the platform cache. The version cache is written
+only after the core `amq` replacement succeeds; a later companion failure
+still leaves that cache truthful.
 
 On Windows, `amq upgrade --all` prints a skip line for companions because
 companion binaries are not published for Windows, then continues with the

--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ Homebrew:
 brew upgrade amq
 ```
 
+`amq upgrade` detects a Homebrew install from the resolved executable path
+and delegates to `brew update && brew upgrade amq` instead of overwriting
+the Cellar; pass `amq upgrade -y` to run the delegate without prompting.
+Scoop installs on Windows delegate to `scoop update amq` the same way.
+
 Retire live wakes started by the previous Cellar binary first. If a leftover
 lock's image directory is gone, `wake check` reports `binary_dir_gone`;
 remove it with `amq doctor --ops --fix-wake-locks`. See
@@ -192,11 +197,33 @@ GitHub Actions `verify-brew-release` confirms a published tag installs from
 `avivsinai/tap/amq` and that `amq --version` matches that tag. It does not
 replace `brew upgrade` on an operator machine.
 
-Install-script or other manual binary installs:
+Install-script or other manual binary installs keep the direct download and
+atomic-replace path:
 
 ```bash
 amq upgrade
 ```
+
+Upgrade the companion binaries (`amq-keepalive`, `amq-bridge`, `amq-acp`)
+that sit next to a direct-install `amq` or in `~/.local/bin` from the same
+release tag, with checksum verification:
+
+```bash
+amq upgrade --all
+```
+
+A running `amq-keepalive` is never killed: the atomic rename swaps the path
+while the running process keeps the old image, and `amq upgrade --all`
+notes that a running supervisor picks up the new image on its next supervise
+pass (self-upgrade); a supervisor started with `--no-self-upgrade` is restarted
+with `amq-keepalive install-launchd`.
+Missing companions are skipped with a line. Companions are direct-installed
+only; the Homebrew formula and Scoop manifest ship `amq` itself, so `--all`
+under a package-managed install is a no-op with an explanatory line.
+
+`AMQ_CACHE_DIR` overrides the update-check cache location for `amq upgrade`;
+when unset, the platform cache (`~/Library/Caches` on macOS, `XDG_CACHE_HOME`
+or `~/.cache` elsewhere) is used.
 
 ### Keepalive companion
 

--- a/README.md
+++ b/README.md
@@ -183,10 +183,11 @@ Homebrew:
 brew upgrade amq
 ```
 
-`amq upgrade` detects a Homebrew install from the resolved executable path
-and delegates to `brew update && brew upgrade amq` instead of overwriting
-the Cellar; pass `amq upgrade -y` to run the delegate without prompting.
-Scoop installs on Windows delegate to `scoop update amq` the same way.
+`amq upgrade` checks the resolved executable against all known Homebrew
+prefixes and delegates to the matched Homebrew executable instead of
+overwriting the Cellar; pass `amq upgrade -y` to run the delegate without an
+AMQ prompt. The package manager may still prompt. Scoop installs on Windows
+delegate to the matched `scoop` executable in the same way.
 
 Retire live wakes started by the previous Cellar binary first. If a leftover
 lock's image directory is gone, `wake check` reports `binary_dir_gone`;
@@ -212,18 +213,22 @@ release tag, with checksum verification:
 amq upgrade --all
 ```
 
-A running `amq-keepalive` is never killed: the atomic rename swaps the path
-while the running process keeps the old image, and `amq upgrade --all`
-notes that a running supervisor picks up the new image on its next supervise
-pass (self-upgrade); a supervisor started with `--no-self-upgrade` is restarted
-with `amq-keepalive install-launchd`.
-Missing companions are skipped with a line. Companions are direct-installed
-only; the Homebrew formula and Scoop manifest ship `amq` itself, so `--all`
-under a package-managed install is a no-op with an explanatory line.
+The command upgrades one distinct canonical target for each companion. Missing
+companions are skipped with a line; multiple distinct copies refuse the
+upgrade and list their paths. A running `amq-keepalive` is never killed: the
+atomic rename swaps the path while the running process keeps the old image.
+When the upgraded path is the supervisor's path, `amq upgrade --all` notes
+that self-upgrade can pick up the new image on its next supervise pass; a
+supervisor started with `--no-self-upgrade` is restarted with
+`amq-keepalive install-launchd`. Companions are direct-installed only; the
+Homebrew formula and Scoop manifest ship `amq` itself, so `--all` under a
+package-managed install is a no-op with an explanatory line.
 
-`AMQ_CACHE_DIR` overrides the update-check cache location for `amq upgrade`;
-when unset, the platform cache (`~/Library/Caches` on macOS, `XDG_CACHE_HOME`
-or `~/.cache` elsewhere) is used.
+`AMQ_CACHE_DIR` overrides the update cache location used by `amq upgrade` and
+the background update notifier. When unset, the platform cache
+(`~/Library/Caches` on macOS, `XDG_CACHE_HOME` or `~/.cache` elsewhere) is
+used. A set override must resolve to an absolute path; AMQ fails rather than
+silently falling back to the platform cache.
 
 ### Keepalive companion
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,12 @@ Homebrew:
 brew upgrade amq
 ```
 
-`amq upgrade` checks the resolved executable against all known Homebrew
-prefixes and delegates to the matched Homebrew executable instead of
-overwriting the Cellar; pass `amq upgrade -y` to run the delegate without an
-AMQ prompt. The package manager may still prompt. Scoop installs on Windows
-delegate to the matched `scoop` executable in the same way.
+`amq upgrade` checks the raw and resolved executable paths against every
+evidenced or executable-derived Homebrew prefix and delegates to the matched
+Homebrew executable instead of overwriting the Cellar; pass `amq upgrade -y`
+to run the delegate without an AMQ prompt. The package manager may still
+prompt. Scoop installs on Windows delegate to the matched `scoop` executable
+in the same way.
 
 Retire live wakes started by the previous Cellar binary first. If a leftover
 lock's image directory is gone, `wake check` reports `binary_dir_gone`;
@@ -198,8 +199,8 @@ GitHub Actions `verify-brew-release` confirms a published tag installs from
 `avivsinai/tap/amq` and that `amq --version` matches that tag. It does not
 replace `brew upgrade` on an operator machine.
 
-Install-script or other manual binary installs keep the direct download and
-atomic-replace path:
+Install-script or other manual binary installs outside an evidenced Homebrew
+prefix keep the direct download and atomic-replace path:
 
 ```bash
 amq upgrade
@@ -213,10 +214,12 @@ release tag, with checksum verification:
 amq upgrade --all
 ```
 
-The command upgrades one distinct canonical target for each companion. Missing
-companions are skipped with a line; multiple distinct copies refuse the
-upgrade and list their paths. A running `amq-keepalive` is never killed: the
-atomic rename swaps the path while the running process keeps the old image.
+The command plans one verified target per companion, unique across all
+companions, before any replacement. It verifies each target's Go build
+identity. Missing companions are skipped with a line; aliases, wrong builds,
+and multiple distinct copies refuse the upgrade and give a repair action. A
+running `amq-keepalive` is never killed: the atomic rename swaps the path
+while the running process keeps the old image.
 When the upgraded path is the supervisor's path, `amq upgrade --all` notes
 that self-upgrade can pick up the new image on its next supervise pass; a
 supervisor started with `--no-self-upgrade` is restarted with
@@ -227,8 +230,15 @@ package-managed install is a no-op with an explanatory line.
 `AMQ_CACHE_DIR` overrides the update cache location used by `amq upgrade` and
 the background update notifier. When unset, the platform cache
 (`~/Library/Caches` on macOS, `XDG_CACHE_HOME` or `~/.cache` elsewhere) is
-used. A set override must resolve to an absolute path; AMQ fails rather than
-silently falling back to the platform cache.
+used. For the direct-upgrade cache-writing path, a set override must resolve
+to an absolute path; AMQ fails before replacement rather than silently
+falling back to the platform cache. The version cache is written only after
+the core `amq` replacement succeeds; a later companion failure still leaves
+that cache truthful.
+
+On Windows, `amq upgrade --all` prints a skip line for companions because
+companion binaries are not published for Windows, then continues with the
+core upgrade.
 
 ### Keepalive companion
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,10 @@ brew upgrade amq
 evidenced or executable-derived Homebrew prefix and delegates to the matched
 Homebrew executable instead of overwriting the Cellar; pass `amq upgrade -y`
 to run the delegate without an AMQ prompt. The package manager may still
-prompt. Scoop installs on Windows delegate to the matched `scoop` executable
-in the same way.
+prompt. Scoop installs on Windows are scoped as user (`$SCOOP` or the default
+`%USERPROFILE%\scoop`) or global (`$SCOOP_GLOBAL` or `C:\ProgramData\scoop`);
+the matched `scoop` executable receives `scoop update amq` for user scope or
+`scoop update -g amq` for global scope.
 
 Retire live wakes started by the previous Cellar binary first. If a leftover
 lock's image directory is gone, `wake check` reports `binary_dir_gone`;
@@ -207,8 +209,9 @@ amq upgrade
 ```
 
 Upgrade the companion binaries (`amq-keepalive`, `amq-bridge`, `amq-acp`)
-that sit next to a direct-install `amq` or in `~/.local/bin` from the same
-release tag, with checksum verification:
+that sit in the raw or resolved executable directory of a direct-install
+`amq`, or in `~/.local/bin`, from the same release tag, with checksum
+verification:
 
 ```bash
 amq upgrade --all
@@ -230,7 +233,9 @@ restart the service unit, for example
 `systemctl --user restart amq-keepalive.service`. Companions are
 direct-installed only; the
 Homebrew formula and Scoop manifest ship `amq` itself, so `--all` under a
-package-managed install is a no-op with an explanatory line.
+package-managed install is a no-op with an explanatory line. Companion links
+are revalidated by their primary path; a secondary same-name alias repointed
+during download is not detected.
 
 `AMQ_CACHE_DIR` overrides the update cache location used by `amq upgrade` and
 the background update notifier. When unset, the platform cache
@@ -239,9 +244,11 @@ other Unix systems, and the user's Local AppData cache on Windows) is used.
 `internal/update.DefaultCachePath` is the sole authority for the platform
 update-cache path. For the direct-upgrade cache-writing path, a set override
 must resolve to an absolute path; AMQ fails before replacement rather than
-silently falling back to the platform cache. The version cache is written
-only after the core `amq` replacement succeeds; a later companion failure
-still leaves that cache truthful.
+silently falling back to the platform cache. The version cache is refreshed
+after an authoritative direct check confirms the latest version (already
+current, or after a successful immediate replacement). A later companion
+failure does not change that result. A scheduled replacement is reflected when
+the next successful check refreshes the cache (best-effort).
 
 On Windows, `amq upgrade --all` prints a skip line for companions because
 companion binaries are not published for Windows, then continues with the

--- a/internal/cli/cache_authority_test.go
+++ b/internal/cli/cache_authority_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDefaultCachePathIsSolePlatformCacheAuthority(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+	updateDir := filepath.Join(repoRoot, "internal", "update")
+	var offenders []string
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path == filepath.Join(repoRoot, ".git") || path == filepath.Join(repoRoot, ".agent-mail") || path == updateDir {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		osName := ""
+		for _, imported := range file.Imports {
+			if strings.Trim(imported.Path.Value, `"`) != "os" {
+				continue
+			}
+			osName = "os"
+			if imported.Name != nil {
+				osName = imported.Name.Name
+			}
+		}
+		if osName == "" || osName == "." {
+			return nil
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || selector.Sel.Name != "UserCacheDir" {
+				return true
+			}
+			identifier, ok := selector.X.(*ast.Ident)
+			if ok && identifier.Name == osName {
+				offenders = append(offenders, path)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offenders) != 0 {
+		t.Fatalf("os.UserCacheDir is called outside internal/update; use update.DefaultCachePath: %s", strings.Join(offenders, ", "))
+	}
+}

--- a/internal/cli/cache_authority_test.go
+++ b/internal/cli/cache_authority_test.go
@@ -29,7 +29,7 @@ func TestDefaultCachePathIsSolePlatformCacheAuthority(t *testing.T) {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
 		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/update"
 )
 
 const (
@@ -64,6 +66,20 @@ func TestMain(m *testing.M) {
 	}
 
 	cliSecureTempRoot = tempRoot
+
+	// Isolate the update-check cache (issue #646 class) so tests that drive
+	// runUpgrade / the update Notifier never write through to the developer's
+	// real ~/Library/Caches/amq. AMQ_CACHE_DIR is the authoritative override
+	// (darwin's os.UserCacheDir ignores HOME); XDG_CACHE_HOME covers any code
+	// path that consults it directly.
+	testCacheDir := filepath.Join(tempRoot, "cache")
+	if err := os.MkdirAll(testCacheDir, 0o700); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "create test cache dir: %v\n", err)
+		os.Exit(1)
+	}
+	_ = os.Setenv(update.EnvCacheDir, testCacheDir)
+	_ = os.Setenv("XDG_CACHE_HOME", testCacheDir)
+
 	exitCode := m.Run()
 	cliSecureTempRoot = ""
 	if err := os.RemoveAll(tempRoot); err != nil {

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -77,8 +77,18 @@ func TestMain(m *testing.M) {
 		_, _ = fmt.Fprintf(os.Stderr, "create test cache dir: %v\n", err)
 		os.Exit(1)
 	}
-	_ = os.Setenv(update.EnvCacheDir, testCacheDir)
-	_ = os.Setenv("XDG_CACHE_HOME", testCacheDir)
+	for _, env := range []struct {
+		key   string
+		value string
+	}{
+		{key: update.EnvCacheDir, value: testCacheDir},
+		{key: "XDG_CACHE_HOME", value: testCacheDir},
+	} {
+		if err := os.Setenv(env.key, env.value); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "set %s for tests: %v\n", env.key, err)
+			os.Exit(1)
+		}
+	}
 
 	exitCode := m.Run()
 	cliSecureTempRoot = ""

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -12,27 +13,35 @@ import (
 	"strings"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
 	"github.com/avivsinai/agent-message-queue/internal/update"
 )
 
 var (
-	executablePathForUpgrade        = update.ExecutablePath
-	fetchLatestTagForUpgrade        = update.FetchLatestTag
-	detectHomebrewPrefixForUpgrade  = detectHomebrewPrefix
-	lookPathForHomebrewUpgrade      = exec.LookPath
-	runBrewPrefixForHomebrewUpgrade = runBrewPrefix
-	homebrewBrewExistsForUpgrade    = homebrewBrewExists
-	classifyInstallForUpgrade       = update.ClassifyInstall
-	runDelegateForUpgrade           = runDelegateCommand
-	companionBinariesForUpgrade     = update.CompanionBinaries
-	homeDirForUpgrade               = os.UserHomeDir
-	downloadReleaseAssetForUpgrade  = update.DownloadReleaseAsset
-	fetchChecksumsForUpgrade        = update.FetchChecksums
-	extractBinaryForUpgrade         = extractBinaryFromArchive
-	replaceBinaryForUpgrade         = update.ReplaceBinary
-	updateVerifySHA256ForUpgrade    = update.VerifySHA256
-	saveUpgradeCacheForUpgrade      = saveUpgradeCache
+	executablePathForUpgrade              = update.ExecutablePath
+	fetchLatestTagForUpgrade              = update.FetchLatestTag
+	detectHomebrewPrefixForUpgrade        = detectHomebrewPrefix
+	detectHomebrewInstallationsForUpgrade = detectHomebrewInstallations
+	lookPathForHomebrewUpgrade            = exec.LookPath
+	lookPathForDelegateForUpgrade         = exec.LookPath
+	runBrewPrefixForHomebrewUpgrade       = runBrewPrefix
+	homebrewBrewExistsForUpgrade          = homebrewBrewExists
+	classifyInstallForUpgrade             = update.ClassifyInstall
+	runDelegateForUpgrade                 = runDelegateCommand
+	companionBinariesForUpgrade           = update.CompanionBinaries
+	homeDirForUpgrade                     = os.UserHomeDir
+	downloadReleaseAssetForUpgrade        = update.DownloadReleaseAsset
+	fetchChecksumsForUpgrade              = update.FetchChecksums
+	extractBinaryForUpgrade               = extractBinaryFromArchive
+	replaceBinaryForUpgrade               = update.ReplaceBinary
+	updateVerifySHA256ForUpgrade          = update.VerifySHA256
+	saveUpgradeCacheForUpgrade            = saveUpgradeCache
 )
+
+type homebrewInstallation struct {
+	prefix     string
+	executable string
+}
 
 // saveUpgradeCache writes the latest-known-version cache for the amq binary
 // (not companions). It is best-effort: a cache write failure does not fail
@@ -54,12 +63,13 @@ var wellKnownHomebrewPrefixes = []string{
 	"/opt/homebrew",
 	"/usr/local",
 	"/home/linuxbrew/.linuxbrew",
+	"/opt/linuxbrew/.linuxbrew",
 }
 
 func runUpgrade(args []string, currentVersion string) error {
 	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	allFlag := fs.Bool("all", false, "Also upgrade present companion binaries (amq-keepalive, amq-bridge, amq-acp)")
-	yesFlag := fs.Bool("y", false, "Run the package-manager delegate non-interactively (Homebrew/Scoop installs)")
+	yesFlag := fs.Bool("y", false, "Run the package-manager delegate without an AMQ confirmation; the manager may still prompt")
 	usage := usageWithFlags(
 		fs,
 		"amq upgrade [--all] [-y]",
@@ -80,21 +90,23 @@ func runUpgrade(args []string, currentVersion string) error {
 		return err
 	}
 
-	homebrewPrefix := detectHomebrewPrefixForUpgrade()
-	// Classify from BOTH the resolved path (authoritative: a symlink into the
-	// Cellar lands there) and the pre-resolution path (a user-made
-	// ~/bin/amq -> /opt/homebrew/bin/amq link is Homebrew-owned by its link
-	// path even before resolution). Either matching a package manager wins.
-	kind := classifyInstallForUpgrade(resolved, homebrewPrefix)
-	if kind == update.InstallDirect {
-		kind = classifyInstallForUpgrade(path, homebrewPrefix)
-	}
-
+	homebrewInstallations := homebrewInstallationsForUpgrade()
+	homebrewPrefixes := homebrewPrefixesFromInstallations(homebrewInstallations)
+	kind, managerPath := classifyPackageInstall(path, resolved, homebrewPrefixes, homebrewInstallations)
 	if kind.IsPackageManaged() {
-		return runManagedUpgrade(kind, *yesFlag, *allFlag)
+		if managerPath == "" {
+			return fmt.Errorf("%s executable not found; refusing package-manager delegation", packageManagerName(kind))
+		}
+		return runManagedUpgradeWithManager(kind, managerPath, *yesFlag, *allFlag)
 	}
 
-	destPath, err := selectUpgradeDestination(path, resolved, upgradeDestinationWritable)
+	destPath, err := selectUpgradeDestinationWithRoots(
+		path,
+		resolved,
+		upgradeDestinationWritable,
+		homebrewPrefixes,
+		update.ScoopAppsDir(),
+	)
 	if err != nil {
 		return err
 	}
@@ -118,7 +130,15 @@ func runUpgrade(args []string, currentVersion string) error {
 			return err
 		}
 		if *allFlag {
-			if err := upgradeCompanions(ctx, client, latestTag, latest, destPath); err != nil {
+			if err := upgradeCompanionsWithProtection(
+				ctx,
+				client,
+				latestTag,
+				latest,
+				destPath,
+				homebrewPrefixes,
+				update.ScoopAppsDir(),
+			); err != nil {
 				return err
 			}
 		}
@@ -129,27 +149,54 @@ func runUpgrade(args []string, currentVersion string) error {
 		return err
 	}
 
-	if err := runDirectUpgrade(ctx, client, update.BinaryName, latestTag, latest, destPath); err != nil {
+	if err := validateUpgradeCachePath(); err != nil {
 		return err
 	}
-	saveUpgradeCacheForUpgrade(latest)
+	result, err := runDirectUpgradeWithProtection(
+		ctx,
+		client,
+		update.BinaryName,
+		latestTag,
+		latest,
+		destPath,
+		homebrewPrefixes,
+		update.ScoopAppsDir(),
+	)
+	if err != nil {
+		return err
+	}
+	if result.scheduled {
+		if err := writeStdoutLine("replacement scheduled; version cache updates on next run"); err != nil {
+			return err
+		}
+	} else {
+		saveUpgradeCacheForUpgrade(latest)
+	}
 	if *allFlag {
-		if err := upgradeCompanions(ctx, client, latestTag, latest, destPath); err != nil {
+		if err := upgradeCompanionsWithProtection(
+			ctx,
+			client,
+			latestTag,
+			latest,
+			destPath,
+			homebrewPrefixes,
+			update.ScoopAppsDir(),
+		); err != nil {
 			return err
 		}
 	}
 	return reportStaleWakesAfterUpgrade()
 }
 
-// runManagedUpgrade handles Homebrew/Scoop installs by printing the delegate
-// command and, with -y, running it. Companions are never package-managed, so
-// --all under a managed install is a no-op with an explanatory line.
-func runManagedUpgrade(kind update.InstallKind, yes, all bool) error {
-	argvs, remedy := delegateUpgradeCommand(kind)
+func runManagedUpgradeWithManager(kind update.InstallKind, managerPath string, yes, all bool) error {
+	argvs, remedy := delegateUpgradeCommandWithManager(kind, managerPath)
 	if all {
 		if err := writeStdoutLine("--all: companions are direct-installed; upgrade them with 'amq upgrade --all' from a direct amq install."); err != nil {
 			return err
 		}
+	}
+	if len(argvs) == 0 {
+		return errors.New("unsupported package manager install")
 	}
 	if yes {
 		for _, argv := range argvs {
@@ -165,17 +212,30 @@ func runManagedUpgrade(kind update.InstallKind, yes, all bool) error {
 	return fmt.Errorf("%s", remedy)
 }
 
-// delegateUpgradeCommand returns the argv slices to run (no shell, so a future
-// dynamic value cannot inject) and the non-interactive remedy string for a
-// package-managed install kind. Homebrew runs `brew update` then
-// `brew upgrade amq`; Scoop runs `scoop update amq`.
-func delegateUpgradeCommand(kind update.InstallKind) ([][]string, string) {
+func packageManagerName(kind update.InstallKind) string {
 	switch kind {
 	case update.InstallHomebrew:
-		return [][]string{{"brew", "update"}, {"brew", "upgrade", "amq"}},
+		return "Homebrew brew"
+	case update.InstallScoop:
+		return "Scoop scoop"
+	default:
+		return "package manager"
+	}
+}
+
+func delegateUpgradeCommandWithManager(kind update.InstallKind, managerPath string) ([][]string, string) {
+	switch kind {
+	case update.InstallHomebrew:
+		if managerPath == "" {
+			managerPath = "brew"
+		}
+		return [][]string{{managerPath, "update"}, {managerPath, "upgrade", "amq"}},
 			"amq is installed via Homebrew; run brew update && brew upgrade amq (or amq upgrade -y)"
 	case update.InstallScoop:
-		return [][]string{{"scoop", "update", "amq"}},
+		if managerPath == "" {
+			managerPath = "scoop"
+		}
+		return [][]string{{managerPath, "update", "amq"}},
 			"amq is installed via Scoop; run scoop update amq (or amq upgrade -y)"
 	default:
 		return nil, ""
@@ -208,36 +268,53 @@ func extractBinaryFromArchive(binaryName, archivePath, destDir string, zip bool)
 	return update.ExtractBinaryFromTarGzNamed(binaryName, archivePath, destDir)
 }
 
-// runDirectUpgrade downloads, verifies, extracts, and atomically replaces a
-// single binary at destPath. It is shared by the amq self-upgrade and the
-// per-companion --all loop.
-func runDirectUpgrade(ctx context.Context, client *http.Client, binaryName, latestTag, latest, destPath string) error {
+type directUpgradeResult struct {
+	scheduled bool
+}
+
+func validateUpgradeCachePath() error {
+	if _, err := update.DefaultCachePath(); err != nil {
+		return fmt.Errorf("cannot resolve update cache path: %w", err)
+	}
+	return nil
+}
+
+// runDirectUpgradeWithProtection performs the final package-manager guard
+// immediately before replacement. Classification happens earlier, but this
+// independent check protects against a missed Homebrew prefix or a path race.
+func runDirectUpgradeWithProtection(
+	ctx context.Context,
+	client *http.Client,
+	binaryName, latestTag, latest, destPath string,
+	homebrewPrefixes []string,
+	scoopApps string,
+) (directUpgradeResult, error) {
 	assetName, err := update.AssetNameFor(binaryName, latestTag, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 
 	tmpDir, err := os.MkdirTemp("", "amq-upgrade-")
 	if err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	archivePath := filepath.Join(tmpDir, assetName)
 	if err := downloadReleaseAssetForUpgrade(ctx, client, latestTag, assetName, archivePath); err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 
 	checksums, err := fetchChecksumsForUpgrade(ctx, client, latestTag)
 	if err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 	checksum, ok := checksums[assetName]
 	if !ok {
-		return fmt.Errorf("checksum entry not found for %s", assetName)
+		return directUpgradeResult{}, fmt.Errorf("checksum entry not found for %s", assetName)
 	}
 	if err := updateVerifySHA256ForUpgrade(archivePath, checksum); err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 
 	var binaryPath string
@@ -247,39 +324,69 @@ func runDirectUpgrade(ctx context.Context, client *http.Client, binaryName, late
 		binaryPath, err = extractBinaryForUpgrade(binaryName, archivePath, tmpDir, false)
 	}
 	if err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 
+	if err := refusePackageManagedDestination(destPath, homebrewPrefixes, scoopApps); err != nil {
+		return directUpgradeResult{}, err
+	}
 	scheduled, err := replaceBinaryForUpgrade(binaryPath, destPath)
 	if err != nil {
-		return err
+		return directUpgradeResult{}, err
 	}
 	if scheduled {
-		return writeStdoutLine(binaryName + " upgrade scheduled; it will complete after this process exits.")
+		if err := writeStdoutLine(binaryName + " upgrade scheduled; it will complete after this process exits."); err != nil {
+			return directUpgradeResult{}, err
+		}
+		return directUpgradeResult{scheduled: true}, nil
 	}
-	return writeStdoutLine(binaryName + " upgrade complete.")
+	if err := writeStdoutLine(binaryName + " upgrade complete."); err != nil {
+		return directUpgradeResult{}, err
+	}
+	return directUpgradeResult{}, nil
 }
 
-// upgradeCompanions upgrades each companion binary (amq-keepalive,
-// amq-bridge, amq-acp) present next to the direct-install amq (destDir) or in
-// ~/.local/bin. Missing companions are skipped with a line. A running
-// amq-keepalive is never killed: the atomic rename swaps the path while the
-// running process keeps the old inode, and the remedy to restart the
-// supervisor is printed afterward.
-func upgradeCompanions(ctx context.Context, client *http.Client, latestTag, latest, amqDest string) error {
+func upgradeCompanionsWithProtection(
+	ctx context.Context,
+	client *http.Client,
+	latestTag, latest, amqDest string,
+	homebrewPrefixes []string,
+	scoopApps string,
+) error {
 	searchDirs := companionSearchDirs(amqDest)
 	for _, name := range companionBinariesForUpgrade {
-		dest, found := findCompanion(name, searchDirs)
-		if !found {
+		matches, err := findCompanionMatches(name, searchDirs, amqDest, homebrewPrefixes, scoopApps)
+		if err != nil {
+			return err
+		}
+		if len(matches) == 0 {
 			if err := writeStdoutLine(name + " not found; skipping."); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := runDirectUpgrade(ctx, client, name, latestTag, latest, dest); err != nil {
+		if len(matches) > 1 {
+			return fmt.Errorf("%s found at multiple distinct targets: %s", name, strings.Join(matches, ", "))
+		}
+		result, err := runDirectUpgradeWithProtection(
+			ctx,
+			client,
+			name,
+			latestTag,
+			latest,
+			matches[0],
+			homebrewPrefixes,
+			scoopApps,
+		)
+		if err != nil {
 			return fmt.Errorf("%s: %w", name, err)
 		}
 		if name == "amq-keepalive" {
+			if result.scheduled {
+				if err := writeStdoutLine("amq-keepalive: replacement scheduled; version cache updates on next run"); err != nil {
+					return err
+				}
+			}
 			if err := writeStdoutLine("amq-keepalive: a running supervisor picks up the new image on its next supervise pass (self-upgrade); if it was started with --no-self-upgrade, restart it with 'amq-keepalive install-launchd'."); err != nil {
 				return err
 			}
@@ -304,41 +411,248 @@ func companionSearchDirs(amqDest string) []string {
 	return dirs
 }
 
-// findCompanion returns the first existing companion path across the search
-// dirs, resolving a symlink to its real target so ReplaceBinary writes the
-// backing file (preserving the operator's link structure) rather than
-// replacing the link itself. A regular file is returned as-is. Returns "",
-// false if absent everywhere.
-func findCompanion(name string, dirs []string) (string, bool) {
+func findCompanionMatches(name string, dirs []string, amqDest string, homebrewPrefixes []string, scoopApps string) ([]string, error) {
+	var amqInfo os.FileInfo
+	var err error
+	if amqDest != "" {
+		amqInfo, err = os.Stat(amqDest)
+		if err != nil {
+			return nil, fmt.Errorf("cannot inspect amq destination %s: %w", amqDest, err)
+		}
+	}
+	matches := make([]string, 0, len(dirs))
+	seen := make(map[string]struct{}, len(dirs))
 	for _, dir := range dirs {
 		candidate := filepath.Join(dir, name)
 		if runtime.GOOS == "windows" {
 			candidate += ".exe"
 		}
-		info, err := os.Stat(candidate)
-		if err != nil || info.IsDir() {
+		linkInfo, err := os.Lstat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
-		// Resolve only an actual symlink to its target; a regular file is
-		// returned as-is so its path stays comparable for callers.
-		if li, err := os.Lstat(candidate); err == nil && li.Mode()&os.ModeSymlink != 0 {
-			if resolved, err := filepath.EvalSymlinks(candidate); err == nil {
-				return resolved, true
+		if err != nil {
+			return nil, fmt.Errorf("cannot inspect companion %s: %w", candidate, err)
+		}
+
+		var target string
+		switch {
+		case linkInfo.Mode().IsRegular():
+			target, err = filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return nil, fmt.Errorf("cannot resolve companion %s: %w", candidate, err)
+			}
+		case linkInfo.Mode()&os.ModeSymlink != 0:
+			target, err = filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return nil, fmt.Errorf("cannot resolve companion symlink %s: %w", candidate, err)
+			}
+		default:
+			return nil, fmt.Errorf("refusing companion %s: object is not a regular file or symlink", candidate)
+		}
+
+		target = filepath.Clean(target)
+		targetInfo, statErr := os.Stat(target)
+		if statErr != nil {
+			return nil, fmt.Errorf("cannot inspect companion target %s: %w", target, statErr)
+		}
+		if !targetInfo.Mode().IsRegular() {
+			return nil, fmt.Errorf("refusing companion %s: target %s is not a regular file", candidate, target)
+		}
+		if amqInfo != nil {
+			if os.SameFile(targetInfo, amqInfo) {
+				return nil, fmt.Errorf("refusing companion %s: target %s is the amq executable", candidate, target)
 			}
 		}
-		return candidate, true
+		if isUnderProtectedRoot(target, homebrewPrefixes, scoopApps) {
+			return nil, fmt.Errorf("refusing companion %s: target %s is package-managed", candidate, target)
+		}
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		matches = append(matches, target)
 	}
-	return "", false
+	return matches, nil
 }
 
-// selectUpgradeDestination resolves the write target for a direct install.
-// It is only reached after the install classifier has already delegated
-// Homebrew/Scoop installs, so it does not re-check for a normal Homebrew
-// path. It does keep one guard the classifier cannot express: a severed
-// Homebrew binary — a regular file sitting at <prefix>/bin/amq where brew
-// expects a symlink — which means someone overwrote the brew-managed path
-// and must reinstall rather than self-replace into the corruption.
+func classifyPackageInstall(path, resolved string, homebrewPrefixes []string, installations []homebrewInstallation) (update.InstallKind, string) {
+	for _, candidate := range []string{resolved, path} {
+		if candidate == "" {
+			continue
+		}
+		for _, prefix := range homebrewPrefixes {
+			if classifyInstallForUpgrade(candidate, prefix) == update.InstallHomebrew {
+				return update.InstallHomebrew, matchingHomebrewManager(candidate, path, installations)
+			}
+		}
+		if classifyInstallForUpgrade(candidate, "") == update.InstallScoop {
+			return update.InstallScoop, scoopManagerExecutable()
+		}
+	}
+	return update.InstallDirect, ""
+}
+
+func matchingHomebrewManager(candidate, rawPath string, installations []homebrewInstallation) string {
+	for _, installation := range installations {
+		prefix := canonicalHomebrewPrefix(installation.prefix)
+		cellar := filepath.Join(prefix, "Cellar")
+		for _, path := range []string{candidate, rawPath} {
+			if path == "" {
+				continue
+			}
+			canonical := canonicalExistingPath(path)
+			if pathWithinDirectory(canonical, cellar) ||
+				(pathWithinDirectory(filepath.Clean(path), filepath.Join(prefix, "bin")) && isSymlinkToHomebrewCellar(path, cellar)) {
+				if installation.executable != "" {
+					return installation.executable
+				}
+				return filepath.Join(prefix, "bin", "brew")
+			}
+		}
+	}
+	return ""
+}
+
+func scoopManagerExecutable() string {
+	if runtime.GOOS != "windows" {
+		return ""
+	}
+	path, err := lookPathForDelegateForUpgrade("scoop")
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func homebrewPrefixesFromInstallations(installations []homebrewInstallation) []string {
+	prefixes := make([]string, 0, len(installations))
+	seen := make(map[string]struct{}, len(installations))
+	for _, installation := range installations {
+		prefix := canonicalHomebrewPrefix(installation.prefix)
+		if prefix == "" {
+			continue
+		}
+		if _, ok := seen[prefix]; ok {
+			continue
+		}
+		seen[prefix] = struct{}{}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes
+}
+
+func homebrewInstallationsForUpgrade() []homebrewInstallation {
+	installations := detectHomebrewInstallationsForUpgrade()
+	legacyPrefix := cleanHomebrewPrefix(detectHomebrewPrefixForUpgrade())
+	if legacyPrefix == "" {
+		return installations
+	}
+	canonical := canonicalHomebrewPrefix(legacyPrefix)
+	for _, installation := range installations {
+		if canonicalHomebrewPrefix(installation.prefix) == canonical {
+			return installations
+		}
+	}
+	return append(installations, homebrewInstallation{
+		prefix:     canonical,
+		executable: filepath.Join(legacyPrefix, "bin", "brew"),
+	})
+}
+
+func detectHomebrewInstallations() []homebrewInstallation {
+	installations := make([]homebrewInstallation, 0, len(wellKnownHomebrewPrefixes)+3)
+	seen := make(map[string]struct{})
+	add := func(prefix, executable string) {
+		prefix = cleanHomebrewPrefix(prefix)
+		if prefix == "" {
+			return
+		}
+		key := canonicalHomebrewPrefix(prefix)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		if executable == "" {
+			executable = filepath.Join(prefix, "bin", "brew")
+		}
+		installations = append(installations, homebrewInstallation{
+			prefix:     key,
+			executable: executable,
+		})
+	}
+
+	if brewPath, err := lookPathForHomebrewUpgrade("brew"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), homebrewDetectionTimeout)
+		output, runErr := runBrewPrefixForHomebrewUpgrade(ctx, brewPath)
+		cancel()
+		if runErr == nil {
+			add(strings.TrimSpace(string(output)), brewPath)
+		}
+	}
+	if prefix := cleanHomebrewPrefix(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
+		add(prefix, filepath.Join(prefix, "bin", "brew"))
+	}
+	for _, prefix := range wellKnownHomebrewPrefixes {
+		add(prefix, filepath.Join(prefix, "bin", "brew"))
+	}
+	if home, err := homeDirForUpgrade(); err == nil {
+		add(filepath.Join(home, ".linuxbrew"), filepath.Join(home, ".linuxbrew", "bin", "brew"))
+	}
+	return installations
+}
+
+func canonicalHomebrewPrefix(prefix string) string {
+	return canonicalExistingPath(cleanHomebrewPrefix(prefix))
+}
+
+func canonicalExistingPath(path string) string {
+	path = filepath.Clean(path)
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	current := path
+	suffix := make([]string, 0, 4)
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			resolved = filepath.Clean(resolved)
+			for index := len(suffix) - 1; index >= 0; index-- {
+				resolved = filepath.Join(resolved, suffix[index])
+			}
+			return filepath.Clean(resolved)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return path
+		}
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
+	}
+}
+
+func isSymlinkToHomebrewCellar(path, cellar string) bool {
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	return err == nil && pathWithinDirectory(filepath.Clean(resolved), cellar)
+}
+
+// selectUpgradeDestination resolves the write target for a direct install and
+// performs the last package-manager safety check before any download starts.
 func selectUpgradeDestination(path, resolved string, writable func(string) error) (string, error) {
+	installations := homebrewInstallationsForUpgrade()
+	return selectUpgradeDestinationWithRoots(
+		path,
+		resolved,
+		writable,
+		homebrewPrefixesFromInstallations(installations),
+		update.ScoopAppsDir(),
+	)
+}
+
+func selectUpgradeDestinationWithRoots(path, resolved string, writable func(string) error, homebrewPrefixes []string, scoopApps string) (string, error) {
 	destPath := resolved
 	if destPath == "" {
 		destPath = path
@@ -348,13 +662,74 @@ func selectUpgradeDestination(path, resolved string, writable func(string) error
 	}
 	destPath = filepath.Clean(destPath)
 
-	if prefix := detectHomebrewPrefixForUpgrade(); prefix != "" && isSeveredHomebrewBinary(prefix, path) {
-		return "", fmt.Errorf("amq is installed via Homebrew; run brew reinstall amq")
+	for _, candidate := range []string{path, destPath} {
+		if candidate == "" {
+			continue
+		}
+		if err := refusePackageManagedDestination(candidate, homebrewPrefixes, scoopApps); err != nil {
+			return "", err
+		}
 	}
 	if err := writable(destPath); err != nil {
 		return "", fmt.Errorf("cannot write the amq install location %s: %w", destPath, err)
 	}
 	return destPath, nil
+}
+
+func refusePackageManagedDestination(path string, homebrewPrefixes []string, scoopApps string) error {
+	path = filepath.Clean(path)
+	canonical := canonicalExistingPath(path)
+	for _, prefix := range homebrewPrefixes {
+		prefix = canonicalHomebrewPrefix(prefix)
+		if prefix == "" {
+			continue
+		}
+		cellar := filepath.Join(prefix, "Cellar")
+		// This is intentionally independent from install classification. A
+		// missed prefix or a path race must not turn a Cellar replacement into
+		// a direct install.
+		if pathWithinDirectory(canonical, cellar) {
+			return fmt.Errorf("amq is installed via Homebrew; run brew update && brew upgrade amq")
+		}
+		if pathWithinDirectory(canonical, filepath.Join(prefix, "bin")) {
+			info, err := os.Lstat(path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				return fmt.Errorf("cannot inspect possible Homebrew destination %s: %w", path, err)
+			}
+			switch {
+			case info.Mode().IsRegular():
+				return fmt.Errorf("amq is in a Homebrew prefix but is not a managed symlink; run brew reinstall amq or brew update && brew upgrade amq")
+			case info.Mode()&os.ModeSymlink != 0:
+				resolved, resolveErr := filepath.EvalSymlinks(path)
+				if resolveErr != nil {
+					return fmt.Errorf("amq is in a Homebrew prefix but its symlink cannot be resolved; run brew reinstall amq or brew update && brew upgrade amq: %w", resolveErr)
+				}
+				if pathWithinDirectory(filepath.Clean(resolved), cellar) {
+					return fmt.Errorf("amq is installed via Homebrew; run brew update && brew upgrade amq")
+				}
+			default:
+				return fmt.Errorf("refusing possible Homebrew destination %s; run brew reinstall amq or brew update && brew upgrade amq", path)
+			}
+		}
+	}
+	if scoopApps != "" && pathWithinDirectory(canonical, canonicalExistingPath(scoopApps)) {
+		return fmt.Errorf("amq is installed via Scoop; run scoop update amq")
+	}
+	return nil
+}
+
+func isUnderProtectedRoot(path string, homebrewPrefixes []string, scoopApps string) bool {
+	canonical := canonicalExistingPath(path)
+	for _, prefix := range homebrewPrefixes {
+		prefix = canonicalHomebrewPrefix(prefix)
+		if prefix != "" && pathWithinDirectory(canonical, filepath.Join(prefix, "Cellar")) {
+			return true
+		}
+	}
+	return scoopApps != "" && pathWithinDirectory(canonical, canonicalExistingPath(scoopApps))
 }
 
 func detectHomebrewPrefix() string {
@@ -390,7 +765,7 @@ func detectHomebrewPrefix() string {
 }
 
 func runBrewPrefix(ctx context.Context, brewPath string) ([]byte, error) {
-	return exec.CommandContext(ctx, brewPath, "--prefix").Output()
+	return selfupgrade.RunBoundedProbe(ctx, brewPath, []string{"--prefix"}, selfupgrade.BoundedProbeOptions{})
 }
 
 func homebrewBrewExists(path string) bool {
@@ -409,7 +784,8 @@ func homebrewOwnsUpgradePath(prefix, path string) bool {
 	if path == "" {
 		return false
 	}
-	path = filepath.Clean(path)
+	path = canonicalExistingPath(path)
+	prefix = canonicalHomebrewPrefix(prefix)
 	return pathWithinDirectory(path, filepath.Join(prefix, "bin")) ||
 		pathWithinDirectory(path, filepath.Join(prefix, "Cellar"))
 }
@@ -420,12 +796,4 @@ func pathWithinDirectory(path, directory string) bool {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func isSeveredHomebrewBinary(prefix, path string) bool {
-	if path == "" || !pathWithinDirectory(filepath.Clean(path), filepath.Join(prefix, "bin")) {
-		return false
-	}
-	info, err := os.Lstat(path)
-	return err == nil && info.Mode().IsRegular()
 }

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -102,7 +102,7 @@ func runUpgrade(args []string, currentVersion string) error {
 		"amq upgrade [--all] [-y]",
 		"Downloads and installs the latest amq release from GitHub.",
 		"When amq is installed via Homebrew or Scoop, amq upgrade delegates to the package manager instead of overwriting it; pass -y to run the delegate.",
-		"--all upgrades companion binaries present next to a direct-install amq or in ~/.local/bin; a running amq-keepalive is never killed.",
+		"--all upgrades companion binaries in the raw or resolved executable directory of a direct-install amq, or in ~/.local/bin; a running amq-keepalive is never killed.",
 		"Retire live wakes started by the previous binary before its install directory is removed.",
 		"If wake check reports binary_dir_gone, run amq doctor --ops --fix-wake-locks.",
 	)
@@ -119,6 +119,7 @@ func runUpgrade(args []string, currentVersion string) error {
 	if err != nil {
 		return err
 	}
+	scoopRoots := update.ScoopInstallRoots()
 
 	homebrewInstallations := homebrewInstallationsForUpgrade()
 	homebrewInstallations, err = addDerivedHomebrewInstallations(path, resolved, homebrewInstallations)
@@ -128,6 +129,9 @@ func runUpgrade(args []string, currentVersion string) error {
 	homebrewPrefixes := homebrewPrefixesFromInstallations(homebrewInstallations)
 	kind, managerPath := classifyPackageInstall(path, resolved, homebrewPrefixes, homebrewInstallations)
 	if kind.IsPackageManaged() {
+		if kind == update.InstallScoopUnknown {
+			return refuseUnknownScoopInstall(path, resolved)
+		}
 		if managerPath == "" {
 			if kind == update.InstallHomebrew {
 				return refuseHomebrewWithoutMatchingManager(path, resolved, homebrewInstallations)
@@ -137,12 +141,12 @@ func runUpgrade(args []string, currentVersion string) error {
 		return runManagedUpgradeWithManager(kind, managerPath, *yesFlag, *allFlag)
 	}
 
-	destPath, err := selectUpgradeDestinationWithRoots(
+	destPath, err := selectUpgradeDestinationWithScoopRoots(
 		path,
 		resolved,
 		upgradeDestinationWritable,
 		homebrewPrefixes,
-		update.ScoopAppsDir(),
+		scoopRoots,
 	)
 	if err != nil {
 		return err
@@ -171,14 +175,15 @@ func runUpgrade(args []string, currentVersion string) error {
 		}
 		saveUpgradeCacheForUpgrade(latest)
 		if *allFlag {
-			if err := upgradeCompanionsWithProtection(
+			if err := upgradeCompanionsWithScoopRoots(
 				ctx,
 				client,
 				latestTag,
 				latest,
+				path,
 				destPath,
 				homebrewPrefixes,
-				update.ScoopAppsDir(),
+				scoopRoots,
 			); err != nil {
 				return err
 			}
@@ -193,7 +198,7 @@ func runUpgrade(args []string, currentVersion string) error {
 	if err := validateUpgradeCachePath(); err != nil {
 		return err
 	}
-	result, err := runDirectUpgradeWithProtection(
+	result, err := runDirectUpgradeWithScoopRoots(
 		ctx,
 		client,
 		update.BinaryName,
@@ -201,27 +206,28 @@ func runUpgrade(args []string, currentVersion string) error {
 		latest,
 		destPath,
 		homebrewPrefixes,
-		update.ScoopAppsDir(),
+		scoopRoots,
 	)
 	if err != nil {
 		return err
 	}
 	if result.scheduled {
-		if err := writeStdoutLine("replacement scheduled; version cache updates on next run"); err != nil {
+		if err := writeStdoutLine("replacement scheduled; version cache is refreshed on the next successful check (best-effort)"); err != nil {
 			return err
 		}
 	} else {
 		saveUpgradeCacheForUpgrade(latest)
 	}
 	if *allFlag {
-		if err := upgradeCompanionsWithProtection(
+		if err := upgradeCompanionsWithScoopRoots(
 			ctx,
 			client,
 			latestTag,
 			latest,
+			path,
 			destPath,
 			homebrewPrefixes,
-			update.ScoopAppsDir(),
+			scoopRoots,
 		); err != nil {
 			return err
 		}
@@ -257,7 +263,7 @@ func packageManagerName(kind update.InstallKind) string {
 	switch kind {
 	case update.InstallHomebrew:
 		return "Homebrew brew"
-	case update.InstallScoop:
+	case update.InstallScoop, update.InstallScoopGlobal:
 		return "Scoop scoop"
 	default:
 		return "package manager"
@@ -279,7 +285,14 @@ func delegateUpgradeCommandWithManager(kind update.InstallKind, managerPath stri
 		}
 		commands := [][]string{{managerPath, "update", "amq"}}
 		return commands,
-			fmt.Sprintf("amq is installed via Scoop; run %s (or amq upgrade -y)", strings.Join(commands[0], " "))
+			fmt.Sprintf("amq is installed via Scoop (user scope); run %s (or amq upgrade -y)", strings.Join(commands[0], " "))
+	case update.InstallScoopGlobal:
+		if managerPath == "" {
+			managerPath = "scoop"
+		}
+		commands := [][]string{{managerPath, "update", "-g", "amq"}}
+		return commands,
+			fmt.Sprintf("amq is installed via Scoop (global scope); run %s (or amq upgrade -y)", strings.Join(commands[0], " "))
 	default:
 		return nil, ""
 	}
@@ -322,12 +335,12 @@ func validateUpgradeCachePath() error {
 	return nil
 }
 
-func prepareDirectUpgradeWithProtection(
+func prepareDirectUpgradeWithScoopRoots(
 	ctx context.Context,
 	client *http.Client,
 	binaryName, latestTag, destPath string,
 	homebrewPrefixes []string,
-	scoopApps string,
+	scoopRoots []update.ScoopInstallRoot,
 	tmpDir string,
 ) (preparedUpgrade, error) {
 	assetName, err := update.AssetNameFor(binaryName, latestTag, runtime.GOOS, runtime.GOARCH)
@@ -365,7 +378,7 @@ func prepareDirectUpgradeWithProtection(
 	// This is a second package-root classification check. Path-derived
 	// Homebrew prefixes are added before classification; this check covers a
 	// prefix that changes between destination selection and replacement.
-	if err := refusePackageManagedDestination(destPath, homebrewPrefixes, scoopApps); err != nil {
+	if err := refusePackageManagedDestinationWithScoopRoots(destPath, homebrewPrefixes, scoopRoots); err != nil {
 		return preparedUpgrade{}, err
 	}
 	return preparedUpgrade{binaryPath: binaryPath, destPath: destPath}, nil
@@ -397,20 +410,39 @@ func runDirectUpgradeWithProtection(
 	homebrewPrefixes []string,
 	scoopApps string,
 ) (directUpgradeResult, error) {
+	return runDirectUpgradeWithScoopRoots(
+		ctx,
+		client,
+		binaryName,
+		latestTag,
+		latest,
+		destPath,
+		homebrewPrefixes,
+		legacyScoopRoots(scoopApps),
+	)
+}
+
+func runDirectUpgradeWithScoopRoots(
+	ctx context.Context,
+	client *http.Client,
+	binaryName, latestTag, latest, destPath string,
+	homebrewPrefixes []string,
+	scoopRoots []update.ScoopInstallRoot,
+) (directUpgradeResult, error) {
 	tmpDir, err := os.MkdirTemp("", "amq-upgrade-")
 	if err != nil {
 		return directUpgradeResult{}, err
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	prepared, err := prepareDirectUpgradeWithProtection(
+	prepared, err := prepareDirectUpgradeWithScoopRoots(
 		ctx,
 		client,
 		binaryName,
 		latestTag,
 		destPath,
 		homebrewPrefixes,
-		scoopApps,
+		scoopRoots,
 		tmpDir,
 	)
 	if err != nil {
@@ -426,8 +458,32 @@ func upgradeCompanionsWithProtection(
 	homebrewPrefixes []string,
 	scoopApps string,
 ) error {
-	searchDirs := companionSearchDirs(amqDest)
-	plan, err := discoverCompanionPlan(companionBinariesForUpgrade, searchDirs, amqDest, homebrewPrefixes, scoopApps)
+	return upgradeCompanionsWithScoopRoots(
+		ctx,
+		client,
+		latestTag,
+		latest,
+		amqDest,
+		amqDest,
+		homebrewPrefixes,
+		legacyScoopRoots(scoopApps),
+	)
+}
+
+func upgradeCompanionsWithScoopRoots(
+	ctx context.Context,
+	client *http.Client,
+	latestTag, latest, rawAMQPath, amqDest string,
+	homebrewPrefixes []string,
+	scoopRoots []update.ScoopInstallRoot,
+) error {
+	searchDirs, homeErr := companionSearchDirsForUpgrade(rawAMQPath, amqDest)
+	if homeErr != nil {
+		if err := writeStdoutLine(fmt.Sprintf("warning: cannot resolve user home directory for companion search; skipping ~/.local/bin: %v", homeErr)); err != nil {
+			return err
+		}
+	}
+	plan, err := discoverCompanionPlan(companionBinariesForUpgrade, searchDirs, amqDest, homebrewPrefixes, scoopRoots)
 	if err != nil {
 		return err
 	}
@@ -457,14 +513,14 @@ func upgradeCompanionsWithProtection(
 		if !ok {
 			continue
 		}
-		item, err := prepareDirectUpgradeWithProtection(
+		item, err := prepareDirectUpgradeWithScoopRoots(
 			ctx,
 			client,
 			name,
 			latestTag,
 			target.target,
 			homebrewPrefixes,
-			scoopApps,
+			scoopRoots,
 			tmpDir,
 		)
 		if err != nil {
@@ -475,7 +531,7 @@ func upgradeCompanionsWithProtection(
 		prepared = append(prepared, preparedCompanionUpgrade{name: name, item: item})
 	}
 
-	if err := revalidatePreparedCompanionPlan(prepared, amqDest, homebrewPrefixes, scoopApps); err != nil {
+	if err := revalidatePreparedCompanionPlan(prepared, amqDest, homebrewPrefixes, scoopRoots); err != nil {
 		return err
 	}
 	for _, item := range prepared {
@@ -486,7 +542,7 @@ func upgradeCompanionsWithProtection(
 		name := item.name
 		if name == "amq-keepalive" {
 			if result.scheduled {
-				if err := writeStdoutLine("amq-keepalive: replacement scheduled; version cache updates on next run"); err != nil {
+				if err := writeStdoutLine("amq-keepalive: replacement scheduled; version cache is refreshed on the next successful check (best-effort)"); err != nil {
 					return err
 				}
 			}
@@ -502,7 +558,7 @@ func upgradeCompanionsWithProtection(
 // target inspected during discovery. The checks are pathname-based and do not
 // claim to close races that would require directory descriptors or no-follow
 // replacement primitives.
-func revalidatePreparedCompanionPlan(prepared []preparedCompanionUpgrade, amqDest string, homebrewPrefixes []string, scoopApps string) error {
+func revalidatePreparedCompanionPlan(prepared []preparedCompanionUpgrade, amqDest string, homebrewPrefixes []string, scoopRoots []update.ScoopInstallRoot) error {
 	var amqInfo os.FileInfo
 	if amqDest != "" {
 		info, err := os.Stat(amqDest)
@@ -521,7 +577,7 @@ func revalidatePreparedCompanionPlan(prepared []preparedCompanionUpgrade, amqDes
 			planned.link,
 			amqInfo,
 			homebrewPrefixes,
-			scoopApps,
+			scoopRoots,
 		)
 		if err != nil {
 			return fmt.Errorf("companion %s changed while preparing; %w", planned.link, err)
@@ -541,23 +597,35 @@ func revalidatePreparedCompanionPlan(prepared []preparedCompanionUpgrade, amqDes
 	return nil
 }
 
-// companionSearchDirs returns the directories to look for companions in, in
-// priority order: the directory holding the direct-install amq, then
-// ~/.local/bin (the documented companion home).
-func companionSearchDirs(amqDest string) []string {
-	dirs := make([]string, 0, 2)
-	if amqDest != "" {
-		if dir := filepath.Dir(amqDest); dir != "" {
-			dirs = append(dirs, dir)
+func companionSearchDirsForUpgrade(rawPath, resolvedPath string) ([]string, error) {
+	dirs := make([]string, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	add := func(dir string) {
+		if dir == "" {
+			return
+		}
+		dir = filepath.Clean(dir)
+		canonical := update.CanonicalPath(dir)
+		if _, ok := seen[canonical]; ok {
+			return
+		}
+		seen[canonical] = struct{}{}
+		dirs = append(dirs, dir)
+	}
+	for _, path := range []string{rawPath, resolvedPath} {
+		if path != "" {
+			add(filepath.Dir(path))
 		}
 	}
-	if home, err := homeDirForUpgrade(); err == nil {
-		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
+	home, err := homeDirForUpgrade()
+	if err != nil {
+		return dirs, err
 	}
-	return dirs
+	add(filepath.Join(home, ".local", "bin"))
+	return dirs, nil
 }
 
-func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebrewPrefixes []string, scoopApps string) (map[string]companionTarget, error) {
+func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebrewPrefixes []string, scoopRoots []update.ScoopInstallRoot) (map[string]companionTarget, error) {
 	var amqInfo os.FileInfo
 	var err error
 	if amqDest != "" {
@@ -576,7 +644,7 @@ func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebr
 			if runtime.GOOS == "windows" {
 				candidate += ".exe"
 			}
-			item, found, err := inspectCompanionCandidate(name, candidate, amqInfo, homebrewPrefixes, scoopApps)
+			item, found, err := inspectCompanionCandidate(name, candidate, amqInfo, homebrewPrefixes, scoopRoots)
 			if err != nil {
 				return nil, err
 			}
@@ -630,7 +698,7 @@ func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebr
 }
 
 func findCompanionMatches(name string, dirs []string, amqDest string, homebrewPrefixes []string, scoopApps string) ([]string, error) {
-	plan, err := discoverCompanionPlan([]string{name}, dirs, amqDest, homebrewPrefixes, scoopApps)
+	plan, err := discoverCompanionPlan([]string{name}, dirs, amqDest, homebrewPrefixes, legacyScoopRoots(scoopApps))
 	if err != nil {
 		return nil, err
 	}
@@ -641,7 +709,7 @@ func findCompanionMatches(name string, dirs []string, amqDest string, homebrewPr
 	return []string{item.target}, nil
 }
 
-func inspectCompanionCandidate(name, candidate string, amqInfo os.FileInfo, homebrewPrefixes []string, scoopApps string) (companionTarget, bool, error) {
+func inspectCompanionCandidate(name, candidate string, amqInfo os.FileInfo, homebrewPrefixes []string, scoopRoots []update.ScoopInstallRoot) (companionTarget, bool, error) {
 	linkInfo, err := os.Lstat(candidate)
 	if errors.Is(err, os.ErrNotExist) {
 		return companionTarget{}, false, nil
@@ -679,7 +747,7 @@ func inspectCompanionCandidate(name, candidate string, amqInfo os.FileInfo, home
 			return companionTarget{}, false, fmt.Errorf("refusing companion %s: target %s is the amq executable; repair the %s symlink to point at a real %s binary", candidate, target, name, name)
 		}
 	}
-	if isUnderProtectedRoot(target, homebrewPrefixes, scoopApps) {
+	if isUnderProtectedRoot(target, homebrewPrefixes, scoopRoots) {
 		return companionTarget{}, false, fmt.Errorf("refusing companion %s: target %s is package-managed; upgrade it with the package manager or repoint the companion link to a direct install", candidate, target)
 	}
 	return companionTarget{name: name, link: candidate, target: target, info: targetInfo}, true, nil
@@ -729,8 +797,11 @@ func classifyPackageInstall(path, resolved string, homebrewPrefixes []string, in
 				return update.InstallHomebrew, matchingHomebrewManager(candidate, path, installations)
 			}
 		}
-		if classifyInstallForUpgrade(candidate, "") == update.InstallScoop {
-			return update.InstallScoop, scoopManagerExecutable()
+		if kind := classifyInstallForUpgrade(candidate, ""); kind.IsScoop() {
+			if kind == update.InstallScoopUnknown {
+				return kind, ""
+			}
+			return kind, scoopManagerExecutable()
 		}
 	}
 	return update.InstallDirect, ""
@@ -832,6 +903,21 @@ func scoopManagerExecutable() string {
 		return ""
 	}
 	return path
+}
+
+func refuseUnknownScoopInstall(path, resolved string) error {
+	location := filepath.Clean(resolved)
+	if location == "." || location == "" {
+		location = filepath.Clean(path)
+	}
+	return fmt.Errorf("amq is in an unrecognized Scoop apps directory at %s; set SCOOP or SCOOP_GLOBAL to that Scoop root, or reinstall amq under a direct path", location)
+}
+
+func legacyScoopRoots(path string) []update.ScoopInstallRoot {
+	if path == "" {
+		return nil
+	}
+	return []update.ScoopInstallRoot{{Path: path, Scope: update.ScoopScopeUser}}
 }
 
 func homebrewPrefixesFromInstallations(installations []homebrewInstallation) []string {
@@ -1018,12 +1104,12 @@ func selectUpgradeDestination(path, resolved string, writable func(string) error
 	if err != nil {
 		return "", err
 	}
-	return selectUpgradeDestinationWithRoots(
+	return selectUpgradeDestinationWithScoopRoots(
 		path,
 		resolved,
 		writable,
 		homebrewPrefixesFromInstallations(installations),
-		update.ScoopAppsDir(),
+		update.ScoopInstallRoots(),
 	)
 }
 
@@ -1039,6 +1125,16 @@ func skipUnavailableCompanionsOnWindows(all *bool, goos string) error {
 }
 
 func selectUpgradeDestinationWithRoots(path, resolved string, writable func(string) error, homebrewPrefixes []string, scoopApps string) (string, error) {
+	return selectUpgradeDestinationWithScoopRoots(
+		path,
+		resolved,
+		writable,
+		homebrewPrefixes,
+		legacyScoopRoots(scoopApps),
+	)
+}
+
+func selectUpgradeDestinationWithScoopRoots(path, resolved string, writable func(string) error, homebrewPrefixes []string, scoopRoots []update.ScoopInstallRoot) (string, error) {
 	destPath := resolved
 	if destPath == "" {
 		destPath = path
@@ -1052,7 +1148,7 @@ func selectUpgradeDestinationWithRoots(path, resolved string, writable func(stri
 		if candidate == "" {
 			continue
 		}
-		if err := refusePackageManagedDestination(candidate, homebrewPrefixes, scoopApps); err != nil {
+		if err := refusePackageManagedDestinationWithScoopRoots(candidate, homebrewPrefixes, scoopRoots); err != nil {
 			return "", err
 		}
 	}
@@ -1063,6 +1159,10 @@ func selectUpgradeDestinationWithRoots(path, resolved string, writable func(stri
 }
 
 func refusePackageManagedDestination(path string, homebrewPrefixes []string, scoopApps string) error {
+	return refusePackageManagedDestinationWithScoopRoots(path, homebrewPrefixes, legacyScoopRoots(scoopApps))
+}
+
+func refusePackageManagedDestinationWithScoopRoots(path string, homebrewPrefixes []string, scoopRoots []update.ScoopInstallRoot) error {
 	path = filepath.Clean(path)
 	canonical := update.CanonicalPath(path)
 	for _, prefix := range homebrewPrefixes {
@@ -1101,13 +1201,24 @@ func refusePackageManagedDestination(path string, homebrewPrefixes []string, sco
 			}
 		}
 	}
-	if scoopApps != "" && pathWithinDirectory(canonical, update.CanonicalPath(scoopApps)) {
-		return fmt.Errorf("amq is installed via Scoop; run scoop update amq")
+	for _, scope := range []update.ScoopScope{update.ScoopScopeGlobal, update.ScoopScopeUser} {
+		for _, root := range scoopRoots {
+			if root.Scope != scope || root.Path == "" || !pathWithinDirectory(canonical, update.CanonicalPath(root.Path)) {
+				continue
+			}
+			if scope == update.ScoopScopeGlobal {
+				return fmt.Errorf("amq is installed via Scoop (global scope); run scoop update -g amq")
+			}
+			return fmt.Errorf("amq is installed via Scoop (user scope); run scoop update amq")
+		}
+	}
+	if update.IsScoopShapedPath(path) || update.IsScoopShapedPath(canonical) {
+		return fmt.Errorf("amq is in an unrecognized Scoop apps directory at %s; set SCOOP or SCOOP_GLOBAL to that Scoop root, or reinstall amq under a direct path", path)
 	}
 	return nil
 }
 
-func isUnderProtectedRoot(path string, homebrewPrefixes []string, scoopApps string) bool {
+func isUnderProtectedRoot(path string, homebrewPrefixes []string, scoopRoots []update.ScoopInstallRoot) bool {
 	canonical := update.CanonicalPath(path)
 	for _, prefix := range homebrewPrefixes {
 		prefix = canonicalHomebrewPrefix(prefix)
@@ -1116,7 +1227,12 @@ func isUnderProtectedRoot(path string, homebrewPrefixes []string, scoopApps stri
 			return true
 		}
 	}
-	return scoopApps != "" && pathWithinDirectory(canonical, update.CanonicalPath(scoopApps))
+	for _, root := range scoopRoots {
+		if root.Path != "" && pathWithinDirectory(canonical, update.CanonicalPath(root.Path)) {
+			return true
+		}
+	}
+	return update.IsScoopShapedPath(path) || update.IsScoopShapedPath(canonical)
 }
 
 func detectHomebrewPrefix() string {

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	debugbuildinfo "debug/buildinfo"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	runtimedebug "runtime/debug"
 	"strings"
 	"time"
 
@@ -26,6 +28,7 @@ var (
 	lookPathForDelegateForUpgrade         = exec.LookPath
 	runBrewPrefixForHomebrewUpgrade       = runBrewPrefix
 	homebrewBrewExistsForUpgrade          = homebrewBrewExists
+	homebrewCellarExistsForUpgrade        = homebrewCellarExists
 	classifyInstallForUpgrade             = update.ClassifyInstall
 	runDelegateForUpgrade                 = runDelegateCommand
 	companionBinariesForUpgrade           = update.CompanionBinaries
@@ -33,6 +36,7 @@ var (
 	downloadReleaseAssetForUpgrade        = update.DownloadReleaseAsset
 	fetchChecksumsForUpgrade              = update.FetchChecksums
 	extractBinaryForUpgrade               = extractBinaryFromArchive
+	readBuildInfoForUpgrade               = debugbuildinfo.ReadFile
 	replaceBinaryForUpgrade               = update.ReplaceBinary
 	updateVerifySHA256ForUpgrade          = update.VerifySHA256
 	saveUpgradeCacheForUpgrade            = saveUpgradeCache
@@ -41,6 +45,23 @@ var (
 type homebrewInstallation struct {
 	prefix     string
 	executable string
+}
+
+type derivedHomebrewPrefix struct {
+	prefix     string
+	fromCellar bool
+}
+
+type companionTarget struct {
+	name   string
+	link   string
+	target string
+	info   os.FileInfo
+}
+
+type preparedUpgrade struct {
+	binaryPath string
+	destPath   string
 }
 
 // saveUpgradeCache writes the latest-known-version cache for the amq binary
@@ -84,6 +105,9 @@ func runUpgrade(args []string, currentVersion string) error {
 	} else if handled {
 		return nil
 	}
+	if err := skipUnavailableCompanionsOnWindows(allFlag, runtime.GOOS); err != nil {
+		return err
+	}
 
 	path, resolved, err := executablePathForUpgrade()
 	if err != nil {
@@ -91,11 +115,21 @@ func runUpgrade(args []string, currentVersion string) error {
 	}
 
 	homebrewInstallations := homebrewInstallationsForUpgrade()
+	homebrewInstallations, err = addDerivedHomebrewInstallations(path, resolved, homebrewInstallations)
+	if err != nil {
+		return err
+	}
 	homebrewPrefixes := homebrewPrefixesFromInstallations(homebrewInstallations)
 	kind, managerPath := classifyPackageInstall(path, resolved, homebrewPrefixes, homebrewInstallations)
 	if kind.IsPackageManaged() {
 		if managerPath == "" {
-			return fmt.Errorf("%s executable not found; refusing package-manager delegation", packageManagerName(kind))
+			if kind == update.InstallHomebrew {
+				for _, prefix := range homebrewPrefixes {
+					brewPath := filepath.Join(canonicalHomebrewPrefix(prefix), "bin", "brew")
+					return fmt.Errorf("amq is installed via Homebrew but no brew executable was found at %s; run %s upgrade amq from that installation, or reinstall amq under ~/.local/bin for direct upgrades", brewPath, brewPath)
+				}
+			}
+			return fmt.Errorf("%s executable not found; refusing package-manager delegation; install the package manager or repoint amq to a direct install", packageManagerName(kind))
 		}
 		return runManagedUpgradeWithManager(kind, managerPath, *yesFlag, *allFlag)
 	}
@@ -279,42 +313,34 @@ func validateUpgradeCachePath() error {
 	return nil
 }
 
-// runDirectUpgradeWithProtection performs the final package-manager guard
-// immediately before replacement. Classification happens earlier, but this
-// independent check protects against a missed Homebrew prefix or a path race.
-func runDirectUpgradeWithProtection(
+func prepareDirectUpgradeWithProtection(
 	ctx context.Context,
 	client *http.Client,
-	binaryName, latestTag, latest, destPath string,
+	binaryName, latestTag, destPath string,
 	homebrewPrefixes []string,
 	scoopApps string,
-) (directUpgradeResult, error) {
+	tmpDir string,
+) (preparedUpgrade, error) {
 	assetName, err := update.AssetNameFor(binaryName, latestTag, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
-		return directUpgradeResult{}, err
+		return preparedUpgrade{}, err
 	}
-
-	tmpDir, err := os.MkdirTemp("", "amq-upgrade-")
-	if err != nil {
-		return directUpgradeResult{}, err
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	archivePath := filepath.Join(tmpDir, assetName)
 	if err := downloadReleaseAssetForUpgrade(ctx, client, latestTag, assetName, archivePath); err != nil {
-		return directUpgradeResult{}, err
+		return preparedUpgrade{}, err
 	}
 
 	checksums, err := fetchChecksumsForUpgrade(ctx, client, latestTag)
 	if err != nil {
-		return directUpgradeResult{}, err
+		return preparedUpgrade{}, err
 	}
 	checksum, ok := checksums[assetName]
 	if !ok {
-		return directUpgradeResult{}, fmt.Errorf("checksum entry not found for %s", assetName)
+		return preparedUpgrade{}, fmt.Errorf("checksum entry not found for %s", assetName)
 	}
 	if err := updateVerifySHA256ForUpgrade(archivePath, checksum); err != nil {
-		return directUpgradeResult{}, err
+		return preparedUpgrade{}, err
 	}
 
 	var binaryPath string
@@ -324,13 +350,20 @@ func runDirectUpgradeWithProtection(
 		binaryPath, err = extractBinaryForUpgrade(binaryName, archivePath, tmpDir, false)
 	}
 	if err != nil {
-		return directUpgradeResult{}, err
+		return preparedUpgrade{}, err
 	}
 
+	// This independent check protects against a path race. Path-derived
+	// Homebrew prefixes are added before classification, so a missed prefix
+	// does not become a direct replacement.
 	if err := refusePackageManagedDestination(destPath, homebrewPrefixes, scoopApps); err != nil {
-		return directUpgradeResult{}, err
+		return preparedUpgrade{}, err
 	}
-	scheduled, err := replaceBinaryForUpgrade(binaryPath, destPath)
+	return preparedUpgrade{binaryPath: binaryPath, destPath: destPath}, nil
+}
+
+func replacePreparedUpgrade(binaryName string, prepared preparedUpgrade) (directUpgradeResult, error) {
+	scheduled, err := replaceBinaryForUpgrade(prepared.binaryPath, prepared.destPath)
 	if err != nil {
 		return directUpgradeResult{}, err
 	}
@@ -346,6 +379,37 @@ func runDirectUpgradeWithProtection(
 	return directUpgradeResult{}, nil
 }
 
+// runDirectUpgradeWithProtection prepares one release and then replaces its
+// destination after the independent package-manager guard succeeds.
+func runDirectUpgradeWithProtection(
+	ctx context.Context,
+	client *http.Client,
+	binaryName, latestTag, latest, destPath string,
+	homebrewPrefixes []string,
+	scoopApps string,
+) (directUpgradeResult, error) {
+	tmpDir, err := os.MkdirTemp("", "amq-upgrade-")
+	if err != nil {
+		return directUpgradeResult{}, err
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	prepared, err := prepareDirectUpgradeWithProtection(
+		ctx,
+		client,
+		binaryName,
+		latestTag,
+		destPath,
+		homebrewPrefixes,
+		scoopApps,
+		tmpDir,
+	)
+	if err != nil {
+		return directUpgradeResult{}, err
+	}
+	return replacePreparedUpgrade(binaryName, prepared)
+}
+
 func upgradeCompanionsWithProtection(
 	ctx context.Context,
 	client *http.Client,
@@ -354,33 +418,64 @@ func upgradeCompanionsWithProtection(
 	scoopApps string,
 ) error {
 	searchDirs := companionSearchDirs(amqDest)
+	plan, err := discoverCompanionPlan(companionBinariesForUpgrade, searchDirs, amqDest, homebrewPrefixes, scoopApps)
+	if err != nil {
+		return err
+	}
+
+	prepared := make([]struct {
+		name string
+		item preparedUpgrade
+	}, 0, len(plan))
 	for _, name := range companionBinariesForUpgrade {
-		matches, err := findCompanionMatches(name, searchDirs, amqDest, homebrewPrefixes, scoopApps)
-		if err != nil {
-			return err
-		}
-		if len(matches) == 0 {
+		_, ok := plan[name]
+		if !ok {
 			if err := writeStdoutLine(name + " not found; skipping."); err != nil {
 				return err
 			}
 			continue
 		}
-		if len(matches) > 1 {
-			return fmt.Errorf("%s found at multiple distinct targets: %s", name, strings.Join(matches, ", "))
+	}
+	if len(plan) == 0 {
+		return nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "amq-upgrade-companions-")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	for _, name := range companionBinariesForUpgrade {
+		target, ok := plan[name]
+		if !ok {
+			continue
 		}
-		result, err := runDirectUpgradeWithProtection(
+		item, err := prepareDirectUpgradeWithProtection(
 			ctx,
 			client,
 			name,
 			latestTag,
-			latest,
-			matches[0],
+			target.target,
 			homebrewPrefixes,
 			scoopApps,
+			tmpDir,
 		)
 		if err != nil {
 			return fmt.Errorf("%s: %w", name, err)
 		}
+		prepared = append(prepared, struct {
+			name string
+			item preparedUpgrade
+		}{name: name, item: item})
+	}
+
+	for _, item := range prepared {
+		result, err := replacePreparedUpgrade(item.name, item.item)
+		if err != nil {
+			return fmt.Errorf("%s: %w", item.name, err)
+		}
+		name := item.name
 		if name == "amq-keepalive" {
 			if result.scheduled {
 				if err := writeStdoutLine("amq-keepalive: replacement scheduled; version cache updates on next run"); err != nil {
@@ -411,7 +506,7 @@ func companionSearchDirs(amqDest string) []string {
 	return dirs
 }
 
-func findCompanionMatches(name string, dirs []string, amqDest string, homebrewPrefixes []string, scoopApps string) ([]string, error) {
+func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebrewPrefixes []string, scoopApps string) (map[string]companionTarget, error) {
 	var amqInfo os.FileInfo
 	var err error
 	if amqDest != "" {
@@ -420,60 +515,158 @@ func findCompanionMatches(name string, dirs []string, amqDest string, homebrewPr
 			return nil, fmt.Errorf("cannot inspect amq destination %s: %w", amqDest, err)
 		}
 	}
-	matches := make([]string, 0, len(dirs))
-	seen := make(map[string]struct{}, len(dirs))
-	for _, dir := range dirs {
-		candidate := filepath.Join(dir, name)
-		if runtime.GOOS == "windows" {
-			candidate += ".exe"
-		}
-		linkInfo, err := os.Lstat(candidate)
-		if errors.Is(err, os.ErrNotExist) {
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("cannot inspect companion %s: %w", candidate, err)
-		}
 
-		var target string
-		switch {
-		case linkInfo.Mode().IsRegular():
-			target, err = filepath.EvalSymlinks(candidate)
-			if err != nil {
-				return nil, fmt.Errorf("cannot resolve companion %s: %w", candidate, err)
+	byName := make(map[string][]companionTarget, len(names))
+	byCanonicalTarget := make(map[string]companionTarget)
+	allTargets := make([]companionTarget, 0, len(names))
+	for _, name := range names {
+		for _, dir := range dirs {
+			candidate := filepath.Join(dir, name)
+			if runtime.GOOS == "windows" {
+				candidate += ".exe"
 			}
-		case linkInfo.Mode()&os.ModeSymlink != 0:
-			target, err = filepath.EvalSymlinks(candidate)
+			item, found, err := inspectCompanionCandidate(name, candidate, amqInfo, homebrewPrefixes, scoopApps)
 			if err != nil {
-				return nil, fmt.Errorf("cannot resolve companion symlink %s: %w", candidate, err)
+				return nil, err
 			}
-		default:
-			return nil, fmt.Errorf("refusing companion %s: object is not a regular file or symlink", candidate)
-		}
+			if !found {
+				continue
+			}
 
-		target = filepath.Clean(target)
-		targetInfo, statErr := os.Stat(target)
-		if statErr != nil {
-			return nil, fmt.Errorf("cannot inspect companion target %s: %w", target, statErr)
-		}
-		if !targetInfo.Mode().IsRegular() {
-			return nil, fmt.Errorf("refusing companion %s: target %s is not a regular file", candidate, target)
-		}
-		if amqInfo != nil {
-			if os.SameFile(targetInfo, amqInfo) {
-				return nil, fmt.Errorf("refusing companion %s: target %s is the amq executable", candidate, target)
+			canonicalTarget := update.CanonicalPath(item.target)
+			if existing, ok := byCanonicalTarget[canonicalTarget]; ok {
+				if existing.name != name {
+					return nil, companionAliasError(item, existing)
+				}
+				continue
 			}
+			duplicate := false
+			for _, existing := range allTargets {
+				if !os.SameFile(existing.info, item.info) {
+					continue
+				}
+				if existing.name != name {
+					return nil, companionAliasError(item, existing)
+				}
+				duplicate = true
+				break
+			}
+			if duplicate {
+				continue
+			}
+			byCanonicalTarget[canonicalTarget] = item
+			allTargets = append(allTargets, item)
+			byName[name] = append(byName[name], item)
 		}
-		if isUnderProtectedRoot(target, homebrewPrefixes, scoopApps) {
-			return nil, fmt.Errorf("refusing companion %s: target %s is package-managed", candidate, target)
-		}
-		if _, ok := seen[target]; ok {
-			continue
-		}
-		seen[target] = struct{}{}
-		matches = append(matches, target)
 	}
-	return matches, nil
+	for _, item := range allTargets {
+		if err := verifyCompanionBuild(item); err != nil {
+			return nil, err
+		}
+	}
+
+	plan := make(map[string]companionTarget, len(byName))
+	for _, name := range names {
+		matches := byName[name]
+		if len(matches) == 0 {
+			continue
+		}
+		if len(matches) > 1 {
+			targets := make([]string, 0, len(matches))
+			for _, match := range matches {
+				targets = append(targets, match.target)
+			}
+			return nil, fmt.Errorf("%s found at multiple distinct targets: %s; remove or consolidate one: %s", name, strings.Join(targets, ", "), strings.Join(targets, ", "))
+		}
+		plan[name] = matches[0]
+	}
+	return plan, nil
+}
+
+func findCompanionMatches(name string, dirs []string, amqDest string, homebrewPrefixes []string, scoopApps string) ([]string, error) {
+	plan, err := discoverCompanionPlan([]string{name}, dirs, amqDest, homebrewPrefixes, scoopApps)
+	if err != nil {
+		return nil, err
+	}
+	item, ok := plan[name]
+	if !ok {
+		return nil, nil
+	}
+	return []string{item.target}, nil
+}
+
+func inspectCompanionCandidate(name, candidate string, amqInfo os.FileInfo, homebrewPrefixes []string, scoopApps string) (companionTarget, bool, error) {
+	linkInfo, err := os.Lstat(candidate)
+	if errors.Is(err, os.ErrNotExist) {
+		return companionTarget{}, false, nil
+	}
+	if err != nil {
+		return companionTarget{}, false, fmt.Errorf("cannot inspect companion %s: %w; remove %s or fix its target", candidate, err, candidate)
+	}
+
+	var target string
+	switch {
+	case linkInfo.Mode().IsRegular():
+		target, err = filepath.EvalSymlinks(candidate)
+		if err != nil {
+			return companionTarget{}, false, fmt.Errorf("cannot resolve companion %s: %w; remove %s or fix its target", candidate, err, candidate)
+		}
+	case linkInfo.Mode()&os.ModeSymlink != 0:
+		target, err = filepath.EvalSymlinks(candidate)
+		if err != nil {
+			return companionTarget{}, false, fmt.Errorf("cannot resolve companion symlink %s: %w; remove %s or fix its target", candidate, err, candidate)
+		}
+	default:
+		return companionTarget{}, false, fmt.Errorf("refusing companion %s: object is not a regular file or symlink; remove %s or fix its target", candidate, candidate)
+	}
+
+	target = filepath.Clean(target)
+	targetInfo, statErr := os.Stat(target)
+	if statErr != nil {
+		return companionTarget{}, false, fmt.Errorf("cannot inspect companion target %s: %w; remove %s or fix its target", target, statErr, candidate)
+	}
+	if !targetInfo.Mode().IsRegular() {
+		return companionTarget{}, false, fmt.Errorf("refusing companion %s: target %s is not a regular file; remove %s or fix its target", candidate, target, candidate)
+	}
+	if amqInfo != nil {
+		if os.SameFile(targetInfo, amqInfo) {
+			return companionTarget{}, false, fmt.Errorf("refusing companion %s: target %s is the amq executable; repair the %s symlink to point at a real %s binary", candidate, target, name, name)
+		}
+	}
+	if isUnderProtectedRoot(target, homebrewPrefixes, scoopApps) {
+		return companionTarget{}, false, fmt.Errorf("refusing companion %s: target %s is package-managed; upgrade it with the package manager or repoint the companion link to a direct install", candidate, target)
+	}
+	return companionTarget{name: name, link: candidate, target: target, info: targetInfo}, true, nil
+}
+
+func verifyCompanionBuild(item companionTarget) error {
+	info, buildErr := readBuildInfoForUpgrade(item.target)
+	expected := expectedCompanionBuildPath(item.name)
+	if buildErr != nil || info == nil {
+		return fmt.Errorf("%s is not an %s build (found non-Go binary); remove or repoint it", item.target, item.name)
+	}
+	found := strings.TrimSpace(info.Path)
+	if found == "" {
+		found = "unknown"
+	}
+	if found != expected {
+		return fmt.Errorf("%s is not an %s build (found %s); remove or repoint it", item.target, item.name, found)
+	}
+	return nil
+}
+
+func expectedCompanionBuildPath(name string) string {
+	modulePath := update.ModulePath
+	if info, ok := runtimedebug.ReadBuildInfo(); ok && info != nil {
+		if mainPath := strings.TrimSpace(info.Main.Path); mainPath != "" && mainPath != "command-line-arguments" {
+			modulePath = mainPath
+		}
+	}
+	return modulePath + "/cmd/" + name
+}
+
+func companionAliasError(item, existing companionTarget) error {
+	return fmt.Errorf("refusing companion %s: target %s aliases %s at %s; repoint %s to a dedicated %s binary or remove it", item.name, item.target, existing.name, existing.link, item.link, item.name)
 }
 
 func classifyPackageInstall(path, resolved string, homebrewPrefixes []string, installations []homebrewInstallation) (update.InstallKind, string) {
@@ -560,10 +753,92 @@ func homebrewInstallationsForUpgrade() []homebrewInstallation {
 	})
 }
 
+func addDerivedHomebrewInstallations(path, resolved string, installations []homebrewInstallation) ([]homebrewInstallation, error) {
+	derived := derivedHomebrewPrefixes(path, resolved)
+	if len(derived) == 0 {
+		return installations, nil
+	}
+
+	result := append([]homebrewInstallation(nil), installations...)
+	known := make(map[string]struct{}, len(result)+len(derived))
+	for _, installation := range result {
+		if prefix := canonicalHomebrewPrefix(installation.prefix); prefix != "" {
+			known[prefix] = struct{}{}
+		}
+	}
+	for _, candidate := range derived {
+		prefix := canonicalHomebrewPrefix(candidate.prefix)
+		if prefix == "" {
+			continue
+		}
+		brewPath := filepath.Join(prefix, "bin", "brew")
+		if candidate.fromCellar && !homebrewBrewExistsForUpgrade(brewPath) {
+			cellarPath := resolved
+			if cellarPath == "" {
+				cellarPath = path
+			}
+			return nil, fmt.Errorf("amq lives in a Homebrew Cellar at %s but no brew executable was found at %s; run %s upgrade amq from that installation, or reinstall amq under ~/.local/bin for direct upgrades", filepath.Clean(cellarPath), brewPath, brewPath)
+		}
+		if _, ok := known[prefix]; ok {
+			continue
+		}
+		known[prefix] = struct{}{}
+		result = append(result, homebrewInstallation{prefix: prefix, executable: brewPath})
+	}
+	return result, nil
+}
+
+func derivedHomebrewPrefixes(path, resolved string) []derivedHomebrewPrefix {
+	result := make([]derivedHomebrewPrefix, 0, 2)
+	seen := make(map[string]struct{}, 2)
+	add := func(prefix string, fromCellar bool) {
+		prefix = canonicalHomebrewPrefix(prefix)
+		if prefix == "" {
+			return
+		}
+		if _, exists := seen[prefix]; exists {
+			return
+		}
+		seen[prefix] = struct{}{}
+		result = append(result, derivedHomebrewPrefix{prefix: prefix, fromCellar: fromCellar})
+	}
+
+	for _, candidate := range []string{resolved} {
+		if prefix := homebrewCellarPrefix(candidate); prefix != "" {
+			add(prefix, true)
+		}
+	}
+
+	rawPath := filepath.Clean(path)
+	if filepath.Base(filepath.Dir(rawPath)) == "bin" {
+		prefix := filepath.Dir(filepath.Dir(rawPath))
+		if homebrewCellarExistsForUpgrade(filepath.Join(prefix, "Cellar")) {
+			add(prefix, false)
+		}
+	}
+	return result
+}
+
+func homebrewCellarPrefix(path string) string {
+	if path == "" {
+		return ""
+	}
+	clean := filepath.Clean(path)
+	marker := string(filepath.Separator) + "Cellar" + string(filepath.Separator)
+	index := strings.Index(clean, marker)
+	if index <= 0 {
+		return ""
+	}
+	return clean[:index]
+}
+
 func detectHomebrewInstallations() []homebrewInstallation {
 	installations := make([]homebrewInstallation, 0, len(wellKnownHomebrewPrefixes)+3)
 	seen := make(map[string]struct{})
-	add := func(prefix, executable string) {
+	add := func(prefix, executable string, evidenced bool) {
+		if !evidenced {
+			return
+		}
 		prefix = cleanHomebrewPrefix(prefix)
 		if prefix == "" {
 			return
@@ -587,17 +862,20 @@ func detectHomebrewInstallations() []homebrewInstallation {
 		output, runErr := runBrewPrefixForHomebrewUpgrade(ctx, brewPath)
 		cancel()
 		if runErr == nil {
-			add(strings.TrimSpace(string(output)), brewPath)
+			add(strings.TrimSpace(string(output)), brewPath, true)
 		}
 	}
 	if prefix := cleanHomebrewPrefix(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
-		add(prefix, filepath.Join(prefix, "bin", "brew"))
+		add(prefix, filepath.Join(prefix, "bin", "brew"), true)
 	}
 	for _, prefix := range wellKnownHomebrewPrefixes {
-		add(prefix, filepath.Join(prefix, "bin", "brew"))
+		brewPath := filepath.Join(prefix, "bin", "brew")
+		add(prefix, brewPath, homebrewBrewExistsForUpgrade(brewPath) || homebrewCellarExistsForUpgrade(filepath.Join(prefix, "Cellar")))
 	}
 	if home, err := homeDirForUpgrade(); err == nil {
-		add(filepath.Join(home, ".linuxbrew"), filepath.Join(home, ".linuxbrew", "bin", "brew"))
+		prefix := filepath.Join(home, ".linuxbrew")
+		brewPath := filepath.Join(prefix, "bin", "brew")
+		add(prefix, brewPath, homebrewBrewExistsForUpgrade(brewPath) || homebrewCellarExistsForUpgrade(filepath.Join(prefix, "Cellar")))
 	}
 	return installations
 }
@@ -619,6 +897,11 @@ func isSymlinkToHomebrewCellar(path, cellar string) bool {
 // performs the last package-manager safety check before any download starts.
 func selectUpgradeDestination(path, resolved string, writable func(string) error) (string, error) {
 	installations := homebrewInstallationsForUpgrade()
+	var err error
+	installations, err = addDerivedHomebrewInstallations(path, resolved, installations)
+	if err != nil {
+		return "", err
+	}
 	return selectUpgradeDestinationWithRoots(
 		path,
 		resolved,
@@ -626,6 +909,17 @@ func selectUpgradeDestination(path, resolved string, writable func(string) error
 		homebrewPrefixesFromInstallations(installations),
 		update.ScoopAppsDir(),
 	)
+}
+
+func skipUnavailableCompanionsOnWindows(all *bool, goos string) error {
+	if all == nil || !*all || goos != "windows" {
+		return nil
+	}
+	if err := writeStdoutLine("--all: companion binaries are not published for Windows; skipping"); err != nil {
+		return err
+	}
+	*all = false
+	return nil
 }
 
 func selectUpgradeDestinationWithRoots(path, resolved string, writable func(string) error, homebrewPrefixes []string, scoopApps string) (string, error) {
@@ -661,9 +955,9 @@ func refusePackageManagedDestination(path string, homebrewPrefixes []string, sco
 			continue
 		}
 		cellar := filepath.Join(prefix, "Cellar")
-		// This is intentionally independent from install classification. A
-		// missed prefix or a path race must not turn a Cellar replacement into
-		// a direct install.
+		// This is intentionally independent from install classification. A path
+		// race must not turn a package-managed replacement into a direct install;
+		// executable-derived prefixes cover prefixes missed during discovery.
 		if pathWithinDirectory(canonical, cellar) {
 			return fmt.Errorf("amq is installed via Homebrew; run brew update && brew upgrade amq")
 		}
@@ -673,21 +967,21 @@ func refusePackageManagedDestination(path string, homebrewPrefixes []string, sco
 				if errors.Is(err, os.ErrNotExist) {
 					continue
 				}
-				return fmt.Errorf("cannot inspect possible Homebrew destination %s: %w", path, err)
+				return fmt.Errorf("cannot inspect possible Homebrew destination %s: %w; remove %s or fix its target", path, err, path)
 			}
 			switch {
 			case info.Mode().IsRegular():
-				return fmt.Errorf("amq is in a Homebrew prefix but is not a managed symlink; run brew reinstall amq or brew update && brew upgrade amq")
+				return fmt.Errorf("amq is in an evidenced Homebrew prefix but is not a managed symlink; brew reinstall amq (if Homebrew owns it) or move the binary to ~/.local/bin and rerun amq upgrade (if you installed it manually)")
 			case info.Mode()&os.ModeSymlink != 0:
 				resolved, resolveErr := filepath.EvalSymlinks(path)
 				if resolveErr != nil {
-					return fmt.Errorf("amq is in a Homebrew prefix but its symlink cannot be resolved; run brew reinstall amq or brew update && brew upgrade amq: %w", resolveErr)
+					return fmt.Errorf("amq is in a Homebrew prefix but its symlink cannot be resolved; remove %s or fix its target: %w", path, resolveErr)
 				}
 				if pathWithinDirectory(filepath.Clean(resolved), cellar) {
 					return fmt.Errorf("amq is installed via Homebrew; run brew update && brew upgrade amq")
 				}
 			default:
-				return fmt.Errorf("refusing possible Homebrew destination %s; run brew reinstall amq or brew update && brew upgrade amq", path)
+				return fmt.Errorf("refusing possible Homebrew destination %s; remove %s or fix its target", path, path)
 			}
 		}
 	}
@@ -701,7 +995,8 @@ func isUnderProtectedRoot(path string, homebrewPrefixes []string, scoopApps stri
 	canonical := update.CanonicalPath(path)
 	for _, prefix := range homebrewPrefixes {
 		prefix = canonicalHomebrewPrefix(prefix)
-		if prefix != "" && pathWithinDirectory(canonical, filepath.Join(prefix, "Cellar")) {
+		if prefix != "" && (pathWithinDirectory(canonical, filepath.Join(prefix, "Cellar")) ||
+			pathWithinDirectory(canonical, filepath.Join(prefix, "bin"))) {
 			return true
 		}
 	}
@@ -725,7 +1020,8 @@ func detectHomebrewPrefix() string {
 	}
 
 	for _, prefix := range wellKnownHomebrewPrefixes {
-		if homebrewBrewExistsForUpgrade(filepath.Join(prefix, "bin", "brew")) {
+		brewPath := filepath.Join(prefix, "bin", "brew")
+		if homebrewBrewExistsForUpgrade(brewPath) || homebrewCellarExistsForUpgrade(filepath.Join(prefix, "Cellar")) {
 			return filepath.Clean(prefix)
 		}
 	}
@@ -733,7 +1029,8 @@ func detectHomebrewPrefix() string {
 	// path, so it is checked separately from the well-known prefix list).
 	if home, err := homeDirForUpgrade(); err == nil {
 		userLinuxbrew := filepath.Join(home, ".linuxbrew")
-		if homebrewBrewExistsForUpgrade(filepath.Join(userLinuxbrew, "bin", "brew")) {
+		brewPath := filepath.Join(userLinuxbrew, "bin", "brew")
+		if homebrewBrewExistsForUpgrade(brewPath) || homebrewCellarExistsForUpgrade(filepath.Join(userLinuxbrew, "Cellar")) {
 			return userLinuxbrew
 		}
 	}
@@ -747,6 +1044,11 @@ func runBrewPrefix(ctx context.Context, brewPath string) ([]byte, error) {
 func homebrewBrewExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+func homebrewCellarExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 func cleanHomebrewPrefix(prefix string) string {

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -60,8 +60,14 @@ type companionTarget struct {
 }
 
 type preparedUpgrade struct {
-	binaryPath string
-	destPath   string
+	binaryPath    string
+	destPath      string
+	plannedTarget *companionTarget
+}
+
+type preparedCompanionUpgrade struct {
+	name string
+	item preparedUpgrade
 }
 
 // saveUpgradeCache writes the latest-known-version cache for the amq binary
@@ -124,10 +130,7 @@ func runUpgrade(args []string, currentVersion string) error {
 	if kind.IsPackageManaged() {
 		if managerPath == "" {
 			if kind == update.InstallHomebrew {
-				for _, prefix := range homebrewPrefixes {
-					brewPath := filepath.Join(canonicalHomebrewPrefix(prefix), "bin", "brew")
-					return fmt.Errorf("amq is installed via Homebrew but no brew executable was found at %s; run %s upgrade amq from that installation, or reinstall amq under ~/.local/bin for direct upgrades", brewPath, brewPath)
-				}
+				return refuseHomebrewWithoutMatchingManager(path, resolved, homebrewInstallations)
 			}
 			return fmt.Errorf("%s executable not found; refusing package-manager delegation; install the package manager or repoint amq to a direct install", packageManagerName(kind))
 		}
@@ -163,6 +166,10 @@ func runUpgrade(args []string, currentVersion string) error {
 		if err := writeStdoutLine(fmt.Sprintf("amq is already up to date (%s)", latest)); err != nil {
 			return err
 		}
+		if err := validateUpgradeCachePath(); err != nil {
+			return err
+		}
+		saveUpgradeCacheForUpgrade(latest)
 		if *allFlag {
 			if err := upgradeCompanionsWithProtection(
 				ctx,
@@ -263,14 +270,16 @@ func delegateUpgradeCommandWithManager(kind update.InstallKind, managerPath stri
 		if managerPath == "" {
 			managerPath = "brew"
 		}
-		return [][]string{{managerPath, "update"}, {managerPath, "upgrade", "amq"}},
-			"amq is installed via Homebrew; run brew update && brew upgrade amq (or amq upgrade -y)"
+		commands := [][]string{{managerPath, "update"}, {managerPath, "upgrade", "amq"}}
+		return commands,
+			fmt.Sprintf("amq is installed via Homebrew; run %s && %s (or amq upgrade -y)", strings.Join(commands[0], " "), strings.Join(commands[1], " "))
 	case update.InstallScoop:
 		if managerPath == "" {
 			managerPath = "scoop"
 		}
-		return [][]string{{managerPath, "update", "amq"}},
-			"amq is installed via Scoop; run scoop update amq (or amq upgrade -y)"
+		commands := [][]string{{managerPath, "update", "amq"}}
+		return commands,
+			fmt.Sprintf("amq is installed via Scoop; run %s (or amq upgrade -y)", strings.Join(commands[0], " "))
 	default:
 		return nil, ""
 	}
@@ -353,9 +362,9 @@ func prepareDirectUpgradeWithProtection(
 		return preparedUpgrade{}, err
 	}
 
-	// This independent check protects against a path race. Path-derived
-	// Homebrew prefixes are added before classification, so a missed prefix
-	// does not become a direct replacement.
+	// This is a second package-root classification check. Path-derived
+	// Homebrew prefixes are added before classification; this check covers a
+	// prefix that changes between destination selection and replacement.
 	if err := refusePackageManagedDestination(destPath, homebrewPrefixes, scoopApps); err != nil {
 		return preparedUpgrade{}, err
 	}
@@ -423,10 +432,7 @@ func upgradeCompanionsWithProtection(
 		return err
 	}
 
-	prepared := make([]struct {
-		name string
-		item preparedUpgrade
-	}, 0, len(plan))
+	prepared := make([]preparedCompanionUpgrade, 0, len(plan))
 	for _, name := range companionBinariesForUpgrade {
 		_, ok := plan[name]
 		if !ok {
@@ -464,12 +470,14 @@ func upgradeCompanionsWithProtection(
 		if err != nil {
 			return fmt.Errorf("%s: %w", name, err)
 		}
-		prepared = append(prepared, struct {
-			name string
-			item preparedUpgrade
-		}{name: name, item: item})
+		planned := target
+		item.plannedTarget = &planned
+		prepared = append(prepared, preparedCompanionUpgrade{name: name, item: item})
 	}
 
+	if err := revalidatePreparedCompanionPlan(prepared, amqDest, homebrewPrefixes, scoopApps); err != nil {
+		return err
+	}
 	for _, item := range prepared {
 		result, err := replacePreparedUpgrade(item.name, item.item)
 		if err != nil {
@@ -482,10 +490,53 @@ func upgradeCompanionsWithProtection(
 					return err
 				}
 			}
-			if err := writeStdoutLine("amq-keepalive: a running supervisor picks up the new image on its next supervise pass (self-upgrade); if it was started with --no-self-upgrade, restart it with 'amq-keepalive install-launchd'."); err != nil {
+			if err := writeStdoutLine("amq-keepalive: a running supervisor picks up a strictly newer image on its next supervise pass (self-upgrade); if it was started with --no-self-upgrade, restart it through its service manager (on macOS use 'amq-keepalive install-launchd'; on Linux use 'systemctl --user restart amq-keepalive.service')."); err != nil {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// revalidatePreparedCompanionPlan binds every prepared replacement to the
+// target inspected during discovery. The checks are pathname-based and do not
+// claim to close races that would require directory descriptors or no-follow
+// replacement primitives.
+func revalidatePreparedCompanionPlan(prepared []preparedCompanionUpgrade, amqDest string, homebrewPrefixes []string, scoopApps string) error {
+	var amqInfo os.FileInfo
+	if amqDest != "" {
+		info, err := os.Stat(amqDest)
+		if err != nil {
+			return fmt.Errorf("cannot inspect amq destination %s before companion replacement: %w", amqDest, err)
+		}
+		amqInfo = info
+	}
+	for index := range prepared {
+		planned := prepared[index].item.plannedTarget
+		if planned == nil {
+			return fmt.Errorf("companion %s has no planned target; remove or repoint it", prepared[index].name)
+		}
+		current, found, err := inspectCompanionCandidate(
+			planned.name,
+			planned.link,
+			amqInfo,
+			homebrewPrefixes,
+			scoopApps,
+		)
+		if err != nil {
+			return fmt.Errorf("companion %s changed while preparing; %w", planned.link, err)
+		}
+		if !found {
+			return fmt.Errorf("companion %s disappeared while preparing; remove or restore its target", planned.link)
+		}
+		if !os.SameFile(current.info, planned.info) {
+			return fmt.Errorf("companion %s changed while preparing; remove or repoint it", planned.link)
+		}
+		if err := verifyCompanionBuild(current); err != nil {
+			return fmt.Errorf("companion %s changed while preparing; %w", planned.link, err)
+		}
+		prepared[index].item.destPath = current.target
+		prepared[index].item.plannedTarget = &current
 	}
 	return nil
 }
@@ -540,7 +591,6 @@ func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebr
 				}
 				continue
 			}
-			duplicate := false
 			for _, existing := range allTargets {
 				if !os.SameFile(existing.info, item.info) {
 					continue
@@ -548,11 +598,7 @@ func discoverCompanionPlan(names []string, dirs []string, amqDest string, homebr
 				if existing.name != name {
 					return nil, companionAliasError(item, existing)
 				}
-				duplicate = true
-				break
-			}
-			if duplicate {
-				continue
+				return nil, companionHardlinkError(item, existing)
 			}
 			byCanonicalTarget[canonicalTarget] = item
 			allTargets = append(allTargets, item)
@@ -669,6 +715,10 @@ func companionAliasError(item, existing companionTarget) error {
 	return fmt.Errorf("refusing companion %s: target %s aliases %s at %s; repoint %s to a dedicated %s binary or remove it", item.name, item.target, existing.name, existing.link, item.link, item.name)
 }
 
+func companionHardlinkError(item, existing companionTarget) error {
+	return fmt.Errorf("refusing companion %s: distinct paths %s and %s are hardlinks to one file; repoint %s to a dedicated %s binary or remove it", item.name, existing.target, item.target, item.link, item.name)
+}
+
 func classifyPackageInstall(path, resolved string, homebrewPrefixes []string, installations []homebrewInstallation) (update.InstallKind, string) {
 	for _, candidate := range []string{resolved, path} {
 		if candidate == "" {
@@ -689,22 +739,88 @@ func classifyPackageInstall(path, resolved string, homebrewPrefixes []string, in
 func matchingHomebrewManager(candidate, rawPath string, installations []homebrewInstallation) string {
 	for _, installation := range installations {
 		prefix := canonicalHomebrewPrefix(installation.prefix)
-		cellar := filepath.Join(prefix, "Cellar")
-		for _, path := range []string{candidate, rawPath} {
-			if path == "" {
-				continue
-			}
-			canonical := update.CanonicalPath(path)
-			if pathWithinDirectory(canonical, cellar) ||
-				(pathWithinDirectory(filepath.Clean(path), filepath.Join(prefix, "bin")) && isSymlinkToHomebrewCellar(path, cellar)) {
-				if installation.executable != "" {
-					return installation.executable
-				}
-				return filepath.Join(prefix, "bin", "brew")
-			}
+		if prefix == "" || !homebrewInstallationMatchesPath(candidate, rawPath, prefix) {
+			continue
+		}
+		if manager, ok := verifiedHomebrewManager(installation); ok {
+			return manager
 		}
 	}
 	return ""
+}
+
+func homebrewInstallationMatchesPath(candidate, rawPath, prefix string) bool {
+	prefix = canonicalHomebrewPrefix(prefix)
+	if prefix == "" {
+		return false
+	}
+	cellar := filepath.Join(prefix, "Cellar")
+	for _, path := range []string{candidate, rawPath} {
+		if path == "" {
+			continue
+		}
+		canonical := update.CanonicalPath(path)
+		if pathWithinDirectory(canonical, cellar) ||
+			(pathWithinDirectory(filepath.Clean(path), filepath.Join(prefix, "bin")) && isSymlinkToHomebrewCellar(path, cellar)) {
+			return true
+		}
+	}
+	return false
+}
+
+func homebrewManagerPath(installation homebrewInstallation) string {
+	if installation.executable != "" {
+		return filepath.Clean(installation.executable)
+	}
+	return filepath.Join(canonicalHomebrewPrefix(installation.prefix), "bin", "brew")
+}
+
+func verifiedHomebrewManager(installation homebrewInstallation) (string, bool) {
+	prefix := canonicalHomebrewPrefix(installation.prefix)
+	manager := homebrewManagerPath(installation)
+	if prefix == "" || manager == "" || !homebrewBrewExistsForUpgrade(manager) {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), homebrewDetectionTimeout)
+	output, err := runBrewPrefixForHomebrewUpgrade(ctx, manager)
+	cancel()
+	if err != nil {
+		return "", false
+	}
+	reported := cleanHomebrewPrefix(strings.TrimSpace(string(output)))
+	if reported == "" || canonicalHomebrewPrefix(reported) != prefix {
+		return "", false
+	}
+	return manager, true
+}
+
+func refuseHomebrewWithoutMatchingManager(path, resolved string, installations []homebrewInstallation) error {
+	for _, installation := range installations {
+		prefix := canonicalHomebrewPrefix(installation.prefix)
+		if prefix == "" || !homebrewInstallationMatchesPath(resolved, path, prefix) {
+			continue
+		}
+		manager := homebrewManagerPath(installation)
+		location := resolved
+		if location == "" {
+			location = path
+		}
+		if !homebrewBrewExistsForUpgrade(manager) {
+			if cellarPrefix := homebrewCellarPrefix(location); cellarPrefix != "" {
+				return fmt.Errorf("amq lives in a Homebrew Cellar at %s but no brew executable was found at %s; run %s upgrade amq from that installation, or reinstall amq under ~/.local/bin for direct upgrades", filepath.Clean(location), manager, manager)
+			}
+			return fmt.Errorf("amq is installed in Homebrew prefix %s but no brew executable was found at %s; repair that installation or reinstall amq under ~/.local/bin for direct upgrades", prefix, manager)
+		}
+		return fmt.Errorf("amq is installed in a Homebrew Cellar at %s, but %s does not report prefix %s; repair that Homebrew installation or reinstall amq under ~/.local/bin for direct upgrades", filepath.Clean(location), manager, prefix)
+	}
+	if len(installations) > 0 {
+		manager := homebrewManagerPath(installations[0])
+		if !homebrewBrewExistsForUpgrade(manager) {
+			return fmt.Errorf("amq is installed via Homebrew but no brew executable was found at %s; run %s upgrade amq from that installation, or reinstall amq under ~/.local/bin for direct upgrades", manager, manager)
+		}
+		return fmt.Errorf("amq is installed via Homebrew, but %s does not report its installation prefix; repair that Homebrew installation or reinstall amq under ~/.local/bin for direct upgrades", manager)
+	}
+	return fmt.Errorf("amq is installed via Homebrew but no matching brew executable was found; repair that Homebrew installation or reinstall amq under ~/.local/bin for direct upgrades")
 }
 
 func scoopManagerExecutable() string {
@@ -1043,7 +1159,7 @@ func runBrewPrefix(ctx context.Context, brewPath string) ([]byte, error) {
 
 func homebrewBrewExists(path string) bool {
 	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
 }
 
 func homebrewCellarExists(path string) bool {

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -501,7 +501,7 @@ func matchingHomebrewManager(candidate, rawPath string, installations []homebrew
 			if path == "" {
 				continue
 			}
-			canonical := canonicalExistingPath(path)
+			canonical := update.CanonicalPath(path)
 			if pathWithinDirectory(canonical, cellar) ||
 				(pathWithinDirectory(filepath.Clean(path), filepath.Join(prefix, "bin")) && isSymlinkToHomebrewCellar(path, cellar)) {
 				if installation.executable != "" {
@@ -603,31 +603,7 @@ func detectHomebrewInstallations() []homebrewInstallation {
 }
 
 func canonicalHomebrewPrefix(prefix string) string {
-	return canonicalExistingPath(cleanHomebrewPrefix(prefix))
-}
-
-func canonicalExistingPath(path string) string {
-	path = filepath.Clean(path)
-	if abs, err := filepath.Abs(path); err == nil {
-		path = abs
-	}
-	current := path
-	suffix := make([]string, 0, 4)
-	for {
-		if resolved, err := filepath.EvalSymlinks(current); err == nil {
-			resolved = filepath.Clean(resolved)
-			for index := len(suffix) - 1; index >= 0; index-- {
-				resolved = filepath.Join(resolved, suffix[index])
-			}
-			return filepath.Clean(resolved)
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return path
-		}
-		suffix = append(suffix, filepath.Base(current))
-		current = parent
-	}
+	return update.CanonicalPath(cleanHomebrewPrefix(prefix))
 }
 
 func isSymlinkToHomebrewCellar(path, cellar string) bool {
@@ -678,7 +654,7 @@ func selectUpgradeDestinationWithRoots(path, resolved string, writable func(stri
 
 func refusePackageManagedDestination(path string, homebrewPrefixes []string, scoopApps string) error {
 	path = filepath.Clean(path)
-	canonical := canonicalExistingPath(path)
+	canonical := update.CanonicalPath(path)
 	for _, prefix := range homebrewPrefixes {
 		prefix = canonicalHomebrewPrefix(prefix)
 		if prefix == "" {
@@ -715,21 +691,21 @@ func refusePackageManagedDestination(path string, homebrewPrefixes []string, sco
 			}
 		}
 	}
-	if scoopApps != "" && pathWithinDirectory(canonical, canonicalExistingPath(scoopApps)) {
+	if scoopApps != "" && pathWithinDirectory(canonical, update.CanonicalPath(scoopApps)) {
 		return fmt.Errorf("amq is installed via Scoop; run scoop update amq")
 	}
 	return nil
 }
 
 func isUnderProtectedRoot(path string, homebrewPrefixes []string, scoopApps string) bool {
-	canonical := canonicalExistingPath(path)
+	canonical := update.CanonicalPath(path)
 	for _, prefix := range homebrewPrefixes {
 		prefix = canonicalHomebrewPrefix(prefix)
 		if prefix != "" && pathWithinDirectory(canonical, filepath.Join(prefix, "Cellar")) {
 			return true
 		}
 	}
-	return scoopApps != "" && pathWithinDirectory(canonical, canonicalExistingPath(scoopApps))
+	return scoopApps != "" && pathWithinDirectory(canonical, update.CanonicalPath(scoopApps))
 }
 
 func detectHomebrewPrefix() string {
@@ -784,7 +760,7 @@ func homebrewOwnsUpgradePath(prefix, path string) bool {
 	if path == "" {
 		return false
 	}
-	path = canonicalExistingPath(path)
+	path = update.CanonicalPath(path)
 	prefix = canonicalHomebrewPrefix(prefix)
 	return pathWithinDirectory(path, filepath.Join(prefix, "bin")) ||
 		pathWithinDirectory(path, filepath.Join(prefix, "Cellar"))

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -22,7 +22,31 @@ var (
 	lookPathForHomebrewUpgrade      = exec.LookPath
 	runBrewPrefixForHomebrewUpgrade = runBrewPrefix
 	homebrewBrewExistsForUpgrade    = homebrewBrewExists
+	classifyInstallForUpgrade       = update.ClassifyInstall
+	runDelegateForUpgrade           = runDelegateCommand
+	companionBinariesForUpgrade     = update.CompanionBinaries
+	homeDirForUpgrade               = os.UserHomeDir
+	downloadReleaseAssetForUpgrade  = update.DownloadReleaseAsset
+	fetchChecksumsForUpgrade        = update.FetchChecksums
+	extractBinaryForUpgrade         = extractBinaryFromArchive
+	replaceBinaryForUpgrade         = update.ReplaceBinary
+	updateVerifySHA256ForUpgrade    = update.VerifySHA256
+	saveUpgradeCacheForUpgrade      = saveUpgradeCache
 )
+
+// saveUpgradeCache writes the latest-known-version cache for the amq binary
+// (not companions). It is best-effort: a cache write failure does not fail
+// the upgrade.
+func saveUpgradeCache(latest string) {
+	cachePath, err := update.DefaultCachePath()
+	if err != nil {
+		return
+	}
+	_ = update.SaveCache(cachePath, &update.Cache{
+		CheckedAt:     time.Now().UTC(),
+		LatestVersion: latest,
+	})
+}
 
 const homebrewDetectionTimeout = 2 * time.Second
 
@@ -34,11 +58,14 @@ var wellKnownHomebrewPrefixes = []string{
 
 func runUpgrade(args []string, currentVersion string) error {
 	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
+	allFlag := fs.Bool("all", false, "Also upgrade present companion binaries (amq-keepalive, amq-bridge, amq-acp)")
+	yesFlag := fs.Bool("y", false, "Run the package-manager delegate non-interactively (Homebrew/Scoop installs)")
 	usage := usageWithFlags(
 		fs,
-		"amq upgrade",
-		"Downloads and installs the latest amq release from GitHub",
-		"",
+		"amq upgrade [--all] [-y]",
+		"Downloads and installs the latest amq release from GitHub.",
+		"When amq is installed via Homebrew or Scoop, amq upgrade delegates to the package manager instead of overwriting it; pass -y to run the delegate.",
+		"--all upgrades companion binaries present next to a direct-install amq or in ~/.local/bin; a running amq-keepalive is never killed.",
 		"Retire live wakes started by the previous binary before its install directory is removed.",
 		"If wake check reports binary_dir_gone, run amq doctor --ops --fix-wake-locks.",
 	)
@@ -52,6 +79,21 @@ func runUpgrade(args []string, currentVersion string) error {
 	if err != nil {
 		return err
 	}
+
+	homebrewPrefix := detectHomebrewPrefixForUpgrade()
+	// Classify from BOTH the resolved path (authoritative: a symlink into the
+	// Cellar lands there) and the pre-resolution path (a user-made
+	// ~/bin/amq -> /opt/homebrew/bin/amq link is Homebrew-owned by its link
+	// path even before resolution). Either matching a package manager wins.
+	kind := classifyInstallForUpgrade(resolved, homebrewPrefix)
+	if kind == update.InstallDirect {
+		kind = classifyInstallForUpgrade(path, homebrewPrefix)
+	}
+
+	if kind.IsPackageManaged() {
+		return runManagedUpgrade(kind, *yesFlag, *allFlag)
+	}
+
 	destPath, err := selectUpgradeDestination(path, resolved, upgradeDestinationWritable)
 	if err != nil {
 		return err
@@ -75,6 +117,11 @@ func runUpgrade(args []string, currentVersion string) error {
 		if err := writeStdoutLine(fmt.Sprintf("amq is already up to date (%s)", latest)); err != nil {
 			return err
 		}
+		if *allFlag {
+			if err := upgradeCompanions(ctx, client, latestTag, latest, destPath); err != nil {
+				return err
+			}
+		}
 		return reportStaleWakesAfterUpgrade()
 	}
 
@@ -82,7 +129,90 @@ func runUpgrade(args []string, currentVersion string) error {
 		return err
 	}
 
-	assetName, err := update.AssetName(latestTag, runtime.GOOS, runtime.GOARCH)
+	if err := runDirectUpgrade(ctx, client, update.BinaryName, latestTag, latest, destPath); err != nil {
+		return err
+	}
+	saveUpgradeCacheForUpgrade(latest)
+	if *allFlag {
+		if err := upgradeCompanions(ctx, client, latestTag, latest, destPath); err != nil {
+			return err
+		}
+	}
+	return reportStaleWakesAfterUpgrade()
+}
+
+// runManagedUpgrade handles Homebrew/Scoop installs by printing the delegate
+// command and, with -y, running it. Companions are never package-managed, so
+// --all under a managed install is a no-op with an explanatory line.
+func runManagedUpgrade(kind update.InstallKind, yes, all bool) error {
+	argvs, remedy := delegateUpgradeCommand(kind)
+	if all {
+		if err := writeStdoutLine("--all: companions are direct-installed; upgrade them with 'amq upgrade --all' from a direct amq install."); err != nil {
+			return err
+		}
+	}
+	if yes {
+		for _, argv := range argvs {
+			if err := writeStdoutLine("Running:", strings.Join(argv, " ")); err != nil {
+				return err
+			}
+			if err := runDelegateForUpgrade(argv); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("%s", remedy)
+}
+
+// delegateUpgradeCommand returns the argv slices to run (no shell, so a future
+// dynamic value cannot inject) and the non-interactive remedy string for a
+// package-managed install kind. Homebrew runs `brew update` then
+// `brew upgrade amq`; Scoop runs `scoop update amq`.
+func delegateUpgradeCommand(kind update.InstallKind) ([][]string, string) {
+	switch kind {
+	case update.InstallHomebrew:
+		return [][]string{{"brew", "update"}, {"brew", "upgrade", "amq"}},
+			"amq is installed via Homebrew; run brew update && brew upgrade amq (or amq upgrade -y)"
+	case update.InstallScoop:
+		return [][]string{{"scoop", "update", "amq"}},
+			"amq is installed via Scoop; run scoop update amq (or amq upgrade -y)"
+	default:
+		return nil, ""
+	}
+}
+
+// runDelegateCommand runs a delegate argv (brew/scoop) directly — no shell —
+// with the caller's stdin/stdout/stderr and returns its exit status as an
+// error.
+func runDelegateCommand(argv []string) error {
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return WithExitCode(exitErr.ExitCode(), fmt.Errorf("delegate command failed: %s", strings.Join(argv, " ")))
+		}
+		return fmt.Errorf("delegate command failed: %w", err)
+	}
+	return nil
+}
+
+// extractBinaryFromArchive extracts the named binary from a release archive
+// into destDir. The zip flag selects the Windows zip reader over tar.gz.
+func extractBinaryFromArchive(binaryName, archivePath, destDir string, zip bool) (string, error) {
+	if zip {
+		return update.ExtractBinaryFromZipNamed(binaryName, archivePath, destDir)
+	}
+	return update.ExtractBinaryFromTarGzNamed(binaryName, archivePath, destDir)
+}
+
+// runDirectUpgrade downloads, verifies, extracts, and atomically replaces a
+// single binary at destPath. It is shared by the amq self-upgrade and the
+// per-companion --all loop.
+func runDirectUpgrade(ctx context.Context, client *http.Client, binaryName, latestTag, latest, destPath string) error {
+	assetName, err := update.AssetNameFor(binaryName, latestTag, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return err
 	}
@@ -94,11 +224,11 @@ func runUpgrade(args []string, currentVersion string) error {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	archivePath := filepath.Join(tmpDir, assetName)
-	if err := update.DownloadReleaseAsset(ctx, client, latestTag, assetName, archivePath); err != nil {
+	if err := downloadReleaseAssetForUpgrade(ctx, client, latestTag, assetName, archivePath); err != nil {
 		return err
 	}
 
-	checksums, err := update.FetchChecksums(ctx, client, latestTag)
+	checksums, err := fetchChecksumsForUpgrade(ctx, client, latestTag)
 	if err != nil {
 		return err
 	}
@@ -106,44 +236,108 @@ func runUpgrade(args []string, currentVersion string) error {
 	if !ok {
 		return fmt.Errorf("checksum entry not found for %s", assetName)
 	}
-	if err := update.VerifySHA256(archivePath, checksum); err != nil {
+	if err := updateVerifySHA256ForUpgrade(archivePath, checksum); err != nil {
 		return err
 	}
 
 	var binaryPath string
 	if runtime.GOOS == "windows" {
-		binaryPath, err = update.ExtractBinaryFromZip(archivePath, tmpDir)
+		binaryPath, err = extractBinaryForUpgrade(binaryName, archivePath, tmpDir, true)
 	} else {
-		binaryPath, err = update.ExtractBinaryFromTarGz(archivePath, tmpDir)
+		binaryPath, err = extractBinaryForUpgrade(binaryName, archivePath, tmpDir, false)
 	}
 	if err != nil {
 		return err
 	}
 
-	scheduled, err := update.ReplaceBinary(binaryPath, destPath)
+	scheduled, err := replaceBinaryForUpgrade(binaryPath, destPath)
 	if err != nil {
 		return err
 	}
-
-	if cachePath, err := update.DefaultCachePath(); err == nil {
-		_ = update.SaveCache(cachePath, &update.Cache{
-			CheckedAt:     time.Now().UTC(),
-			LatestVersion: latest,
-		})
-	}
-
 	if scheduled {
-		if err := writeStdoutLine("Upgrade scheduled; it will complete after this process exits."); err != nil {
-			return err
-		}
-		return reportStaleWakesAfterUpgrade()
+		return writeStdoutLine(binaryName + " upgrade scheduled; it will complete after this process exits.")
 	}
-	if err := writeStdoutLine("Upgrade complete."); err != nil {
-		return err
-	}
-	return reportStaleWakesAfterUpgrade()
+	return writeStdoutLine(binaryName + " upgrade complete.")
 }
 
+// upgradeCompanions upgrades each companion binary (amq-keepalive,
+// amq-bridge, amq-acp) present next to the direct-install amq (destDir) or in
+// ~/.local/bin. Missing companions are skipped with a line. A running
+// amq-keepalive is never killed: the atomic rename swaps the path while the
+// running process keeps the old inode, and the remedy to restart the
+// supervisor is printed afterward.
+func upgradeCompanions(ctx context.Context, client *http.Client, latestTag, latest, amqDest string) error {
+	searchDirs := companionSearchDirs(amqDest)
+	for _, name := range companionBinariesForUpgrade {
+		dest, found := findCompanion(name, searchDirs)
+		if !found {
+			if err := writeStdoutLine(name + " not found; skipping."); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := runDirectUpgrade(ctx, client, name, latestTag, latest, dest); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+		if name == "amq-keepalive" {
+			if err := writeStdoutLine("amq-keepalive: a running supervisor picks up the new image on its next supervise pass (self-upgrade); if it was started with --no-self-upgrade, restart it with 'amq-keepalive install-launchd'."); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// companionSearchDirs returns the directories to look for companions in, in
+// priority order: the directory holding the direct-install amq, then
+// ~/.local/bin (the documented companion home).
+func companionSearchDirs(amqDest string) []string {
+	dirs := make([]string, 0, 2)
+	if amqDest != "" {
+		if dir := filepath.Dir(amqDest); dir != "" {
+			dirs = append(dirs, dir)
+		}
+	}
+	if home, err := homeDirForUpgrade(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
+	}
+	return dirs
+}
+
+// findCompanion returns the first existing companion path across the search
+// dirs, resolving a symlink to its real target so ReplaceBinary writes the
+// backing file (preserving the operator's link structure) rather than
+// replacing the link itself. A regular file is returned as-is. Returns "",
+// false if absent everywhere.
+func findCompanion(name string, dirs []string) (string, bool) {
+	for _, dir := range dirs {
+		candidate := filepath.Join(dir, name)
+		if runtime.GOOS == "windows" {
+			candidate += ".exe"
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		// Resolve only an actual symlink to its target; a regular file is
+		// returned as-is so its path stays comparable for callers.
+		if li, err := os.Lstat(candidate); err == nil && li.Mode()&os.ModeSymlink != 0 {
+			if resolved, err := filepath.EvalSymlinks(candidate); err == nil {
+				return resolved, true
+			}
+		}
+		return candidate, true
+	}
+	return "", false
+}
+
+// selectUpgradeDestination resolves the write target for a direct install.
+// It is only reached after the install classifier has already delegated
+// Homebrew/Scoop installs, so it does not re-check for a normal Homebrew
+// path. It does keep one guard the classifier cannot express: a severed
+// Homebrew binary — a regular file sitting at <prefix>/bin/amq where brew
+// expects a symlink — which means someone overwrote the brew-managed path
+// and must reinstall rather than self-replace into the corruption.
 func selectUpgradeDestination(path, resolved string, writable func(string) error) (string, error) {
 	destPath := resolved
 	if destPath == "" {
@@ -154,12 +348,8 @@ func selectUpgradeDestination(path, resolved string, writable func(string) error
 	}
 	destPath = filepath.Clean(destPath)
 
-	if prefix := detectHomebrewPrefixForUpgrade(); prefix != "" &&
-		(homebrewOwnsUpgradePath(prefix, path) || homebrewOwnsUpgradePath(prefix, destPath)) {
-		if isSeveredHomebrewBinary(prefix, path) {
-			return "", fmt.Errorf("amq is installed via Homebrew; run brew reinstall amq")
-		}
-		return "", fmt.Errorf("amq is installed via Homebrew; run brew update && brew upgrade amq")
+	if prefix := detectHomebrewPrefixForUpgrade(); prefix != "" && isSeveredHomebrewBinary(prefix, path) {
+		return "", fmt.Errorf("amq is installed via Homebrew; run brew reinstall amq")
 	}
 	if err := writable(destPath); err != nil {
 		return "", fmt.Errorf("cannot write the amq install location %s: %w", destPath, err)
@@ -186,6 +376,14 @@ func detectHomebrewPrefix() string {
 	for _, prefix := range wellKnownHomebrewPrefixes {
 		if homebrewBrewExistsForUpgrade(filepath.Join(prefix, "bin", "brew")) {
 			return filepath.Clean(prefix)
+		}
+	}
+	// User-local Linuxbrew installs under ~/.linuxbrew (not a fixed absolute
+	// path, so it is checked separately from the well-known prefix list).
+	if home, err := homeDirForUpgrade(); err == nil {
+		userLinuxbrew := filepath.Join(home, ".linuxbrew")
+		if homebrewBrewExistsForUpgrade(filepath.Join(userLinuxbrew, "bin", "brew")) {
+			return userLinuxbrew
 		}
 	}
 	return ""

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -183,9 +182,10 @@ func TestRunUpgradeDelegatesHomebrewInstall(t *testing.T) {
 	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
 	oldBrewExists := homebrewBrewExistsForUpgrade
 	homebrewBrewExistsForUpgrade = func(path string) bool {
-		return path == filepath.Join(canonicalHomebrewPrefix(filepath.Join(base, "homebrew")), "bin", "brew")
+		return update.CanonicalPath(path) == filepath.Join(canonicalHomebrewPrefix(filepath.Join(base, "homebrew")), "bin", "brew")
 	}
 	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
+	stubHomebrewPrefixProbe(t, filepath.Join(base, "homebrew"))
 	// The classifier is authoritative: a Homebrew install delegates to brew,
 	// so the /private symlink-resolution mismatch in the temp fixture does
 	// not change the outcome.
@@ -203,7 +203,8 @@ func TestRunUpgradeDelegatesHomebrewInstall(t *testing.T) {
 	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetchLatestTag })
 
 	err = runUpgrade(nil, "v0.0.0")
-	const want = "amq is installed via Homebrew; run brew update && brew upgrade amq (or amq upgrade -y)"
+	manager := filepath.Join(base, "homebrew", "bin", "brew")
+	want := "amq is installed via Homebrew; run " + manager + " update && " + manager + " upgrade amq (or amq upgrade -y)"
 	if err == nil || err.Error() != want {
 		t.Fatalf("runUpgrade error = %v, want %q", err, want)
 	}
@@ -216,6 +217,82 @@ func TestRunUpgradeDelegatesHomebrewInstall(t *testing.T) {
 	}
 	if fetchCalls != 0 {
 		t.Fatalf("release lookups = %d, want 0 before Homebrew delegate", fetchCalls)
+	}
+}
+
+func TestRunUpgradeRefusesHomebrewManagerWithWrongPrefix(t *testing.T) {
+	prefix := t.TempDir()
+	wrongPrefix := t.TempDir()
+	cellarBinary := filepath.Join(prefix, "Cellar", "amq", "0.74.0", "bin", "amq")
+	manager := filepath.Join(prefix, "bin", "brew")
+	if err := os.MkdirAll(filepath.Dir(cellarBinary), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cellarBinary, []byte("homebrew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) {
+		return cellarBinary, cellarBinary, nil
+	}
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
+		return []homebrewInstallation{{prefix: prefix, executable: manager}}
+	}
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldBrewExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return update.CanonicalPath(path) == update.CanonicalPath(manager)
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
+	oldProbe := runBrewPrefixForHomebrewUpgrade
+	runBrewPrefixForHomebrewUpgrade = func(ctx context.Context, path string) ([]byte, error) {
+		if path != manager {
+			t.Fatalf("brew probe path = %q, want %q", path, manager)
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("brew --prefix probe is not bounded")
+		}
+		return []byte(wrongPrefix + "\n"), nil
+	}
+	t.Cleanup(func() { runBrewPrefixForHomebrewUpgrade = oldProbe })
+
+	err := runUpgrade(nil, "v0.0.0")
+	want := "amq is installed in a Homebrew Cellar at " + cellarBinary + ", but " + manager + " does not report prefix " + canonicalHomebrewPrefix(prefix)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("runUpgrade error = %v, want %q", err, want)
+	}
+}
+
+func TestHomebrewBrewExistsRequiresRegularExecutable(t *testing.T) {
+	dir := t.TempDir()
+	directory := filepath.Join(dir, "directory-brew")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if homebrewBrewExists(directory) {
+		t.Fatal("homebrewBrewExists accepted a directory")
+	}
+
+	nonExecutable := filepath.Join(dir, "non-executable-brew")
+	if err := os.WriteFile(nonExecutable, []byte("brew"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if homebrewBrewExists(nonExecutable) {
+		t.Fatal("homebrewBrewExists accepted a non-executable regular file")
+	}
+
+	executable := filepath.Join(dir, "brew")
+	if err := os.WriteFile(executable, []byte("brew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !homebrewBrewExists(executable) {
+		t.Fatal("homebrewBrewExists rejected an executable regular file")
 	}
 }
 
@@ -754,6 +831,24 @@ func stubExpectedCompanionBuildInfo(t *testing.T) {
 	t.Cleanup(func() { readBuildInfoForUpgrade = oldReadBuildInfo })
 }
 
+func stubHomebrewPrefixProbe(t *testing.T, prefixes ...string) {
+	t.Helper()
+	oldProbe := runBrewPrefixForHomebrewUpgrade
+	want := make(map[string]string, len(prefixes))
+	for _, prefix := range prefixes {
+		prefix := canonicalHomebrewPrefix(prefix)
+		manager := filepath.Join(prefix, "bin", "brew")
+		want[manager] = prefix
+	}
+	runBrewPrefixForHomebrewUpgrade = func(_ context.Context, path string) ([]byte, error) {
+		if prefix, ok := want[update.CanonicalPath(path)]; ok {
+			return []byte(prefix + "\n"), nil
+		}
+		return nil, errors.New("unexpected Homebrew manager probe")
+	}
+	t.Cleanup(func() { runBrewPrefixForHomebrewUpgrade = oldProbe })
+}
+
 func TestRunUpgradeDirectInstallReplacesBinary(t *testing.T) {
 	bin := filepath.Join(t.TempDir(), "amq")
 	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
@@ -856,6 +951,71 @@ func TestRunUpgradeScheduledSkipsVersionCache(t *testing.T) {
 	}
 }
 
+func TestRunUpgradeScheduledCacheRepairsOnNextRun(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv(update.EnvCacheDir, cacheDir)
+	cachePath, err := update.DefaultCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := update.SaveCache(cachePath, &update.Cache{
+		CheckedAt:     time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
+		LatestVersion: "v9.9.9",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	stubUpgradeNetwork(t)
+	oldReplace := replaceBinaryForUpgrade
+	replaceCalls := 0
+	replaceBinaryForUpgrade = func(_, _ string) (bool, error) {
+		replaceCalls++
+		return replaceCalls == 1, nil
+	}
+	t.Cleanup(func() { replaceBinaryForUpgrade = oldReplace })
+	oldSave := saveUpgradeCacheForUpgrade
+	saveUpgradeCacheForUpgrade = saveUpgradeCache
+	t.Cleanup(func() { saveUpgradeCacheForUpgrade = oldSave })
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "dev") }); err != nil {
+		t.Fatalf("scheduled runUpgrade: %v", err)
+	}
+	first, err := update.LoadCache(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == nil || first.LatestVersion != "v9.9.9" {
+		t.Fatalf("cache after scheduled replacement = %#v, want stale value preserved", first)
+	}
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "v0.0.0-test") }); err != nil {
+		t.Fatalf("already-current runUpgrade: %v", err)
+	}
+	second, err := update.LoadCache(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second == nil || second.LatestVersion != "v0.0.0-test" {
+		t.Fatalf("cache after next run = %#v, want repaired latest version", second)
+	}
+	if replaceCalls != 1 {
+		t.Fatalf("replacement calls = %d, want only the scheduled first attempt", replaceCalls)
+	}
+}
+
 func TestFindCompanionRejectsSymlinkToAMQ(t *testing.T) {
 	dir := t.TempDir()
 	amqDest := filepath.Join(dir, "amq")
@@ -904,7 +1064,7 @@ func TestFindCompanionRejectsBrokenSymlink(t *testing.T) {
 func TestFindCompanionRejectsNonRegularFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "amq-keepalive")
-	if err := syscall.Mkfifo(path, 0o600); err != nil {
+	if err := os.Mkdir(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	_, err := findCompanionMatches("amq-keepalive", []string{dir}, "", nil, "")
@@ -1009,6 +1169,72 @@ func TestUpgradeCompanionsRejectsCrossCompanionAlias(t *testing.T) {
 	}
 }
 
+func TestUpgradeCompanionsRejectsSameNameHardlinks(t *testing.T) {
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	amqDest := filepath.Join(firstDir, "amq")
+	first := filepath.Join(firstDir, "amq-keepalive")
+	second := filepath.Join(secondDir, "amq-keepalive")
+	for _, path := range []string{amqDest, first} {
+		if err := os.WriteFile(path, []byte(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Link(first, second); err != nil {
+		t.Fatal(err)
+	}
+	_, err := findCompanionMatches("amq-keepalive", []string{firstDir, secondDir}, amqDest, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "hardlinks") ||
+		!strings.Contains(err.Error(), first) || !strings.Contains(err.Error(), second) {
+		t.Fatalf("findCompanionMatches error = %v, want same-name hardlink refusal", err)
+	}
+}
+
+func TestUpgradeCompanionsRevalidatesTargetsBeforeReplacement(t *testing.T) {
+	stubExpectedCompanionBuildInfo(t)
+	binDir := t.TempDir()
+	amqDest := filepath.Join(binDir, "amq")
+	first := filepath.Join(binDir, "amq-keepalive")
+	second := filepath.Join(binDir, "amq-bridge")
+	for _, path := range []string{amqDest, first, second} {
+		if err := os.WriteFile(path, []byte(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fakeHome := t.TempDir()
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return fakeHome, nil }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+	oldCompanions := companionBinariesForUpgrade
+	companionBinariesForUpgrade = []string{"amq-keepalive", "amq-bridge"}
+	t.Cleanup(func() { companionBinariesForUpgrade = oldCompanions })
+	replaced := stubUpgradeNetwork(t)
+	oldChecksums := fetchChecksumsForUpgrade
+	checksumCalls := 0
+	fetchChecksumsForUpgrade = func(ctx context.Context, client *http.Client, tag string) (map[string]string, error) {
+		checksumCalls++
+		if checksumCalls == 2 {
+			drift := first + ".drift"
+			if err := os.WriteFile(drift, []byte("different occupant"), 0o755); err != nil {
+				return nil, err
+			}
+			if err := os.Rename(drift, first); err != nil {
+				return nil, err
+			}
+		}
+		return oldChecksums(ctx, client, tag)
+	}
+	t.Cleanup(func() { fetchChecksumsForUpgrade = oldChecksums })
+
+	err := upgradeCompanionsWithProtection(context.Background(), nil, "v0.0.0-test", "v0.0.0-test", amqDest, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "changed while preparing") || !strings.Contains(err.Error(), first) {
+		t.Fatalf("upgradeCompanions error = %v, want post-download target drift refusal", err)
+	}
+	if len(*replaced) != 0 {
+		t.Fatalf("replacements = %#v, want none after target drift", *replaced)
+	}
+}
+
 func TestFindCompanionRejectsNonGoBinary(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "amq-keepalive")
@@ -1074,9 +1300,10 @@ func TestRunUpgradeClassifiesAgainstAllHomebrewPrefixes(t *testing.T) {
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 	oldBrewExists := homebrewBrewExistsForUpgrade
 	homebrewBrewExistsForUpgrade = func(path string) bool {
-		return path == filepath.Join(canonicalHomebrewPrefix(second), "bin", "brew")
+		return update.CanonicalPath(path) == filepath.Join(canonicalHomebrewPrefix(second), "bin", "brew")
 	}
 	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
+	stubHomebrewPrefixProbe(t, second)
 	oldDelegate := runDelegateForUpgrade
 	var ran []string
 	runDelegateForUpgrade = func(argv []string) error { ran = append(ran, strings.Join(argv, " ")); return nil }
@@ -1151,6 +1378,12 @@ func TestRunUpgradeHomebrewDelegatesWithYes(t *testing.T) {
 		return []homebrewInstallation{{prefix: prefix, executable: filepath.Join(prefix, "bin", "brew")}}
 	}
 	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
+	oldBrewExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return update.CanonicalPath(path) == filepath.Join(canonicalHomebrewPrefix(prefix), "bin", "brew")
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
+	stubHomebrewPrefixProbe(t, prefix)
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return "" }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
@@ -1223,9 +1456,10 @@ func TestRunUpgradeClassifiesUserSymlinkToHomebrew(t *testing.T) {
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 	oldBrewExists := homebrewBrewExistsForUpgrade
 	homebrewBrewExistsForUpgrade = func(path string) bool {
-		return path == filepath.Join(canonicalHomebrewPrefix(prefix), "bin", "brew")
+		return update.CanonicalPath(path) == filepath.Join(canonicalHomebrewPrefix(prefix), "bin", "brew")
 	}
 	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
+	stubHomebrewPrefixProbe(t, prefix)
 	oldInstallations := detectHomebrewInstallationsForUpgrade
 	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
 		return []homebrewInstallation{{prefix: prefix, executable: filepath.Join(prefix, "bin", "brew")}}
@@ -1309,7 +1543,7 @@ func TestRunUpgradeAllReplacesPresentCompanionsSkipsMissing(t *testing.T) {
 	if !strings.Contains(stdout, "amq-acp not found; skipping.") {
 		t.Fatalf("output missing amq-acp skip line:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "amq-keepalive: a running supervisor picks up the new image") {
+	if !strings.Contains(stdout, "amq-keepalive: a running supervisor picks up a strictly newer image") {
 		t.Fatalf("output missing keepalive self-upgrade remedy:\n%s", stdout)
 	}
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -946,7 +946,7 @@ func TestRunUpgradeScheduledSkipsVersionCache(t *testing.T) {
 	if cacheWrites != 0 {
 		t.Fatalf("scheduled replacement wrote version cache %d times", cacheWrites)
 	}
-	if !strings.Contains(stdout, "replacement scheduled; version cache updates on next run") {
+	if !strings.Contains(stdout, "replacement scheduled; version cache is refreshed on the next successful check (best-effort)") {
 		t.Fatalf("scheduled output missing cache timing: %s", stdout)
 	}
 }
@@ -1609,5 +1609,99 @@ func TestRunUpgradeAllReplacesSymlinkedCompanionAtTarget(t *testing.T) {
 	// The link still resolves to the target (structure preserved).
 	if resolved, err := filepath.EvalSymlinks(keepaliveLink); err != nil || resolved != canonicalTarget {
 		t.Fatalf("link %q no longer resolves to %q (got %q, err=%v)", keepaliveLink, canonicalTarget, resolved, err)
+	}
+}
+
+func TestDelegateUpgradeCommandWithManagerScoopGlobal(t *testing.T) {
+	commands, remedy := delegateUpgradeCommandWithManager(update.InstallScoopGlobal, "scoop")
+	if len(commands) != 1 || strings.Join(commands[0], " ") != "scoop update -g amq" {
+		t.Fatalf("global Scoop commands = %#v, want [scoop update -g amq]", commands)
+	}
+	if !strings.Contains(remedy, "Scoop (global scope)") || !strings.Contains(remedy, "scoop update -g amq") {
+		t.Fatalf("global Scoop remedy = %q", remedy)
+	}
+}
+
+func TestRefusePackageManagedDestinationScoopGlobal(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "scoop", "apps")
+	dest := filepath.Join(root, "amq", "current", "amq.exe")
+	err := refusePackageManagedDestinationWithScoopRoots(
+		dest,
+		nil,
+		[]update.ScoopInstallRoot{
+			{Path: root, Scope: update.ScoopScopeUser},
+			{Path: root, Scope: update.ScoopScopeGlobal},
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "Scoop (global scope)") || !strings.Contains(err.Error(), "scoop update -g amq") {
+		t.Fatalf("global Scoop guard error = %v", err)
+	}
+}
+
+func TestCompanionSearchDirsIncludesRawAndResolvedDirectories(t *testing.T) {
+	rawDir := t.TempDir()
+	resolvedDir := t.TempDir()
+	aliasParent := t.TempDir()
+	rawAlias := filepath.Join(aliasParent, "raw")
+	if err := os.Symlink(rawDir, rawAlias); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return home, nil }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+
+	dirs, err := companionSearchDirsForUpgrade(
+		filepath.Join(rawAlias, "amq"),
+		filepath.Join(resolvedDir, "amq"),
+	)
+	if err != nil {
+		t.Fatalf("companionSearchDirsForUpgrade: %v", err)
+	}
+	want := []string{rawAlias, resolvedDir, filepath.Join(home, ".local", "bin")}
+	if len(dirs) != len(want) {
+		t.Fatalf("companion search dirs = %#v, want %#v", dirs, want)
+	}
+	for index := range want {
+		if dirs[index] != want[index] {
+			t.Fatalf("companion search dirs[%d] = %q, want %q", index, dirs[index], want[index])
+		}
+	}
+	seen := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
+		canonical := update.CanonicalPath(dir)
+		if _, ok := seen[canonical]; ok {
+			t.Fatalf("companion search dirs contain canonical duplicate: %#v", dirs)
+		}
+		seen[canonical] = struct{}{}
+	}
+}
+
+func TestUpgradeCompanionsWarnsWhenHomeDirectoryFails(t *testing.T) {
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return "", errors.New("home unavailable") }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+	oldCompanions := companionBinariesForUpgrade
+	companionBinariesForUpgrade = nil
+	t.Cleanup(func() { companionBinariesForUpgrade = oldCompanions })
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return upgradeCompanionsWithScoopRoots(
+			context.Background(),
+			nil,
+			"v0.0.0-test",
+			"v0.0.0-test",
+			"",
+			"",
+			nil,
+			nil,
+		)
+	})
+	if err != nil {
+		t.Fatalf("upgradeCompanionsWithScoopRoots: %v", err)
+	}
+	if !strings.Contains(stdout, "warning: cannot resolve user home directory for companion search") ||
+		!strings.Contains(stdout, "home unavailable") {
+		t.Fatalf("home lookup warning missing: %q", stdout)
 	}
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -3,18 +3,21 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/update"
 )
 
 func TestRunUpgradeAlreadyCurrentReportsStaleWakesWithInvalidAmbientAgent(t *testing.T) {
@@ -139,7 +142,7 @@ func TestUpgradeDiagnosticRootsIncludesValidUnderscoreSession(t *testing.T) {
 	}
 }
 
-func TestRunUpgradeRefusesHomebrewSymlinkBeforeDownload(t *testing.T) {
+func TestRunUpgradeDelegatesHomebrewInstall(t *testing.T) {
 	base := t.TempDir()
 	target := filepath.Join(base, "homebrew", "Cellar", "amq", "0.49.6", "bin", "amq")
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
@@ -169,6 +172,14 @@ func TestRunUpgradeRefusesHomebrewSymlinkBeforeDownload(t *testing.T) {
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return filepath.Join(base, "homebrew") }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	// The classifier is authoritative: a Homebrew install delegates to brew,
+	// so the /private symlink-resolution mismatch in the temp fixture does
+	// not change the outcome.
+	oldClassify := classifyInstallForUpgrade
+	classifyInstallForUpgrade = func(string, string) update.InstallKind {
+		return update.InstallHomebrew
+	}
+	t.Cleanup(func() { classifyInstallForUpgrade = oldClassify })
 	oldFetchLatestTag := fetchLatestTagForUpgrade
 	fetchCalls := 0
 	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
@@ -178,19 +189,19 @@ func TestRunUpgradeRefusesHomebrewSymlinkBeforeDownload(t *testing.T) {
 	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetchLatestTag })
 
 	err = runUpgrade(nil, "v0.0.0")
-	const want = "amq is installed via Homebrew; run brew update && brew upgrade amq"
+	const want = "amq is installed via Homebrew; run brew update && brew upgrade amq (or amq upgrade -y)"
 	if err == nil || err.Error() != want {
 		t.Fatalf("runUpgrade error = %v, want %q", err, want)
 	}
 	got, err := os.ReadFile(target)
 	if err != nil {
-		t.Fatalf("read Cellar binary after refusal: %v", err)
+		t.Fatalf("read Cellar binary after delegate: %v", err)
 	}
 	if string(got) != original {
 		t.Fatalf("Cellar binary mutated: got %q, want %q", got, original)
 	}
 	if fetchCalls != 0 {
-		t.Fatalf("release lookups = %d, want 0 before Homebrew refusal", fetchCalls)
+		t.Fatalf("release lookups = %d, want 0 before Homebrew delegate", fetchCalls)
 	}
 }
 
@@ -325,7 +336,7 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("dangling Cellar symlink refuses before resolution", func(t *testing.T) {
+	t.Run("dangling Cellar symlink is not refused here (classifier owns it)", func(t *testing.T) {
 		if err := os.Remove(binPath); err != nil {
 			t.Fatalf("remove regular prefix binary: %v", err)
 		}
@@ -334,13 +345,19 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 			t.Fatalf("create dangling Cellar symlink: %v", err)
 		}
 
-		_, err := selectUpgradeDestination(binPath, binPath, func(string) error { return nil })
-		if err == nil || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
-			t.Fatalf("selectUpgradeDestination error = %v, want update and upgrade remedy", err)
+		// selectUpgradeDestination only guards the severed-binary corruption;
+		// a Cellar symlink (healthy or dangling) is delegated by the
+		// classifier upstream, so this function returns the dest cleanly.
+		got, err := selectUpgradeDestination(binPath, binPath, func(string) error { return nil })
+		if err != nil {
+			t.Fatalf("selectUpgradeDestination error = %v, want no refusal (classifier owns Homebrew delegation)", err)
+		}
+		if got != binPath {
+			t.Fatalf("destination = %q, want %q", got, binPath)
 		}
 	})
 
-	t.Run("healthy Cellar symlink refuses", func(t *testing.T) {
+	t.Run("healthy Cellar symlink is not refused here (classifier owns it)", func(t *testing.T) {
 		if err := os.Remove(binPath); err != nil {
 			t.Fatalf("remove dangling symlink: %v", err)
 		}
@@ -348,9 +365,12 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 			t.Fatalf("create healthy Cellar symlink: %v", err)
 		}
 
-		_, err := selectUpgradeDestination(binPath, cellarPath, func(string) error { return nil })
-		if err == nil || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
-			t.Fatalf("selectUpgradeDestination error = %v, want update and upgrade remedy", err)
+		got, err := selectUpgradeDestination(binPath, cellarPath, func(string) error { return nil })
+		if err != nil {
+			t.Fatalf("selectUpgradeDestination error = %v, want no refusal (classifier owns Homebrew delegation)", err)
+		}
+		if got != cellarPath {
+			t.Fatalf("destination = %q, want %q", got, cellarPath)
 		}
 	})
 }
@@ -517,4 +537,380 @@ func TestHomebrewOwnsUpgradePathBinOrCellar(t *testing.T) {
 	if homebrewOwnsUpgradePath(prefix, "") {
 		t.Fatal("empty path treated as Homebrew-owned")
 	}
+}
+
+// stubUpgradeNetwork replaces the network-touching indirection vars with
+// in-memory fakes that succeed for any asset and return a fixed checksum. It
+// returns a cleanup func and a counter of how many binaries were replaced.
+func stubUpgradeNetwork(t *testing.T) (replaced *[]string) {
+	t.Helper()
+	replacedList := []string{}
+	replaced = &replacedList
+	oldDownload := downloadReleaseAssetForUpgrade
+	downloadReleaseAssetForUpgrade = func(_ context.Context, _ *http.Client, _, _, destPath string) error {
+		return os.WriteFile(destPath, []byte("archive"), 0o600)
+	}
+	t.Cleanup(func() { downloadReleaseAssetForUpgrade = oldDownload })
+	oldChecksums := fetchChecksumsForUpgrade
+	fetchChecksumsForUpgrade = func(context.Context, *http.Client, string) (map[string]string, error) {
+		// Return a checksum for every asset name the upgrade loop can request
+		// (amq + each companion) so the lookup always hits regardless of OS.
+		m := map[string]string{}
+		for _, name := range append([]string{update.BinaryName}, update.CompanionBinaries...) {
+			if asset, err := update.AssetNameFor(name, "v0.0.0-test", runtime.GOOS, runtime.GOARCH); err == nil {
+				m[asset] = "checksum"
+			}
+		}
+		return m, nil
+	}
+	t.Cleanup(func() { fetchChecksumsForUpgrade = oldChecksums })
+	oldVerify := updateVerifySHA256ForUpgrade
+	updateVerifySHA256ForUpgrade = func(string, string) error { return nil }
+	t.Cleanup(func() { updateVerifySHA256ForUpgrade = oldVerify })
+	oldExtract := extractBinaryForUpgrade
+	extractBinaryForUpgrade = func(name, _, destDir string, _ bool) (string, error) {
+		p := filepath.Join(destDir, name)
+		return p, os.WriteFile(p, []byte("new-"+name), 0o755)
+	}
+	t.Cleanup(func() { extractBinaryForUpgrade = oldExtract })
+	oldReplace := replaceBinaryForUpgrade
+	replaceBinaryForUpgrade = func(_, destPath string) (bool, error) {
+		replacedList = append(replacedList, destPath)
+		return false, nil
+	}
+	t.Cleanup(func() { replaceBinaryForUpgrade = oldReplace })
+	oldSaveCache := saveUpgradeCacheForUpgrade
+	saveUpgradeCacheForUpgrade = func(string) {}
+	t.Cleanup(func() { saveUpgradeCacheForUpgrade = oldSaveCache })
+	return replaced
+}
+
+func TestRunUpgradeDirectInstallReplacesBinary(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	replaced := stubUpgradeNetwork(t)
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runUpgrade(nil, "dev")
+	})
+	if err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if len(*replaced) != 1 || (*replaced)[0] != bin {
+		t.Fatalf("replaced = %#v, want [%s]", *replaced, bin)
+	}
+	if !strings.Contains(stdout, "Upgrading to v0.0.0-test") || !strings.Contains(stdout, "amq upgrade complete.") {
+		t.Fatalf("upgrade output missing expected lines:\n%s", stdout)
+	}
+}
+
+func TestRunUpgradeHomebrewDelegatesWithYes(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(bin, []byte("homebrew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldClassify := classifyInstallForUpgrade
+	classifyInstallForUpgrade = func(string, string) update.InstallKind { return update.InstallHomebrew }
+	t.Cleanup(func() { classifyInstallForUpgrade = oldClassify })
+	var delegateRan []string
+	oldDelegate := runDelegateForUpgrade
+	runDelegateForUpgrade = func(argv []string) error { delegateRan = append(delegateRan, strings.Join(argv, " ")); return nil }
+	t.Cleanup(func() { runDelegateForUpgrade = oldDelegate })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchCalls := 0
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		fetchCalls++
+		return "", errors.New("unexpected release lookup")
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runUpgrade([]string{"-y"}, "v0.0.0")
+	})
+	if err != nil {
+		t.Fatalf("runUpgrade -y: %v", err)
+	}
+	if len(delegateRan) != 2 || delegateRan[0] != "brew update" || delegateRan[1] != "brew upgrade amq" {
+		t.Fatalf("delegate ran %#v, want [brew update, brew upgrade amq]", delegateRan)
+	}
+	if fetchCalls != 0 {
+		t.Fatalf("release lookups = %d, want 0 for a delegated upgrade", fetchCalls)
+	}
+	if !strings.Contains(stdout, "Running:") {
+		t.Fatalf("output missing 'Running:' line:\n%s", stdout)
+	}
+	// The Homebrew binary is never overwritten by amq.
+	got, _ := os.ReadFile(bin)
+	if string(got) != "homebrew" {
+		t.Fatalf("homebrew binary mutated: %q", got)
+	}
+}
+
+// TestRunUpgradeClassifiesUserSymlinkToHomebrew covers Y2: a user-made
+// ~/bin/amq -> /opt/homebrew/bin/amq link must classify as Homebrew from the
+// pre-resolution path (the link itself sits in <prefix>/bin), so the upgrade
+// delegates to brew rather than self-replacing through the link.
+func TestRunUpgradeClassifiesUserSymlinkToHomebrew(t *testing.T) {
+	prefix := filepath.Join(t.TempDir(), "homebrew")
+	cellarTarget := filepath.Join(prefix, "Cellar", "amq", "0.73.0", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(cellarTarget), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cellarTarget, []byte("homebrew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The pre-resolution path is a user bin link into the Cellar; the resolved
+	// path lands in the Cellar too. Either way it must delegate.
+	userBin := filepath.Join(prefix, "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(userBin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(cellarTarget, userBin); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(userBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return userBin, resolved, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return prefix }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	var delegateRan []string
+	oldDelegate := runDelegateForUpgrade
+	runDelegateForUpgrade = func(argv []string) error { delegateRan = append(delegateRan, strings.Join(argv, " ")); return nil }
+	t.Cleanup(func() { runDelegateForUpgrade = oldDelegate })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		return "", errors.New("unexpected release lookup")
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade([]string{"-y"}, "dev") }); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if len(delegateRan) != 2 || delegateRan[0] != "brew update" || delegateRan[1] != "brew upgrade amq" {
+		t.Fatalf("delegate ran %#v, want [brew update, brew upgrade amq]", delegateRan)
+	}
+}
+
+func TestRunUpgradeAllReplacesPresentCompanionsSkipsMissing(t *testing.T) {
+	binDir := t.TempDir()
+	amqBin := filepath.Join(binDir, "amq")
+	if err := os.WriteFile(amqBin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Two companions present next to amq; amq-acp absent.
+	keepalive := filepath.Join(binDir, "amq-keepalive")
+	bridge := filepath.Join(binDir, "amq-bridge")
+	for _, p := range []string{keepalive, bridge} {
+		if err := os.WriteFile(p, []byte("old"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return amqBin, amqBin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	// Isolate companion search from the operator's real ~/.local/bin.
+	fakeHome := t.TempDir()
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return fakeHome, nil }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	replaced := stubUpgradeNetwork(t)
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runUpgrade([]string{"--all"}, "dev")
+	})
+	if err != nil {
+		t.Fatalf("runUpgrade --all: %v", err)
+	}
+	// amq + keepalive + bridge replaced; amq-acp skipped.
+	want := map[string]bool{amqBin: false, keepalive: false, bridge: false}
+	for _, p := range *replaced {
+		if _, ok := want[p]; ok {
+			want[p] = true
+		}
+	}
+	for p, seen := range want {
+		if !seen {
+			t.Fatalf("companion %s not replaced; replaced=%#v", p, *replaced)
+		}
+	}
+	if !strings.Contains(stdout, "amq-acp not found; skipping.") {
+		t.Fatalf("output missing amq-acp skip line:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "amq-keepalive: a running supervisor picks up the new image") {
+		t.Fatalf("output missing keepalive self-upgrade remedy:\n%s", stdout)
+	}
+}
+
+// TestRunUpgradeAllReplacesSymlinkedCompanionAtTarget covers Y4: a symlinked
+// companion (~/.local/bin/amq-keepalive -> /stable/amq-keepalive) is upgraded
+// at its resolved TARGET, not by replacing the link, so the operator's link
+// structure survives and the backing file is the new image.
+func TestRunUpgradeAllReplacesSymlinkedCompanionAtTarget(t *testing.T) {
+	binDir := t.TempDir()
+	amqBin := filepath.Join(binDir, "amq")
+	if err := os.WriteFile(amqBin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A stable target the link points at.
+	stableDir := t.TempDir()
+	keepaliveTarget := filepath.Join(stableDir, "amq-keepalive")
+	if err := os.WriteFile(keepaliveTarget, []byte("old-keepalive"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The companion found next to amq is a symlink to the stable target.
+	keepaliveLink := filepath.Join(binDir, "amq-keepalive")
+	if err := os.Symlink(keepaliveTarget, keepaliveLink); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return amqBin, amqBin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	fakeHome := t.TempDir()
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return fakeHome, nil }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	replaced := stubUpgradeNetwork(t)
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade([]string{"--all"}, "dev") }); err != nil {
+		t.Fatalf("runUpgrade --all: %v", err)
+	}
+	// The resolved TARGET was replaced, not the link path. Canonicalize the
+	// target the way EvalSymlinks does so /var and /private/var agree on macOS.
+	canonicalTarget, err := filepath.EvalSymlinks(keepaliveTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundTarget := false
+	for _, p := range *replaced {
+		if p == canonicalTarget {
+			foundTarget = true
+		}
+		if p == keepaliveLink {
+			t.Fatalf("companion link path %q was replaced instead of its target", p)
+		}
+	}
+	if !foundTarget {
+		t.Fatalf("symlinked companion target %q not replaced; replaced=%#v", canonicalTarget, *replaced)
+	}
+	// The link still resolves to the target (structure preserved).
+	if resolved, err := filepath.EvalSymlinks(keepaliveLink); err != nil || resolved != canonicalTarget {
+		t.Fatalf("link %q no longer resolves to %q (got %q, err=%v)", keepaliveLink, canonicalTarget, resolved, err)
+	}
+}
+
+// TestUpgradeDoesNotTouchRealCacheWhenIsolated is the WP-646 sentinel for the
+// update cache: it pre-seeds the REAL cache path (the one DefaultCachePath
+// resolves to when AMQ_CACHE_DIR is unset) with a sentinel, then runs an
+// upgrade under the TestMain-isolated AMQ_CACHE_DIR, and asserts the real
+// sentinel is byte-identical afterward. This catches a regression where a
+// test path writes through to ~/Library/Caches/amq/update.json.
+func TestUpgradeDoesNotTouchRealCacheWhenIsolated(t *testing.T) {
+	// Resolve the REAL cache path by ignoring the TestMain override.
+	realCachePath := realDefaultCachePath(t)
+	if err := os.MkdirAll(filepath.Dir(realCachePath), 0o700); err != nil {
+		t.Fatalf("mkdir real cache dir: %v", err)
+	}
+	// Save any pre-existing real cache content so the test restores the
+	// developer's actual cache state rather than deleting it.
+	preExisting, _ := os.ReadFile(realCachePath)
+	sentinel := []byte(`{"checked_at":"2026-01-01T00:00:00Z","latest_version":"v0.0.0-sentinel"}`)
+	if err := os.WriteFile(realCachePath, sentinel, 0o600); err != nil {
+		t.Fatalf("seed sentinel cache: %v", err)
+	}
+	t.Cleanup(func() {
+		if len(preExisting) > 0 {
+			_ = os.WriteFile(realCachePath, preExisting, 0o600)
+		} else {
+			_ = os.Remove(realCachePath)
+		}
+	})
+
+	// Confirm the isolated cache dir is distinct from the real one (TestMain
+	// sets AMQ_CACHE_DIR); an upgrade must write only there.
+	isolatedPath, err := update.DefaultCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isolatedPath == realCachePath {
+		t.Fatalf("TestMain did not isolate the cache: isolated path == real path %s", realCachePath)
+	}
+
+	bin := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		return "v0.0.0-test", nil
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	stubUpgradeNetwork(t)
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "dev") }); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	after, err := os.ReadFile(realCachePath)
+	if err != nil {
+		t.Fatalf("read sentinel after upgrade: %v", err)
+	}
+	if !bytes.Equal(sentinel, after) {
+		t.Fatalf("real cache sentinel was mutated by upgrade: before=%s after=%s", sentinel, after)
+	}
+}
+
+// realDefaultCachePath computes DefaultCachePath as it would resolve in
+// production (AMQ_CACHE_DIR unset), restoring the override immediately so the
+// rest of the test runs under TestMain's isolated cache.
+func realDefaultCachePath(t *testing.T) string {
+	t.Helper()
+	saved := os.Getenv(update.EnvCacheDir)
+	_ = os.Unsetenv(update.EnvCacheDir)
+	path, err := update.DefaultCachePath()
+	if saved != "" {
+		_ = os.Setenv(update.EnvCacheDir, saved)
+	} else {
+		_ = os.Unsetenv(update.EnvCacheDir)
+	}
+	if err != nil {
+		t.Fatalf("resolve real cache path: %v", err)
+	}
+	return path
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -897,17 +897,25 @@ func TestUpgradeDoesNotTouchRealCacheWhenIsolated(t *testing.T) {
 }
 
 // realDefaultCachePath computes DefaultCachePath as it would resolve in
-// production (AMQ_CACHE_DIR unset), restoring the override immediately so the
-// rest of the test runs under TestMain's isolated cache.
+// production (AMQ_CACHE_DIR and XDG_CACHE_HOME unset, so os.UserCacheDir
+// returns the true platform default), restoring the overrides immediately so
+// the rest of the test runs under TestMain's isolated cache.
 func realDefaultCachePath(t *testing.T) string {
 	t.Helper()
-	saved := os.Getenv(update.EnvCacheDir)
+	savedCacheDir := os.Getenv(update.EnvCacheDir)
+	savedXDG := os.Getenv("XDG_CACHE_HOME")
 	_ = os.Unsetenv(update.EnvCacheDir)
+	_ = os.Unsetenv("XDG_CACHE_HOME")
 	path, err := update.DefaultCachePath()
-	if saved != "" {
-		_ = os.Setenv(update.EnvCacheDir, saved)
+	if savedCacheDir != "" {
+		_ = os.Setenv(update.EnvCacheDir, savedCacheDir)
 	} else {
 		_ = os.Unsetenv(update.EnvCacheDir)
+	}
+	if savedXDG != "" {
+		_ = os.Setenv("XDG_CACHE_HOME", savedXDG)
+	} else {
+		_ = os.Unsetenv("XDG_CACHE_HOME")
 	}
 	if err != nil {
 		t.Fatalf("resolve real cache path: %v", err)

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"context"
+	debugbuildinfo "debug/buildinfo"
 	"errors"
 	"net/http"
 	"os"
@@ -180,6 +181,11 @@ func TestRunUpgradeDelegatesHomebrewInstall(t *testing.T) {
 		}}
 	}
 	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
+	oldBrewExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return path == filepath.Join(canonicalHomebrewPrefix(filepath.Join(base, "homebrew")), "bin", "brew")
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
 	// The classifier is authoritative: a Homebrew install delegates to brew,
 	// so the /private symlink-resolution mismatch in the temp fixture does
 	// not change the outcome.
@@ -344,7 +350,7 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 		}
 
 		_, err := selectUpgradeDestinationWithRoots(binPath, binPath, func(string) error { return nil }, []string{prefix}, "")
-		if err == nil || !strings.Contains(err.Error(), "brew reinstall amq") || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
+		if err == nil || !strings.Contains(err.Error(), "brew reinstall amq (if Homebrew owns it)") || !strings.Contains(err.Error(), "move the binary to ~/.local/bin and rerun amq upgrade (if you installed it manually)") {
 			t.Fatalf("selectUpgradeDestination error = %v, want both Homebrew remedies", err)
 		}
 	})
@@ -390,14 +396,16 @@ func TestSelectUpgradeDestinationRequiresDetectedHomebrewOwnership(t *testing.T)
 		detectHomebrewPrefixForUpgrade = func() string { return "" }
 		t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 
-		for _, path := range []string{brewBinPath, brewCellarPath} {
-			got, err := selectUpgradeDestination(path, path, func(string) error { return nil })
-			if err != nil {
-				t.Fatalf("selectUpgradeDestination(%q): %v", path, err)
-			}
-			if got != path {
-				t.Fatalf("destination = %q, want %q", got, path)
-			}
+		got, err := selectUpgradeDestination(brewBinPath, brewBinPath, func(string) error { return nil })
+		if err != nil {
+			t.Fatalf("selectUpgradeDestination(%q): %v", brewBinPath, err)
+		}
+		if got != brewBinPath {
+			t.Fatalf("destination = %q, want %q", got, brewBinPath)
+		}
+		if _, err := selectUpgradeDestination(brewCellarPath, brewCellarPath, func(string) error { return nil }); err == nil ||
+			!strings.Contains(err.Error(), "amq lives in a Homebrew Cellar") {
+			t.Fatalf("selectUpgradeDestination(%q) error = %v, want executable-derived Homebrew refusal", brewCellarPath, err)
 		}
 	})
 
@@ -498,6 +506,9 @@ func TestDetectHomebrewPrefixForUpgradeFallsBackToExistingWellKnownBrew(t *testi
 		return path == filepath.Join(want, "bin", "brew")
 	}
 	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldExists })
+	oldCellarExists := homebrewCellarExistsForUpgrade
+	homebrewCellarExistsForUpgrade = func(string) bool { return false }
+	t.Cleanup(func() { homebrewCellarExistsForUpgrade = oldCellarExists })
 
 	if got := detectHomebrewPrefix(); got != want {
 		t.Fatalf("detectHomebrewPrefix() = %q, want %q", got, want)
@@ -525,10 +536,21 @@ func TestDetectHomebrewInstallationsCollectsAllCandidates(t *testing.T) {
 	oldHome := homeDirForUpgrade
 	homeDirForUpgrade = func() (string, error) { return fakeHome, nil }
 	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+	oldExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return path == filepath.Join("/usr/local", "bin", "brew")
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldExists })
+	oldCellarExists := homebrewCellarExistsForUpgrade
+	homebrewCellarExistsForUpgrade = func(path string) bool {
+		return path == filepath.Join("/home/linuxbrew/.linuxbrew", "Cellar") ||
+			path == filepath.Join(fakeHome, ".linuxbrew", "Cellar")
+	}
+	t.Cleanup(func() { homebrewCellarExistsForUpgrade = oldCellarExists })
 
 	installations := detectHomebrewInstallations()
 	prefixes := homebrewPrefixesFromInstallations(installations)
-	for _, want := range []string{envPrefix, probePrefix, "/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew", "/opt/linuxbrew/.linuxbrew", filepath.Join(fakeHome, ".linuxbrew")} {
+	for _, want := range []string{envPrefix, probePrefix, "/usr/local", "/home/linuxbrew/.linuxbrew", filepath.Join(fakeHome, ".linuxbrew")} {
 		found := false
 		canonicalWant := canonicalHomebrewPrefix(want)
 		for _, got := range prefixes {
@@ -541,10 +563,99 @@ func TestDetectHomebrewInstallationsCollectsAllCandidates(t *testing.T) {
 			t.Fatalf("detected Homebrew prefixes = %#v, missing %q", prefixes, want)
 		}
 	}
+	for _, unwanted := range []string{"/opt/homebrew", "/opt/linuxbrew/.linuxbrew"} {
+		if slices.Contains(prefixes, canonicalHomebrewPrefix(unwanted)) {
+			t.Fatalf("unevidenced Homebrew prefix %q was detected: %#v", unwanted, prefixes)
+		}
+	}
 	for _, installation := range installations {
 		if installation.prefix == canonicalHomebrewPrefix(probePrefix) && installation.executable != "/custom/bin/brew" {
 			t.Fatalf("probe installation executable = %q, want exact PATH executable", installation.executable)
 		}
+	}
+}
+
+func TestRunUpgradeDerivesUnknownHomebrewCellarPrefix(t *testing.T) {
+	const cellarBinary = "/srv/homebrew/Cellar/amq/0.74.0/bin/amq"
+	t.Setenv("HOMEBREW_PREFIX", "")
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return cellarBinary, cellarBinary, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation { return nil }
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldLookPath := lookPathForHomebrewUpgrade
+	lookPathForHomebrewUpgrade = func(string) (string, error) { return "", exec.ErrNotFound }
+	t.Cleanup(func() { lookPathForHomebrewUpgrade = oldLookPath })
+	oldBrewExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(string) bool { return false }
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchCalls := 0
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		fetchCalls++
+		return "v0.0.0-test", nil
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+
+	err := runUpgrade(nil, "dev")
+	want := "amq lives in a Homebrew Cellar at " + cellarBinary + " but no brew executable was found at /srv/homebrew/bin/brew; run /srv/homebrew/bin/brew upgrade amq from that installation, or reinstall amq under ~/.local/bin for direct upgrades"
+	if err == nil || err.Error() != want {
+		t.Fatalf("runUpgrade error = %v, want %q", err, want)
+	}
+	if fetchCalls != 0 {
+		t.Fatalf("release lookups = %d, want 0 before Homebrew prefix refusal", fetchCalls)
+	}
+}
+
+func TestDerivedRawHomebrewPrefixProtectsEvidencedBin(t *testing.T) {
+	prefix := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(prefix, "Cellar"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(prefix, "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("manual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	derived := derivedHomebrewPrefixes(path, path)
+	if len(derived) != 1 || canonicalHomebrewPrefix(derived[0].prefix) != canonicalHomebrewPrefix(prefix) {
+		t.Fatalf("derived prefixes = %#v, want %q", derived, prefix)
+	}
+	installations, err := addDerivedHomebrewInstallations(path, path, nil)
+	if err != nil {
+		t.Fatalf("addDerivedHomebrewInstallations: %v", err)
+	}
+	got := homebrewPrefixesFromInstallations(installations)
+	if len(got) != 1 || got[0] != canonicalHomebrewPrefix(prefix) {
+		t.Fatalf("derived installation prefixes = %#v, want [%q]", got, canonicalHomebrewPrefix(prefix))
+	}
+	err = refusePackageManagedDestination(path, got, "")
+	if err == nil || !strings.Contains(err.Error(), "brew reinstall amq (if Homebrew owns it)") ||
+		!strings.Contains(err.Error(), "move the binary to ~/.local/bin and rerun amq upgrade (if you installed it manually)") {
+		t.Fatalf("refusePackageManagedDestination error = %v, want both manual/Homebrew remedies", err)
+	}
+}
+
+func TestSkipUnavailableCompanionsOnWindows(t *testing.T) {
+	all := true
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return skipUnavailableCompanionsOnWindows(&all, "windows")
+	})
+	if err != nil {
+		t.Fatalf("skipUnavailableCompanionsOnWindows: %v", err)
+	}
+	if all {
+		t.Fatal("--all remained enabled on Windows")
+	}
+	if stdout != "--all: companion binaries are not published for Windows; skipping\n" {
+		t.Fatalf("stdout = %q, want exact Windows skip line", stdout)
 	}
 }
 
@@ -631,6 +742,16 @@ func stubUpgradeNetwork(t *testing.T) (replaced *[]string) {
 	saveUpgradeCacheForUpgrade = func(string) {}
 	t.Cleanup(func() { saveUpgradeCacheForUpgrade = oldSaveCache })
 	return replaced
+}
+
+func stubExpectedCompanionBuildInfo(t *testing.T) {
+	t.Helper()
+	oldReadBuildInfo := readBuildInfoForUpgrade
+	readBuildInfoForUpgrade = func(path string) (*debugbuildinfo.BuildInfo, error) {
+		name := strings.TrimSuffix(filepath.Base(path), ".exe")
+		return &debugbuildinfo.BuildInfo{Path: update.ModulePath + "/cmd/" + name}, nil
+	}
+	t.Cleanup(func() { readBuildInfoForUpgrade = oldReadBuildInfo })
 }
 
 func TestRunUpgradeDirectInstallReplacesBinary(t *testing.T) {
@@ -793,6 +914,7 @@ func TestFindCompanionRejectsNonRegularFile(t *testing.T) {
 }
 
 func TestUpgradeCompanionsRejectsDistinctDuplicateTargets(t *testing.T) {
+	stubExpectedCompanionBuildInfo(t)
 	firstDir := t.TempDir()
 	secondHome := t.TempDir()
 	secondDir := filepath.Join(secondHome, ".local", "bin")
@@ -824,6 +946,108 @@ func TestUpgradeCompanionsRejectsDistinctDuplicateTargets(t *testing.T) {
 	}
 }
 
+func TestUpgradeCompanionsPlansEveryTargetBeforeReplacement(t *testing.T) {
+	binDir := t.TempDir()
+	amqDest := filepath.Join(binDir, "amq")
+	keepalive := filepath.Join(binDir, "amq-keepalive")
+	bridge := filepath.Join(binDir, "amq-bridge")
+	for _, path := range []string{amqDest, keepalive, bridge} {
+		if err := os.WriteFile(path, []byte(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldCompanions := companionBinariesForUpgrade
+	companionBinariesForUpgrade = []string{"amq-keepalive", "amq-bridge"}
+	t.Cleanup(func() { companionBinariesForUpgrade = oldCompanions })
+	oldReadBuildInfo := readBuildInfoForUpgrade
+	readBuildInfoForUpgrade = func(path string) (*debugbuildinfo.BuildInfo, error) {
+		name := strings.TrimSuffix(filepath.Base(path), ".exe")
+		if name == "amq-bridge" {
+			return &debugbuildinfo.BuildInfo{Path: update.ModulePath + "/cmd/amq"}, nil
+		}
+		return &debugbuildinfo.BuildInfo{Path: update.ModulePath + "/cmd/" + name}, nil
+	}
+	t.Cleanup(func() { readBuildInfoForUpgrade = oldReadBuildInfo })
+	replaced := stubUpgradeNetwork(t)
+
+	err := upgradeCompanionsWithProtection(context.Background(), nil, "v0.0.0-test", "v0.0.0-test", amqDest, nil, "")
+	if err == nil || !strings.Contains(err.Error(), bridge+" is not an amq-bridge build (found "+update.ModulePath+"/cmd/amq); remove or repoint it") {
+		t.Fatalf("upgradeCompanions error = %v, want unrelated Go build refusal", err)
+	}
+	if len(*replaced) != 0 {
+		t.Fatalf("replacements = %#v, want none when a later target fails verification", *replaced)
+	}
+	_ = keepalive
+}
+
+func TestUpgradeCompanionsRejectsCrossCompanionAlias(t *testing.T) {
+	binDir := t.TempDir()
+	amqDest := filepath.Join(binDir, "amq")
+	target := filepath.Join(t.TempDir(), "amq-keepalive")
+	for _, path := range []string{amqDest, target} {
+		if err := os.WriteFile(path, []byte(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"amq-keepalive", "amq-bridge"} {
+		if err := os.Symlink(target, filepath.Join(binDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldCompanions := companionBinariesForUpgrade
+	companionBinariesForUpgrade = []string{"amq-keepalive", "amq-bridge"}
+	t.Cleanup(func() { companionBinariesForUpgrade = oldCompanions })
+	stubExpectedCompanionBuildInfo(t)
+	replaced := stubUpgradeNetwork(t)
+
+	err := upgradeCompanionsWithProtection(context.Background(), nil, "v0.0.0-test", "v0.0.0-test", amqDest, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "repoint "+filepath.Join(binDir, "amq-bridge")+" to a dedicated amq-bridge binary or remove it") {
+		t.Fatalf("upgradeCompanions error = %v, want cross-companion alias refusal", err)
+	}
+	if len(*replaced) != 0 {
+		t.Fatalf("replacements = %#v, want none for cross-companion alias", *replaced)
+	}
+}
+
+func TestFindCompanionRejectsNonGoBinary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "amq-keepalive")
+	if err := os.WriteFile(path, []byte("not a Go binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := findCompanionMatches("amq-keepalive", []string{dir}, "", nil, "")
+	if err == nil || !strings.Contains(err.Error(), path+" is not an amq-keepalive build (found non-Go binary); remove or repoint it") {
+		t.Fatalf("findCompanionMatches error = %v, want non-Go build refusal", err)
+	}
+}
+
+func TestVerifyCompanionBuildUsesModulePath(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+	binary := filepath.Join(t.TempDir(), "amq-acp")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/amq-acp")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cmd/amq-acp: %v\n%s", err, output)
+	}
+
+	oldReadBuildInfo := readBuildInfoForUpgrade
+	readBuildInfoForUpgrade = debugbuildinfo.ReadFile
+	t.Cleanup(func() { readBuildInfoForUpgrade = oldReadBuildInfo })
+
+	item := companionTarget{name: "amq-acp", target: binary}
+	if err := verifyCompanionBuild(item); err != nil {
+		t.Fatalf("verifyCompanionBuild(%s): %v", item.name, err)
+	}
+	item.name = "amq-bridge"
+	if err := verifyCompanionBuild(item); err == nil || !strings.Contains(err.Error(), "found "+update.ModulePath+"/cmd/amq-acp") {
+		t.Fatalf("verifyCompanionBuild(%s) = %v, want module-path mismatch", item.name, err)
+	}
+}
+
 func TestRunUpgradeClassifiesAgainstAllHomebrewPrefixes(t *testing.T) {
 	first := t.TempDir()
 	second := t.TempDir()
@@ -848,6 +1072,11 @@ func TestRunUpgradeClassifiesAgainstAllHomebrewPrefixes(t *testing.T) {
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return "" }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldBrewExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return path == filepath.Join(canonicalHomebrewPrefix(second), "bin", "brew")
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
 	oldDelegate := runDelegateForUpgrade
 	var ran []string
 	runDelegateForUpgrade = func(argv []string) error { ran = append(ran, strings.Join(argv, " ")); return nil }
@@ -992,6 +1221,11 @@ func TestRunUpgradeClassifiesUserSymlinkToHomebrew(t *testing.T) {
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return prefix }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldBrewExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return path == filepath.Join(canonicalHomebrewPrefix(prefix), "bin", "brew")
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldBrewExists })
 	oldInstallations := detectHomebrewInstallationsForUpgrade
 	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
 		return []homebrewInstallation{{prefix: prefix, executable: filepath.Join(prefix, "bin", "brew")}}
@@ -1017,6 +1251,7 @@ func TestRunUpgradeClassifiesUserSymlinkToHomebrew(t *testing.T) {
 }
 
 func TestRunUpgradeAllReplacesPresentCompanionsSkipsMissing(t *testing.T) {
+	stubExpectedCompanionBuildInfo(t)
 	binDir := t.TempDir()
 	amqBin := filepath.Join(binDir, "amq")
 	if err := os.WriteFile(amqBin, []byte("old"), 0o755); err != nil {
@@ -1084,6 +1319,7 @@ func TestRunUpgradeAllReplacesPresentCompanionsSkipsMissing(t *testing.T) {
 // at its resolved TARGET, not by replacing the link, so the operator's link
 // structure survives and the backing file is the new image.
 func TestRunUpgradeAllReplacesSymlinkedCompanionAtTarget(t *testing.T) {
+	stubExpectedCompanionBuildInfo(t)
 	binDir := t.TempDir()
 	amqBin := filepath.Join(binDir, "amq")
 	if err := os.WriteFile(amqBin, []byte("old"), 0o755); err != nil {

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -3,7 +3,6 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -172,6 +172,14 @@ func TestRunUpgradeDelegatesHomebrewInstall(t *testing.T) {
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return filepath.Join(base, "homebrew") }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
+		return []homebrewInstallation{{
+			prefix:     filepath.Join(base, "homebrew"),
+			executable: filepath.Join(base, "homebrew", "bin", "brew"),
+		}}
+	}
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
 	// The classifier is authoritative: a Homebrew install delegates to brew,
 	// so the /private symlink-resolution mismatch in the temp fixture does
 	// not change the outcome.
@@ -324,19 +332,24 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return prefix }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
+		return []homebrewInstallation{{prefix: prefix, executable: filepath.Join(prefix, "bin", "brew")}}
+	}
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
 
 	t.Run("severed regular prefix binary recommends reinstall", func(t *testing.T) {
 		if err := os.WriteFile(binPath, []byte("self-upgraded"), 0o755); err != nil {
 			t.Fatalf("write severed prefix binary: %v", err)
 		}
 
-		_, err := selectUpgradeDestination(binPath, binPath, func(string) error { return nil })
-		if err == nil || !strings.Contains(err.Error(), "brew reinstall amq") {
-			t.Fatalf("selectUpgradeDestination error = %v, want reinstall remedy", err)
+		_, err := selectUpgradeDestinationWithRoots(binPath, binPath, func(string) error { return nil }, []string{prefix}, "")
+		if err == nil || !strings.Contains(err.Error(), "brew reinstall amq") || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
+			t.Fatalf("selectUpgradeDestination error = %v, want both Homebrew remedies", err)
 		}
 	})
 
-	t.Run("dangling Cellar symlink is not refused here (classifier owns it)", func(t *testing.T) {
+	t.Run("dangling Cellar symlink refuses before resolution", func(t *testing.T) {
 		if err := os.Remove(binPath); err != nil {
 			t.Fatalf("remove regular prefix binary: %v", err)
 		}
@@ -345,19 +358,13 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 			t.Fatalf("create dangling Cellar symlink: %v", err)
 		}
 
-		// selectUpgradeDestination only guards the severed-binary corruption;
-		// a Cellar symlink (healthy or dangling) is delegated by the
-		// classifier upstream, so this function returns the dest cleanly.
-		got, err := selectUpgradeDestination(binPath, binPath, func(string) error { return nil })
-		if err != nil {
-			t.Fatalf("selectUpgradeDestination error = %v, want no refusal (classifier owns Homebrew delegation)", err)
-		}
-		if got != binPath {
-			t.Fatalf("destination = %q, want %q", got, binPath)
+		_, err := selectUpgradeDestinationWithRoots(binPath, binPath, func(string) error { return nil }, []string{prefix}, "")
+		if err == nil {
+			t.Fatal("selectUpgradeDestination accepted a broken Homebrew symlink")
 		}
 	})
 
-	t.Run("healthy Cellar symlink is not refused here (classifier owns it)", func(t *testing.T) {
+	t.Run("healthy Cellar symlink refuses", func(t *testing.T) {
 		if err := os.Remove(binPath); err != nil {
 			t.Fatalf("remove dangling symlink: %v", err)
 		}
@@ -365,12 +372,9 @@ func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
 			t.Fatalf("create healthy Cellar symlink: %v", err)
 		}
 
-		got, err := selectUpgradeDestination(binPath, cellarPath, func(string) error { return nil })
-		if err != nil {
-			t.Fatalf("selectUpgradeDestination error = %v, want no refusal (classifier owns Homebrew delegation)", err)
-		}
-		if got != cellarPath {
-			t.Fatalf("destination = %q, want %q", got, cellarPath)
+		_, err := selectUpgradeDestinationWithRoots(binPath, cellarPath, func(string) error { return nil }, []string{prefix}, "")
+		if err == nil || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
+			t.Fatalf("selectUpgradeDestination error = %v, want Homebrew remedy", err)
 		}
 	})
 }
@@ -500,6 +504,50 @@ func TestDetectHomebrewPrefixForUpgradeFallsBackToExistingWellKnownBrew(t *testi
 	}
 }
 
+func TestDetectHomebrewInstallationsCollectsAllCandidates(t *testing.T) {
+	envPrefix := filepath.Join(t.TempDir(), "env-homebrew")
+	probePrefix := filepath.Join(t.TempDir(), "probe-homebrew")
+	fakeHome := t.TempDir()
+	t.Setenv("HOMEBREW_PREFIX", envPrefix)
+	oldLookPath := lookPathForHomebrewUpgrade
+	lookPathForHomebrewUpgrade = func(name string) (string, error) {
+		if name != "brew" {
+			t.Fatalf("LookPath name = %q, want brew", name)
+		}
+		return "/custom/bin/brew", nil
+	}
+	t.Cleanup(func() { lookPathForHomebrewUpgrade = oldLookPath })
+	oldRun := runBrewPrefixForHomebrewUpgrade
+	runBrewPrefixForHomebrewUpgrade = func(context.Context, string) ([]byte, error) {
+		return []byte(probePrefix + "\n"), nil
+	}
+	t.Cleanup(func() { runBrewPrefixForHomebrewUpgrade = oldRun })
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return fakeHome, nil }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+
+	installations := detectHomebrewInstallations()
+	prefixes := homebrewPrefixesFromInstallations(installations)
+	for _, want := range []string{envPrefix, probePrefix, "/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew", "/opt/linuxbrew/.linuxbrew", filepath.Join(fakeHome, ".linuxbrew")} {
+		found := false
+		canonicalWant := canonicalHomebrewPrefix(want)
+		for _, got := range prefixes {
+			if got == canonicalWant {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("detected Homebrew prefixes = %#v, missing %q", prefixes, want)
+		}
+	}
+	for _, installation := range installations {
+		if installation.prefix == canonicalHomebrewPrefix(probePrefix) && installation.executable != "/custom/bin/brew" {
+			t.Fatalf("probe installation executable = %q, want exact PATH executable", installation.executable)
+		}
+	}
+}
+
 func TestPathWithinDirectoryEachClause(t *testing.T) {
 	parent := t.TempDir()
 	inside := filepath.Join(parent, "bin", "amq")
@@ -615,9 +663,252 @@ func TestRunUpgradeDirectInstallReplacesBinary(t *testing.T) {
 	}
 }
 
-func TestRunUpgradeHomebrewDelegatesWithYes(t *testing.T) {
+func TestRunUpgradeWritesCacheToOverride(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv(update.EnvCacheDir, cacheDir)
 	bin := filepath.Join(t.TempDir(), "amq")
-	if err := os.WriteFile(bin, []byte("homebrew"), 0o755); err != nil {
+	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	stubUpgradeNetwork(t)
+	oldSave := saveUpgradeCacheForUpgrade
+	saveUpgradeCacheForUpgrade = saveUpgradeCache
+	t.Cleanup(func() { saveUpgradeCacheForUpgrade = oldSave })
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "dev") }); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	path, err := update.DefaultCachePath()
+	if err != nil {
+		t.Fatalf("DefaultCachePath: %v", err)
+	}
+	cache, err := update.LoadCache(path)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if cache == nil || cache.LatestVersion != "v0.0.0-test" {
+		t.Fatalf("cache = %#v, want latest v0.0.0-test under %s", cache, cacheDir)
+	}
+}
+
+func TestRunUpgradeScheduledSkipsVersionCache(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldFetch := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
+	stubUpgradeNetwork(t)
+	oldReplace := replaceBinaryForUpgrade
+	replaceBinaryForUpgrade = func(_, _ string) (bool, error) { return true, nil }
+	t.Cleanup(func() { replaceBinaryForUpgrade = oldReplace })
+	cacheWrites := 0
+	oldSave := saveUpgradeCacheForUpgrade
+	saveUpgradeCacheForUpgrade = func(string) { cacheWrites++ }
+	t.Cleanup(func() { saveUpgradeCacheForUpgrade = oldSave })
+
+	stdout, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "dev") })
+	if err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if cacheWrites != 0 {
+		t.Fatalf("scheduled replacement wrote version cache %d times", cacheWrites)
+	}
+	if !strings.Contains(stdout, "replacement scheduled; version cache updates on next run") {
+		t.Fatalf("scheduled output missing cache timing: %s", stdout)
+	}
+}
+
+func TestFindCompanionRejectsSymlinkToAMQ(t *testing.T) {
+	dir := t.TempDir()
+	amqDest := filepath.Join(dir, "amq")
+	if err := os.WriteFile(amqDest, []byte("amq"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(amqDest, filepath.Join(dir, "amq-keepalive")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := findCompanionMatches("amq-keepalive", []string{dir}, amqDest, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "is the amq executable") {
+		t.Fatalf("findCompanionMatches error = %v, want same-file refusal", err)
+	}
+}
+
+func TestFindCompanionRejectsPackageManagedSymlink(t *testing.T) {
+	prefix := t.TempDir()
+	target := filepath.Join(prefix, "Cellar", "amq", "0.74.0", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("brew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.Symlink(target, filepath.Join(dir, "amq-keepalive")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := findCompanionMatches("amq-keepalive", []string{dir}, "", []string{prefix}, "")
+	if err == nil || !strings.Contains(err.Error(), "package-managed") {
+		t.Fatalf("findCompanionMatches error = %v, want package-managed refusal", err)
+	}
+}
+
+func TestFindCompanionRejectsBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "missing"), filepath.Join(dir, "amq-keepalive")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := findCompanionMatches("amq-keepalive", []string{dir}, "", nil, "")
+	if err == nil || !strings.Contains(err.Error(), "cannot resolve companion symlink") {
+		t.Fatalf("findCompanionMatches error = %v, want broken-link refusal", err)
+	}
+}
+
+func TestFindCompanionRejectsNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "amq-keepalive")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := findCompanionMatches("amq-keepalive", []string{dir}, "", nil, "")
+	if err == nil || !strings.Contains(err.Error(), "not a regular file or symlink") {
+		t.Fatalf("findCompanionMatches error = %v, want non-regular refusal", err)
+	}
+}
+
+func TestUpgradeCompanionsRejectsDistinctDuplicateTargets(t *testing.T) {
+	firstDir := t.TempDir()
+	secondHome := t.TempDir()
+	secondDir := filepath.Join(secondHome, ".local", "bin")
+	if err := os.MkdirAll(secondDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	amqDest := filepath.Join(firstDir, "amq")
+	if err := os.WriteFile(amqDest, []byte("amq"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(firstDir, "amq-keepalive")
+	second := filepath.Join(secondDir, "amq-keepalive")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldHome := homeDirForUpgrade
+	homeDirForUpgrade = func() (string, error) { return secondHome, nil }
+	t.Cleanup(func() { homeDirForUpgrade = oldHome })
+	oldCompanions := companionBinariesForUpgrade
+	companionBinariesForUpgrade = []string{"amq-keepalive"}
+	t.Cleanup(func() { companionBinariesForUpgrade = oldCompanions })
+
+	err := upgradeCompanionsWithProtection(context.Background(), nil, "v0.0.0-test", "v0.0.0-test", amqDest, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "multiple distinct targets") ||
+		!strings.Contains(err.Error(), first) || !strings.Contains(err.Error(), second) {
+		t.Fatalf("upgradeCompanions error = %v, want both duplicate paths", err)
+	}
+}
+
+func TestRunUpgradeClassifiesAgainstAllHomebrewPrefixes(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	amqPath := filepath.Join(second, "Cellar", "amq", "0.74.0", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(amqPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(amqPath, []byte("brew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) { return amqPath, amqPath, nil }
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
+		return []homebrewInstallation{
+			{prefix: first, executable: filepath.Join(first, "bin", "brew")},
+			{prefix: second, executable: filepath.Join(second, "bin", "brew")},
+		}
+	}
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldDelegate := runDelegateForUpgrade
+	var ran []string
+	runDelegateForUpgrade = func(argv []string) error { ran = append(ran, strings.Join(argv, " ")); return nil }
+	t.Cleanup(func() { runDelegateForUpgrade = oldDelegate })
+
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade([]string{"-y"}, "dev") }); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	manager := filepath.Join(second, "bin", "brew")
+	if len(ran) != 2 || ran[0] != manager+" update" || ran[1] != manager+" upgrade amq" {
+		t.Fatalf("delegation = %#v, want manager %s", ran, manager)
+	}
+}
+
+func TestRunDirectUpgradeFinalCellarGuard(t *testing.T) {
+	prefix := t.TempDir()
+	dest := filepath.Join(prefix, "Cellar", "amq", "0.74.0", "bin", "amq")
+	stubUpgradeNetwork(t)
+	replaced := false
+	oldReplace := replaceBinaryForUpgrade
+	replaceBinaryForUpgrade = func(_, _ string) (bool, error) { replaced = true; return false, nil }
+	t.Cleanup(func() { replaceBinaryForUpgrade = oldReplace })
+	_, err := runDirectUpgradeWithProtection(context.Background(), nil, "amq", "v0.0.0-test", "v0.0.0-test", dest, []string{prefix}, "")
+	if err == nil || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
+		t.Fatalf("runDirectUpgrade error = %v, want independent Cellar guard", err)
+	}
+	if replaced {
+		t.Fatal("final Cellar guard ran replacement")
+	}
+}
+
+func TestRunBrewPrefixIsBounded(t *testing.T) {
+	dir := t.TempDir()
+	brew := filepath.Join(dir, "brew")
+	if err := os.WriteFile(brew, []byte("#!/bin/sh\nsleep 60 &\nprintf '%s\\n' /tmp/test-prefix\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err := runBrewPrefix(context.Background(), brew)
+	if err == nil {
+		t.Fatal("runBrewPrefix succeeded despite a child holding stdout")
+	}
+	if elapsed := time.Since(started); elapsed > 8*time.Second {
+		t.Fatalf("runBrewPrefix took %v, want bounded cleanup", elapsed)
+	}
+}
+
+func TestRunUpgradeHomebrewDelegatesWithYes(t *testing.T) {
+	prefix := t.TempDir()
+	bin := filepath.Join(prefix, "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cellar := filepath.Join(prefix, "Cellar", "amq", "0.0.0", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(cellar), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cellar, []byte("homebrew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(cellar, bin); err != nil {
 		t.Fatal(err)
 	}
 	oldExecutablePath := executablePathForUpgrade
@@ -626,6 +917,14 @@ func TestRunUpgradeHomebrewDelegatesWithYes(t *testing.T) {
 	oldClassify := classifyInstallForUpgrade
 	classifyInstallForUpgrade = func(string, string) update.InstallKind { return update.InstallHomebrew }
 	t.Cleanup(func() { classifyInstallForUpgrade = oldClassify })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
+		return []homebrewInstallation{{prefix: prefix, executable: filepath.Join(prefix, "bin", "brew")}}
+	}
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return "" }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 	var delegateRan []string
 	oldDelegate := runDelegateForUpgrade
 	runDelegateForUpgrade = func(argv []string) error { delegateRan = append(delegateRan, strings.Join(argv, " ")); return nil }
@@ -644,8 +943,9 @@ func TestRunUpgradeHomebrewDelegatesWithYes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runUpgrade -y: %v", err)
 	}
-	if len(delegateRan) != 2 || delegateRan[0] != "brew update" || delegateRan[1] != "brew upgrade amq" {
-		t.Fatalf("delegate ran %#v, want [brew update, brew upgrade amq]", delegateRan)
+	manager := filepath.Join(prefix, "bin", "brew")
+	if len(delegateRan) != 2 || delegateRan[0] != manager+" update" || delegateRan[1] != manager+" upgrade amq" {
+		t.Fatalf("delegate ran %#v, want [%s update, %s upgrade amq]", delegateRan, manager, manager)
 	}
 	if fetchCalls != 0 {
 		t.Fatalf("release lookups = %d, want 0 for a delegated upgrade", fetchCalls)
@@ -692,6 +992,11 @@ func TestRunUpgradeClassifiesUserSymlinkToHomebrew(t *testing.T) {
 	oldDetect := detectHomebrewPrefixForUpgrade
 	detectHomebrewPrefixForUpgrade = func() string { return prefix }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+	oldInstallations := detectHomebrewInstallationsForUpgrade
+	detectHomebrewInstallationsForUpgrade = func() []homebrewInstallation {
+		return []homebrewInstallation{{prefix: prefix, executable: filepath.Join(prefix, "bin", "brew")}}
+	}
+	t.Cleanup(func() { detectHomebrewInstallationsForUpgrade = oldInstallations })
 	var delegateRan []string
 	oldDelegate := runDelegateForUpgrade
 	runDelegateForUpgrade = func(argv []string) error { delegateRan = append(delegateRan, strings.Join(argv, " ")); return nil }
@@ -705,8 +1010,9 @@ func TestRunUpgradeClassifiesUserSymlinkToHomebrew(t *testing.T) {
 	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade([]string{"-y"}, "dev") }); err != nil {
 		t.Fatalf("runUpgrade: %v", err)
 	}
-	if len(delegateRan) != 2 || delegateRan[0] != "brew update" || delegateRan[1] != "brew upgrade amq" {
-		t.Fatalf("delegate ran %#v, want [brew update, brew upgrade amq]", delegateRan)
+	wantManager := filepath.Join(prefix, "bin", "brew")
+	if len(delegateRan) != 2 || delegateRan[0] != wantManager+" update" || delegateRan[1] != wantManager+" upgrade amq" {
+		t.Fatalf("delegate ran %#v, want [%s update, %s upgrade amq]", delegateRan, wantManager, wantManager)
 	}
 }
 
@@ -747,7 +1053,14 @@ func TestRunUpgradeAllReplacesPresentCompanionsSkipsMissing(t *testing.T) {
 		t.Fatalf("runUpgrade --all: %v", err)
 	}
 	// amq + keepalive + bridge replaced; amq-acp skipped.
-	want := map[string]bool{amqBin: false, keepalive: false, bridge: false}
+	want := map[string]bool{amqBin: false}
+	for _, path := range []string{keepalive, bridge} {
+		canonical, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want[canonical] = false
+	}
 	for _, p := range *replaced {
 		if _, ok := want[p]; ok {
 			want[p] = true
@@ -827,98 +1140,4 @@ func TestRunUpgradeAllReplacesSymlinkedCompanionAtTarget(t *testing.T) {
 	if resolved, err := filepath.EvalSymlinks(keepaliveLink); err != nil || resolved != canonicalTarget {
 		t.Fatalf("link %q no longer resolves to %q (got %q, err=%v)", keepaliveLink, canonicalTarget, resolved, err)
 	}
-}
-
-// TestUpgradeDoesNotTouchRealCacheWhenIsolated is the WP-646 sentinel for the
-// update cache: it pre-seeds the REAL cache path (the one DefaultCachePath
-// resolves to when AMQ_CACHE_DIR is unset) with a sentinel, then runs an
-// upgrade under the TestMain-isolated AMQ_CACHE_DIR, and asserts the real
-// sentinel is byte-identical afterward. This catches a regression where a
-// test path writes through to ~/Library/Caches/amq/update.json.
-func TestUpgradeDoesNotTouchRealCacheWhenIsolated(t *testing.T) {
-	// Resolve the REAL cache path by ignoring the TestMain override.
-	realCachePath := realDefaultCachePath(t)
-	if err := os.MkdirAll(filepath.Dir(realCachePath), 0o700); err != nil {
-		t.Fatalf("mkdir real cache dir: %v", err)
-	}
-	// Save any pre-existing real cache content so the test restores the
-	// developer's actual cache state rather than deleting it.
-	preExisting, _ := os.ReadFile(realCachePath)
-	sentinel := []byte(`{"checked_at":"2026-01-01T00:00:00Z","latest_version":"v0.0.0-sentinel"}`)
-	if err := os.WriteFile(realCachePath, sentinel, 0o600); err != nil {
-		t.Fatalf("seed sentinel cache: %v", err)
-	}
-	t.Cleanup(func() {
-		if len(preExisting) > 0 {
-			_ = os.WriteFile(realCachePath, preExisting, 0o600)
-		} else {
-			_ = os.Remove(realCachePath)
-		}
-	})
-
-	// Confirm the isolated cache dir is distinct from the real one (TestMain
-	// sets AMQ_CACHE_DIR); an upgrade must write only there.
-	isolatedPath, err := update.DefaultCachePath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if isolatedPath == realCachePath {
-		t.Fatalf("TestMain did not isolate the cache: isolated path == real path %s", realCachePath)
-	}
-
-	bin := filepath.Join(t.TempDir(), "amq")
-	if err := os.WriteFile(bin, []byte("old"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	oldExecutablePath := executablePathForUpgrade
-	executablePathForUpgrade = func() (string, string, error) { return bin, bin, nil }
-	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
-	oldDetect := detectHomebrewPrefixForUpgrade
-	detectHomebrewPrefixForUpgrade = func() string { return "" }
-	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
-	oldFetch := fetchLatestTagForUpgrade
-	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
-		return "v0.0.0-test", nil
-	}
-	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
-	stubUpgradeNetwork(t)
-
-	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "dev") }); err != nil {
-		t.Fatalf("runUpgrade: %v", err)
-	}
-
-	after, err := os.ReadFile(realCachePath)
-	if err != nil {
-		t.Fatalf("read sentinel after upgrade: %v", err)
-	}
-	if !bytes.Equal(sentinel, after) {
-		t.Fatalf("real cache sentinel was mutated by upgrade: before=%s after=%s", sentinel, after)
-	}
-}
-
-// realDefaultCachePath computes DefaultCachePath as it would resolve in
-// production (AMQ_CACHE_DIR and XDG_CACHE_HOME unset, so os.UserCacheDir
-// returns the true platform default), restoring the overrides immediately so
-// the rest of the test runs under TestMain's isolated cache.
-func realDefaultCachePath(t *testing.T) string {
-	t.Helper()
-	savedCacheDir := os.Getenv(update.EnvCacheDir)
-	savedXDG := os.Getenv("XDG_CACHE_HOME")
-	_ = os.Unsetenv(update.EnvCacheDir)
-	_ = os.Unsetenv("XDG_CACHE_HOME")
-	path, err := update.DefaultCachePath()
-	if savedCacheDir != "" {
-		_ = os.Setenv(update.EnvCacheDir, savedCacheDir)
-	} else {
-		_ = os.Unsetenv(update.EnvCacheDir)
-	}
-	if savedXDG != "" {
-		_ = os.Setenv("XDG_CACHE_HOME", savedXDG)
-	} else {
-		_ = os.Unsetenv("XDG_CACHE_HOME")
-	}
-	if err != nil {
-		t.Fatalf("resolve real cache path: %v", err)
-	}
-	return path
 }

--- a/internal/keepalive/amq/runner.go
+++ b/internal/keepalive/amq/runner.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/update"
 )
 
 var ErrWakeReadinessUncertain = errors.New("amq wake readiness is uncertain; child was left unsignaled")
@@ -463,7 +465,7 @@ func newWakeReadyPath() (string, string, error) {
 	cacheDir := strings.TrimSpace(os.Getenv("AMQ_KEEPALIVE_CACHE_DIR"))
 	if cacheDir == "" {
 		var err error
-		cacheDir, err = os.UserCacheDir()
+		cacheDir, err = update.DefaultCacheDir()
 		if err != nil {
 			return "", "", fmt.Errorf("resolve user cache directory for wake readiness: %w", err)
 		}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -70,7 +70,6 @@ var (
 	ErrUnsupportedOS      = errors.New("unsupported operating system")
 	ErrUnsupportedArch    = errors.New("unsupported architecture")
 	userCacheDirForUpdate = os.UserCacheDir
-	absPathForCacheDir    = filepath.Abs
 )
 
 type Cache struct {
@@ -738,20 +737,23 @@ func SaveCache(path string, cache *Cache) error {
 }
 
 func DefaultCachePath() (string, error) {
-	if rawDir := os.Getenv(EnvCacheDir); rawDir != "" {
-		dir := strings.TrimSpace(rawDir)
-		if dir == "" {
-			return "", fmt.Errorf("resolve %s: path is empty", EnvCacheDir)
+	if rawDir, set := os.LookupEnv(EnvCacheDir); set {
+		if rawDir == "" || !filepath.IsAbs(rawDir) {
+			return "", fmt.Errorf("resolve %s: unset %s or set it to an absolute cache directory", EnvCacheDir, EnvCacheDir)
 		}
-		abs, err := absPathForCacheDir(dir)
-		if err != nil {
-			return "", fmt.Errorf("resolve %s: %w", EnvCacheDir, err)
-		}
-		if !filepath.IsAbs(abs) {
-			return "", fmt.Errorf("resolve %s: path is not absolute", EnvCacheDir)
-		}
-		return filepath.Join(filepath.Clean(abs), "amq", "update.json"), nil
+		return filepath.Join(filepath.Clean(rawDir), "amq", "update.json"), nil
 	}
+	cacheDir, err := DefaultCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, "amq", "update.json"), nil
+}
+
+// DefaultCacheDir returns the platform user-cache directory. It is shared by
+// update files and keepalive readiness files so platform cache discovery stays
+// in one package.
+func DefaultCacheDir() (string, error) {
 	cacheDir, err := userCacheDirForUpdate()
 	if err != nil {
 		home, err := os.UserHomeDir()
@@ -760,7 +762,7 @@ func DefaultCachePath() (string, error) {
 		}
 		cacheDir = filepath.Join(home, ".cache")
 	}
-	return filepath.Join(cacheDir, "amq", "update.json"), nil
+	return cacheDir, nil
 }
 
 func writeUpdateHint(w io.Writer, current, latest string) error {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -56,14 +56,46 @@ const (
 	// brew bookkeeping. Companions are never Homebrew-owned.
 	InstallHomebrew
 	// InstallScoop means the resolved path lives under the Scoop apps dir on
-	// Windows; amq upgrade delegates to scoop. Companions are never Scoop-owned.
+	// Windows user scope; amq upgrade delegates to scoop. Companions are never
+	// Scoop-owned.
 	InstallScoop
+	// InstallScoopGlobal means the resolved path lives under Scoop's global apps
+	// dir on Windows; the delegate must include Scoop's global flag.
+	InstallScoopGlobal
+	// InstallScoopUnknown means the path looks like a Scoop apps path but is not
+	// under a configured user or global Scoop root. It must never self-replace.
+	InstallScoopUnknown
 )
 
 // IsPackageManaged reports whether the kind delegates to an external package
 // manager rather than self-replacing.
 func (k InstallKind) IsPackageManaged() bool {
-	return k == InstallHomebrew || k == InstallScoop
+	return k == InstallHomebrew || k.IsScoop()
+}
+
+// IsScoop reports whether the kind came from a Scoop-shaped installation.
+func (k InstallKind) IsScoop() bool {
+	return k == InstallScoop || k == InstallScoopGlobal || k == InstallScoopUnknown
+}
+
+// IsScoopGlobal reports whether the kind is a known global Scoop install.
+func (k InstallKind) IsScoopGlobal() bool {
+	return k == InstallScoopGlobal
+}
+
+// ScoopScope identifies the Scoop installation scope for a configured root.
+type ScoopScope string
+
+const (
+	ScoopScopeUser   ScoopScope = "user"
+	ScoopScopeGlobal ScoopScope = "global"
+)
+
+// ScoopInstallRoot describes one Scoop apps directory and its installation
+// scope. Paths are absolute where the platform can make them absolute.
+type ScoopInstallRoot struct {
+	Path  string
+	Scope ScoopScope
 }
 
 var (
@@ -860,6 +892,20 @@ func ClassifyInstall(resolvedPath, homebrewPrefix string) InstallKind {
 // resolves into that same prefix's Cellar; a regular file there remains an
 // ambiguous direct install for the CLI's final safety guard.
 func ClassifyInstallAgainstPrefixes(resolvedPath string, homebrewPrefixes []string) InstallKind {
+	return classifyInstallAgainstPrefixesAndScoopRoots(
+		resolvedPath,
+		homebrewPrefixes,
+		ScoopInstallRoots(),
+		runtime.GOOS == "windows",
+	)
+}
+
+func classifyInstallAgainstPrefixesAndScoopRoots(
+	resolvedPath string,
+	homebrewPrefixes []string,
+	scoopRoots []ScoopInstallRoot,
+	scoopEnabled bool,
+) InstallKind {
 	if resolvedPath == "" {
 		return InstallDirect
 	}
@@ -878,9 +924,24 @@ func ClassifyInstallAgainstPrefixes(resolvedPath string, homebrewPrefixes []stri
 			return InstallHomebrew
 		}
 	}
-	if appsDir := scoopAppsDir(); appsDir != "" {
-		if pathWithinPrefix(path, CanonicalPath(appsDir)) {
-			return InstallScoop
+	if scoopEnabled {
+		// A global root wins if an operator configures overlapping roots. That
+		// keeps the delegate conservative and preserves the global scope.
+		for _, scope := range []ScoopScope{ScoopScopeGlobal, ScoopScopeUser} {
+			for _, root := range scoopRoots {
+				if root.Scope != scope || root.Path == "" {
+					continue
+				}
+				if pathWithinPrefix(path, CanonicalPath(root.Path)) {
+					if scope == ScoopScopeGlobal {
+						return InstallScoopGlobal
+					}
+					return InstallScoop
+				}
+			}
+		}
+		if isScoopShapedPath(rawPath) {
+			return InstallScoopUnknown
 		}
 	}
 	return InstallDirect
@@ -934,25 +995,84 @@ func pathWithinPrefix(path, prefix string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-// scoopAppsDir returns the Scoop apps directory when Scoop is in use, else "".
-// Scoop honors $SCOOP; otherwise it defaults to ~/scoop.
-func scoopAppsDir() string {
+const defaultScoopGlobalRoot = `C:\ProgramData\scoop`
+
+// ScoopInstallRoots returns the configured user and global Scoop apps
+// directories on Windows. Scoop honors $SCOOP and $SCOOP_GLOBAL; the default
+// roots are ~/scoop and C:\ProgramData\scoop.
+func ScoopInstallRoots() []ScoopInstallRoot {
 	if runtime.GOOS != "windows" {
-		return ""
+		return nil
 	}
-	if scoop := strings.TrimSpace(os.Getenv("SCOOP")); scoop != "" {
-		if abs, err := filepath.Abs(scoop); err == nil {
-			return filepath.Join(filepath.Clean(abs), "apps")
+	home, _ := os.UserHomeDir()
+	return scoopInstallRootsFor(
+		runtime.GOOS,
+		strings.TrimSpace(os.Getenv("SCOOP")),
+		strings.TrimSpace(os.Getenv("SCOOP_GLOBAL")),
+		home,
+	)
+}
+
+func scoopInstallRootsFor(goos, scoop, scoopGlobal, home string) []ScoopInstallRoot {
+	if goos != "windows" {
+		return nil
+	}
+	roots := make([]ScoopInstallRoot, 0, 2)
+	seen := make(map[string]struct{}, 2)
+	add := func(root string, scope ScoopScope) {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			return
 		}
+		if abs, err := filepath.Abs(root); err == nil {
+			root = abs
+		}
+		apps := filepath.Join(filepath.Clean(root), "apps")
+		key := CanonicalPath(apps)
+		if _, ok := seen[key+"\x00"+string(scope)]; ok {
+			return
+		}
+		seen[key+"\x00"+string(scope)] = struct{}{}
+		roots = append(roots, ScoopInstallRoot{Path: apps, Scope: scope})
 	}
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, "scoop", "apps")
+
+	if scoop == "" && home != "" {
+		scoop = filepath.Join(home, "scoop")
+	}
+	if scoopGlobal == "" {
+		scoopGlobal = defaultScoopGlobalRoot
+	}
+	add(scoop, ScoopScopeUser)
+	add(scoopGlobal, ScoopScopeGlobal)
+	return roots
+}
+
+// ScoopAppsDir returns the user-scope Scoop apps directory on Windows. It is
+// empty on other operating systems and remains for callers that need only the
+// historical single-root view.
+func ScoopAppsDir() string {
+	for _, root := range ScoopInstallRoots() {
+		if root.Scope == ScoopScopeUser {
+			return root.Path
+		}
 	}
 	return ""
 }
 
-// ScoopAppsDir returns the active Scoop apps directory on Windows. It is
-// empty on other operating systems and can be used by replacement guards.
-func ScoopAppsDir() string {
-	return scoopAppsDir()
+// IsScoopShapedPath reports whether path contains the conventional Scoop
+// root/apps layout on Windows.
+func IsScoopShapedPath(path string) bool {
+	return runtime.GOOS == "windows" && isScoopShapedPath(path)
+}
+
+func isScoopShapedPath(path string) bool {
+	parts := strings.FieldsFunc(filepath.Clean(path), func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for index := 0; index+1 < len(parts); index++ {
+		if strings.EqualFold(parts[index], "scoop") && strings.EqualFold(parts[index+1], "apps") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -26,6 +26,7 @@ const (
 	RepoOwner            = "avivsinai"
 	RepoName             = "agent-message-queue"
 	RepoSlug             = RepoOwner + "/" + RepoName
+	ModulePath           = "github.com/avivsinai/agent-message-queue"
 	BinaryName           = "amq"
 	ChecksumsFilename    = "checksums.txt"
 	DefaultCheckInterval = 24 * time.Hour

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -66,8 +66,10 @@ func (k InstallKind) IsPackageManaged() bool {
 }
 
 var (
-	ErrUnsupportedOS   = errors.New("unsupported operating system")
-	ErrUnsupportedArch = errors.New("unsupported architecture")
+	ErrUnsupportedOS      = errors.New("unsupported operating system")
+	ErrUnsupportedArch    = errors.New("unsupported architecture")
+	userCacheDirForUpdate = os.UserCacheDir
+	absPathForCacheDir    = filepath.Abs
 )
 
 type Cache struct {
@@ -252,12 +254,12 @@ func AssetName(tag, goos, goarch string) (string, error) {
 // darwin/linux tar.gz, but this function does not enforce that — the caller
 // picks the asset for a binary the release actually publishes.
 func AssetNameFor(binaryName, tag, goos, goarch string) (string, error) {
-	version := strings.TrimSpace(strings.TrimPrefix(tag, "v"))
-	if version == "" {
-		return "", errors.New("invalid release tag")
+	if err := validateBinaryName(binaryName); err != nil {
+		return "", err
 	}
-	if strings.TrimSpace(binaryName) == "" {
-		return "", errors.New("binary name is required")
+	version, err := validateReleaseVersion(tag)
+	if err != nil {
+		return "", err
 	}
 	osName, err := normalizeOS(goos)
 	if err != nil {
@@ -271,7 +273,66 @@ func AssetNameFor(binaryName, tag, goos, goarch string) (string, error) {
 	if osName == "windows" {
 		ext = "zip"
 	}
-	return fmt.Sprintf("%s_%s_%s_%s.%s", binaryName, version, osName, archName, ext), nil
+	assetName := fmt.Sprintf("%s_%s_%s_%s.%s", binaryName, version, osName, archName, ext)
+	if err := validateAssetName(assetName); err != nil {
+		return "", err
+	}
+	return assetName, nil
+}
+
+func validateBinaryName(binaryName string) error {
+	switch binaryName {
+	case BinaryName, "amq-keepalive", "amq-bridge", "amq-acp":
+		return nil
+	default:
+		return fmt.Errorf("invalid binary name: %q", binaryName)
+	}
+}
+
+func validateReleaseVersion(tag string) (string, error) {
+	version := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(tag), "v"))
+	if version == "" || filepath.Base(version) != version || filepath.VolumeName(version) != "" ||
+		strings.ContainsAny(version, `/\\`) {
+		return "", fmt.Errorf("invalid release tag: %q", tag)
+	}
+
+	core := version
+	if cut := strings.IndexAny(core, "+-"); cut >= 0 {
+		suffix := core[cut+1:]
+		if suffix == "" {
+			return "", fmt.Errorf("invalid release tag: %q", tag)
+		}
+		for _, char := range suffix {
+			if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') &&
+				(char < '0' || char > '9') && char != '.' && char != '-' {
+				return "", fmt.Errorf("invalid release tag: %q", tag)
+			}
+		}
+		core = core[:cut]
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid release tag: %q", tag)
+	}
+	for _, part := range parts {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
+			return "", fmt.Errorf("invalid release tag: %q", tag)
+		}
+		for _, char := range part {
+			if char < '0' || char > '9' {
+				return "", fmt.Errorf("invalid release tag: %q", tag)
+			}
+		}
+	}
+	return version, nil
+}
+
+func validateAssetName(assetName string) error {
+	if assetName == "" || filepath.Base(assetName) != assetName || filepath.VolumeName(assetName) != "" ||
+		strings.ContainsAny(assetName, `/\\`) {
+		return fmt.Errorf("invalid release asset name: %q", assetName)
+	}
+	return nil
 }
 
 func normalizeOS(goos string) (string, error) {
@@ -319,6 +380,9 @@ func ExtractBinaryFromTarGz(archivePath, destDir string) (string, error) {
 func ExtractBinaryFromTarGzNamed(binaryName, archivePath, destDir string) (string, error) {
 	if strings.TrimSpace(binaryName) == "" {
 		binaryName = BinaryName
+	}
+	if err := validateBinaryName(binaryName); err != nil {
+		return "", err
 	}
 	file, err := os.Open(archivePath)
 	if err != nil {
@@ -385,6 +449,9 @@ func ExtractBinaryFromZip(archivePath, destDir string) (string, error) {
 func ExtractBinaryFromZipNamed(binaryName, archivePath, destDir string) (string, error) {
 	if strings.TrimSpace(binaryName) == "" {
 		binaryName = BinaryName
+	}
+	if err := validateBinaryName(binaryName); err != nil {
+		return "", err
 	}
 	reader, err := zip.OpenReader(archivePath)
 	if err != nil {
@@ -547,6 +614,12 @@ func FetchLatestTag(ctx context.Context, client *http.Client) (string, error) {
 }
 
 func DownloadReleaseAsset(ctx context.Context, client *http.Client, tag, assetName, destPath string) error {
+	if err := validateAssetName(assetName); err != nil {
+		return err
+	}
+	if _, err := validateReleaseVersion(tag); err != nil {
+		return err
+	}
 	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", RepoSlug, tag, assetName)
 	// Use a simple GET request without API headers for binary downloads
 	// GitHub redirects to blob storage which doesn't need Accept: application/vnd.github+json
@@ -664,12 +737,21 @@ func SaveCache(path string, cache *Cache) error {
 }
 
 func DefaultCachePath() (string, error) {
-	if dir := strings.TrimSpace(os.Getenv(EnvCacheDir)); dir != "" {
-		if abs, err := filepath.Abs(dir); err == nil {
-			return filepath.Join(filepath.Clean(abs), "amq", "update.json"), nil
+	if rawDir := os.Getenv(EnvCacheDir); rawDir != "" {
+		dir := strings.TrimSpace(rawDir)
+		if dir == "" {
+			return "", fmt.Errorf("resolve %s: path is empty", EnvCacheDir)
 		}
+		abs, err := absPathForCacheDir(dir)
+		if err != nil {
+			return "", fmt.Errorf("resolve %s: %w", EnvCacheDir, err)
+		}
+		if !filepath.IsAbs(abs) {
+			return "", fmt.Errorf("resolve %s: path is not absolute", EnvCacheDir)
+		}
+		return filepath.Join(filepath.Clean(abs), "amq", "update.json"), nil
 	}
-	cacheDir, err := os.UserCacheDir()
+	cacheDir, err := userCacheDirForUpdate()
 	if err != nil {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -762,31 +844,80 @@ func IsNoUpdateCheckEnv() bool {
 	}
 }
 
-// ClassifyInstall determines how the binary at resolvedPath was installed.
-// The path must be the RESOLVED path (EvalSymlinks applied) so a symlink
-// into the Cellar is classified by where it lands, not by the link itself.
-// homebrewPrefix is the detected Homebrew prefix (empty if none); the path
-// is Homebrew-owned when it lives under <prefix>/bin or <prefix>/Cellar.
-// On Windows the path is Scoop-owned when it lives under a scoop apps dir
-// (~/scoop/apps or $SCOOP/apps). Anything else is a direct install.
+// ClassifyInstall determines how a binary was installed using one Homebrew
+// prefix. It remains as a compatibility wrapper; callers that have more than
+// one candidate prefix should use ClassifyInstallAgainstPrefixes.
 func ClassifyInstall(resolvedPath, homebrewPrefix string) InstallKind {
+	return ClassifyInstallAgainstPrefixes(resolvedPath, []string{homebrewPrefix})
+}
+
+// ClassifyInstallAgainstPrefixes classifies a binary against every known
+// Homebrew prefix. A path in <prefix>/Cellar is package-managed. A path in
+// <prefix>/bin is package-managed only when the object is a symlink that
+// resolves into that same prefix's Cellar; a regular file there remains an
+// ambiguous direct install for the CLI's final safety guard.
+func ClassifyInstallAgainstPrefixes(resolvedPath string, homebrewPrefixes []string) InstallKind {
 	if resolvedPath == "" {
 		return InstallDirect
 	}
-	path := filepath.Clean(resolvedPath)
-	if homebrewPrefix != "" {
-		prefix := filepath.Clean(homebrewPrefix)
-		if pathWithinPrefix(path, filepath.Join(prefix, "bin")) ||
-			pathWithinPrefix(path, filepath.Join(prefix, "Cellar")) {
+	rawPath := filepath.Clean(resolvedPath)
+	path := canonicalPath(rawPath)
+	for _, homebrewPrefix := range homebrewPrefixes {
+		if homebrewPrefix == "" {
+			continue
+		}
+		prefix := canonicalPrefix(homebrewPrefix)
+		cellar := filepath.Join(prefix, "Cellar")
+		if pathWithinPrefix(path, cellar) {
+			return InstallHomebrew
+		}
+		if pathWithinPrefix(rawPath, filepath.Join(prefix, "bin")) && isSymlinkToCellar(rawPath, cellar) {
 			return InstallHomebrew
 		}
 	}
 	if appsDir := scoopAppsDir(); appsDir != "" {
-		if pathWithinPrefix(path, appsDir) {
+		if pathWithinPrefix(path, canonicalPath(appsDir)) {
 			return InstallScoop
 		}
 	}
 	return InstallDirect
+}
+
+func canonicalPrefix(prefix string) string {
+	return canonicalPath(prefix)
+}
+
+func isSymlinkToCellar(path, cellar string) bool {
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	return err == nil && pathWithinPrefix(filepath.Clean(resolved), cellar)
+}
+
+func canonicalPath(path string) string {
+	path = filepath.Clean(path)
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	current := path
+	suffix := make([]string, 0, 4)
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			resolved = filepath.Clean(resolved)
+			for index := len(suffix) - 1; index >= 0; index-- {
+				resolved = filepath.Join(resolved, suffix[index])
+			}
+			return filepath.Clean(resolved)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return path
+		}
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
+	}
 }
 
 // pathWithinPrefix reports whether path is equal to or nested inside prefix.
@@ -801,16 +932,22 @@ func pathWithinPrefix(path, prefix string) bool {
 // scoopAppsDir returns the Scoop apps directory when Scoop is in use, else "".
 // Scoop honors $SCOOP; otherwise it defaults to ~/scoop.
 func scoopAppsDir() string {
+	if runtime.GOOS != "windows" {
+		return ""
+	}
 	if scoop := strings.TrimSpace(os.Getenv("SCOOP")); scoop != "" {
 		if abs, err := filepath.Abs(scoop); err == nil {
 			return filepath.Join(filepath.Clean(abs), "apps")
 		}
 	}
-	if runtime.GOOS != "windows" {
-		return ""
-	}
 	if home, err := os.UserHomeDir(); err == nil {
 		return filepath.Join(home, "scoop", "apps")
 	}
 	return ""
+}
+
+// ScoopAppsDir returns the active Scoop apps directory on Windows. It is
+// empty on other operating systems and can be used by replacement guards.
+func ScoopAppsDir() string {
+	return scoopAppsDir()
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -861,7 +861,7 @@ func ClassifyInstallAgainstPrefixes(resolvedPath string, homebrewPrefixes []stri
 		return InstallDirect
 	}
 	rawPath := filepath.Clean(resolvedPath)
-	path := canonicalPath(rawPath)
+	path := CanonicalPath(rawPath)
 	for _, homebrewPrefix := range homebrewPrefixes {
 		if homebrewPrefix == "" {
 			continue
@@ -876,7 +876,7 @@ func ClassifyInstallAgainstPrefixes(resolvedPath string, homebrewPrefixes []stri
 		}
 	}
 	if appsDir := scoopAppsDir(); appsDir != "" {
-		if pathWithinPrefix(path, canonicalPath(appsDir)) {
+		if pathWithinPrefix(path, CanonicalPath(appsDir)) {
 			return InstallScoop
 		}
 	}
@@ -884,7 +884,7 @@ func ClassifyInstallAgainstPrefixes(resolvedPath string, homebrewPrefixes []stri
 }
 
 func canonicalPrefix(prefix string) string {
-	return canonicalPath(prefix)
+	return CanonicalPath(prefix)
 }
 
 func isSymlinkToCellar(path, cellar string) bool {
@@ -896,7 +896,9 @@ func isSymlinkToCellar(path, cellar string) bool {
 	return err == nil && pathWithinPrefix(filepath.Clean(resolved), cellar)
 }
 
-func canonicalPath(path string) string {
+// CanonicalPath resolves the existing portion of path and preserves any
+// non-existent suffix below it.
+func CanonicalPath(path string) string {
 	path = filepath.Clean(path)
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -30,7 +30,40 @@ const (
 	ChecksumsFilename    = "checksums.txt"
 	DefaultCheckInterval = 24 * time.Hour
 	EnvNoUpdateCheck     = "AMQ_NO_UPDATE_CHECK"
+	// EnvCacheDir overrides the update-check cache directory. It takes
+	// precedence over os.UserCacheDir so tests (and operators) can redirect
+	// the cache on platforms where UserCacheDir ignores HOME (darwin's
+	// ~/Library/Caches). When unset, production behavior is unchanged.
+	EnvCacheDir = "AMQ_CACHE_DIR"
 )
+
+// CompanionBinaries are the amq-adjacent binaries published from the same
+// release but not packaged by the Homebrew formula or Scoop manifest: only
+// amq itself goes through a package manager. They are direct-installed at a
+// stable path (~/.local/bin or next to amq) and upgraded in place.
+var CompanionBinaries = []string{"amq-keepalive", "amq-bridge", "amq-acp"}
+
+// InstallKind classifies how a resolved executable path was installed.
+type InstallKind int
+
+const (
+	// InstallDirect is a manually-placed binary (~/.local/bin, a versions
+	// dir, etc.); amq upgrade owns the download+checksum+atomic-replace path.
+	InstallDirect InstallKind = iota
+	// InstallHomebrew means the resolved path lives under a Homebrew Cellar
+	// or prefix bin dir; amq upgrade delegates to brew so it does not corrupt
+	// brew bookkeeping. Companions are never Homebrew-owned.
+	InstallHomebrew
+	// InstallScoop means the resolved path lives under the Scoop apps dir on
+	// Windows; amq upgrade delegates to scoop. Companions are never Scoop-owned.
+	InstallScoop
+)
+
+// IsPackageManaged reports whether the kind delegates to an external package
+// manager rather than self-replacing.
+func (k InstallKind) IsPackageManaged() bool {
+	return k == InstallHomebrew || k == InstallScoop
+}
 
 var (
 	ErrUnsupportedOS   = errors.New("unsupported operating system")
@@ -209,9 +242,22 @@ func NormalizeVersion(version string) string {
 }
 
 func AssetName(tag, goos, goarch string) (string, error) {
+	return AssetNameFor(BinaryName, tag, goos, goarch)
+}
+
+// AssetNameFor returns the release archive asset name for a given binary
+// (amq, amq-keepalive, amq-bridge, amq-acp). The archive name template is
+// <binary>_<version>_<os>_<arch>.<ext>, matching .goreleaser.yaml's
+// name_template per build. Only amq publishes a Windows zip; companions are
+// darwin/linux tar.gz, but this function does not enforce that — the caller
+// picks the asset for a binary the release actually publishes.
+func AssetNameFor(binaryName, tag, goos, goarch string) (string, error) {
 	version := strings.TrimSpace(strings.TrimPrefix(tag, "v"))
 	if version == "" {
 		return "", errors.New("invalid release tag")
+	}
+	if strings.TrimSpace(binaryName) == "" {
+		return "", errors.New("binary name is required")
 	}
 	osName, err := normalizeOS(goos)
 	if err != nil {
@@ -225,7 +271,7 @@ func AssetName(tag, goos, goarch string) (string, error) {
 	if osName == "windows" {
 		ext = "zip"
 	}
-	return fmt.Sprintf("%s_%s_%s_%s.%s", BinaryName, version, osName, archName, ext), nil
+	return fmt.Sprintf("%s_%s_%s_%s.%s", binaryName, version, osName, archName, ext), nil
 }
 
 func normalizeOS(goos string) (string, error) {
@@ -263,6 +309,17 @@ func ExecutablePath() (string, string, error) {
 }
 
 func ExtractBinaryFromTarGz(archivePath, destDir string) (string, error) {
+	return ExtractBinaryFromTarGzNamed(BinaryName, archivePath, destDir)
+}
+
+// ExtractBinaryFromTarGzNamed extracts the named binary (without any .exe
+// suffix) from a tar.gz release archive into destDir and returns its path.
+// It accepts both the bare name and the name with a .exe suffix so a single
+// reader handles Windows archives carried in a tar.gz.
+func ExtractBinaryFromTarGzNamed(binaryName, archivePath, destDir string) (string, error) {
+	if strings.TrimSpace(binaryName) == "" {
+		binaryName = BinaryName
+	}
 	file, err := os.Open(archivePath)
 	if err != nil {
 		return "", err
@@ -291,7 +348,7 @@ func ExtractBinaryFromTarGz(archivePath, destDir string) (string, error) {
 			continue
 		}
 		name := filepath.Base(hdr.Name)
-		if name != BinaryName && name != BinaryName+".exe" {
+		if name != binaryName && name != binaryName+".exe" {
 			continue
 		}
 		outPath := filepath.Join(destDir, name)
@@ -320,6 +377,15 @@ func ExtractBinaryFromTarGz(archivePath, destDir string) (string, error) {
 }
 
 func ExtractBinaryFromZip(archivePath, destDir string) (string, error) {
+	return ExtractBinaryFromZipNamed(BinaryName, archivePath, destDir)
+}
+
+// ExtractBinaryFromZipNamed extracts the named binary (without any .exe
+// suffix) from a zip release archive into destDir and returns its path.
+func ExtractBinaryFromZipNamed(binaryName, archivePath, destDir string) (string, error) {
+	if strings.TrimSpace(binaryName) == "" {
+		binaryName = BinaryName
+	}
 	reader, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return "", err
@@ -331,7 +397,7 @@ func ExtractBinaryFromZip(archivePath, destDir string) (string, error) {
 			continue
 		}
 		name := filepath.Base(file.Name)
-		if name != BinaryName && name != BinaryName+".exe" {
+		if name != binaryName && name != binaryName+".exe" {
 			continue
 		}
 		rc, err := file.Open()
@@ -598,6 +664,11 @@ func SaveCache(path string, cache *Cache) error {
 }
 
 func DefaultCachePath() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv(EnvCacheDir)); dir != "" {
+		if abs, err := filepath.Abs(dir); err == nil {
+			return filepath.Join(filepath.Clean(abs), "amq", "update.json"), nil
+		}
+	}
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
 		home, err := os.UserHomeDir()
@@ -689,4 +760,57 @@ func IsNoUpdateCheckEnv() bool {
 	default:
 		return false
 	}
+}
+
+// ClassifyInstall determines how the binary at resolvedPath was installed.
+// The path must be the RESOLVED path (EvalSymlinks applied) so a symlink
+// into the Cellar is classified by where it lands, not by the link itself.
+// homebrewPrefix is the detected Homebrew prefix (empty if none); the path
+// is Homebrew-owned when it lives under <prefix>/bin or <prefix>/Cellar.
+// On Windows the path is Scoop-owned when it lives under a scoop apps dir
+// (~/scoop/apps or $SCOOP/apps). Anything else is a direct install.
+func ClassifyInstall(resolvedPath, homebrewPrefix string) InstallKind {
+	if resolvedPath == "" {
+		return InstallDirect
+	}
+	path := filepath.Clean(resolvedPath)
+	if homebrewPrefix != "" {
+		prefix := filepath.Clean(homebrewPrefix)
+		if pathWithinPrefix(path, filepath.Join(prefix, "bin")) ||
+			pathWithinPrefix(path, filepath.Join(prefix, "Cellar")) {
+			return InstallHomebrew
+		}
+	}
+	if appsDir := scoopAppsDir(); appsDir != "" {
+		if pathWithinPrefix(path, appsDir) {
+			return InstallScoop
+		}
+	}
+	return InstallDirect
+}
+
+// pathWithinPrefix reports whether path is equal to or nested inside prefix.
+func pathWithinPrefix(path, prefix string) bool {
+	rel, err := filepath.Rel(filepath.Clean(prefix), path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// scoopAppsDir returns the Scoop apps directory when Scoop is in use, else "".
+// Scoop honors $SCOOP; otherwise it defaults to ~/scoop.
+func scoopAppsDir() string {
+	if scoop := strings.TrimSpace(os.Getenv("SCOOP")); scoop != "" {
+		if abs, err := filepath.Abs(scoop); err == nil {
+			return filepath.Join(filepath.Clean(abs), "apps")
+		}
+	}
+	if runtime.GOOS != "windows" {
+		return ""
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, "scoop", "apps")
+	}
+	return ""
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -2,10 +2,10 @@ package update
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -296,22 +296,37 @@ func TestDefaultCachePathUsesAMQCacheDirPrecedence(t *testing.T) {
 }
 
 func TestDefaultCachePathRefusesInvalidAMQCacheDir(t *testing.T) {
-	t.Run("abs failure", func(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		t.Setenv(EnvCacheDir, "")
+		if _, err := DefaultCachePath(); err == nil || !strings.Contains(err.Error(), "unset AMQ_CACHE_DIR or set it to an absolute cache directory") {
+			t.Fatalf("DefaultCachePath error = %v, want actionable empty-value refusal", err)
+		}
+	})
+	t.Run("relative", func(t *testing.T) {
 		t.Setenv(EnvCacheDir, "relative-cache")
-		oldAbs := absPathForCacheDir
-		absPathForCacheDir = func(string) (string, error) { return "", errors.New("working directory is unavailable") }
-		t.Cleanup(func() { absPathForCacheDir = oldAbs })
-
-		if _, err := DefaultCachePath(); err == nil {
-			t.Fatal("DefaultCachePath accepted an unresolvable AMQ_CACHE_DIR")
+		if _, err := DefaultCachePath(); err == nil || !strings.Contains(err.Error(), "unset AMQ_CACHE_DIR or set it to an absolute cache directory") {
+			t.Fatalf("DefaultCachePath error = %v, want actionable relative-value refusal", err)
 		}
 	})
 	t.Run("whitespace", func(t *testing.T) {
 		t.Setenv(EnvCacheDir, " ")
-		if _, err := DefaultCachePath(); err == nil {
-			t.Fatal("DefaultCachePath accepted a whitespace AMQ_CACHE_DIR")
+		if _, err := DefaultCachePath(); err == nil || !strings.Contains(err.Error(), "unset AMQ_CACHE_DIR or set it to an absolute cache directory") {
+			t.Fatalf("DefaultCachePath error = %v, want actionable whitespace-value refusal", err)
 		}
 	})
+}
+
+func TestDefaultCachePathPreservesSpacesInAbsoluteOverride(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "cache with trailing space ")
+	t.Setenv(EnvCacheDir, override)
+	got, err := DefaultCachePath()
+	if err != nil {
+		t.Fatalf("DefaultCachePath: %v", err)
+	}
+	want := filepath.Join(override, "amq", "update.json")
+	if got != want {
+		t.Fatalf("DefaultCachePath()=%q want %q", got, want)
+	}
 }
 
 func TestSaveCacheWritesToIsolatedDefaultPath(t *testing.T) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,6 +1,10 @@
 package update
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestCompareVersions(t *testing.T) {
 	cases := []struct {
@@ -93,5 +97,133 @@ func TestAssetName(t *testing.T) {
 	}
 	if winName != "amq_0.1.0_windows_amd64.zip" {
 		t.Fatalf("AssetName windows=%q", winName)
+	}
+}
+
+func TestAssetNameForCompanions(t *testing.T) {
+	cases := []struct {
+		binary string
+		goos   string
+		want   string
+	}{
+		{"amq-keepalive", "darwin", "amq-keepalive_0.1.0_darwin_arm64.tar.gz"},
+		{"amq-bridge", "linux", "amq-bridge_0.1.0_linux_amd64.tar.gz"},
+		{"amq-acp", "darwin", "amq-acp_0.1.0_darwin_arm64.tar.gz"},
+	}
+	for _, tc := range cases {
+		name, err := AssetNameFor(tc.binary, "v0.1.0", tc.goos, "arm64")
+		if tc.goos == "linux" {
+			name, err = AssetNameFor(tc.binary, "v0.1.0", tc.goos, "amd64")
+		}
+		if err != nil {
+			t.Fatalf("AssetNameFor(%q): %v", tc.binary, err)
+		}
+		if name != tc.want {
+			t.Fatalf("AssetNameFor(%q)=%q want %q", tc.binary, name, tc.want)
+		}
+	}
+	// The core amq asset matches AssetName exactly.
+	core, err := AssetNameFor("amq", "v0.1.0", "darwin", "arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if core != "amq_0.1.0_darwin_arm64.tar.gz" {
+		t.Fatalf("AssetNameFor(amq)=%q", core)
+	}
+	if _, err := AssetNameFor("", "v0.1.0", "darwin", "arm64"); err == nil {
+		t.Fatal("AssetNameFor(empty binary) want error")
+	}
+	if _, err := AssetNameFor("amq", "", "darwin", "arm64"); err == nil {
+		t.Fatal("AssetNameFor(empty tag) want error")
+	}
+}
+
+func TestClassifyInstall(t *testing.T) {
+	prefix := t.TempDir()
+	binPath := filepath.Join(prefix, "bin", "amq")
+	cellarPath := filepath.Join(prefix, "Cellar", "amq", "0.73.0", "bin", "amq")
+	manualPath := filepath.Join(t.TempDir(), "bin", "amq")
+
+	cases := []struct {
+		name   string
+		path   string
+		prefix string
+		want   InstallKind
+	}{
+		{"cellar binary", cellarPath, prefix, InstallHomebrew},
+		{"prefix bin", binPath, prefix, InstallHomebrew},
+		{"manual install", manualPath, prefix, InstallDirect},
+		{"manual install no prefix", manualPath, "", InstallDirect},
+		{"empty path", "", prefix, InstallDirect},
+		{"cellar path but no prefix detected", cellarPath, "", InstallDirect},
+		// A sibling dir that merely shares a prefix STRING must not match.
+		{"prefix-like sibling", prefix + "-other/bin/amq", prefix, InstallDirect},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyInstall(tc.path, tc.prefix)
+			if got != tc.want {
+				t.Fatalf("ClassifyInstall(%q, %q)=%v want %v", tc.path, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyInstallResolvesSymlinkIntoCellar is the bead's negative case:
+// a symlink INTO the Cellar is classified by its resolved target, so it is
+// Homebrew-owned (the operator must not self-replace through the link).
+func TestClassifyInstallResolvesSymlinkIntoCellar(t *testing.T) {
+	rawPrefix := t.TempDir()
+	// Canonicalize the prefix the way `brew --prefix` would: EvalSymlinks so
+	// /var/folders and /private/var/folders agree on macOS.
+	prefix, err := filepath.EvalSymlinks(rawPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(prefix, "Cellar", "amq", "0.73.0", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("homebrew"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "amq-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ClassifyInstall(resolved, prefix); got != InstallHomebrew {
+		t.Fatalf("ClassifyInstall(resolved symlink into Cellar)=%v want %v", got, InstallHomebrew)
+	}
+}
+
+func TestClassifyInstallScoop(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SCOOP", home)
+	appsDir := filepath.Join(home, "apps", "amq", "current")
+	path := filepath.Join(appsDir, "amq.exe")
+	if got := ClassifyInstall(path, ""); got != InstallScoop {
+		t.Fatalf("ClassifyInstall(scoop apps)=%v want %v", got, InstallScoop)
+	}
+	// Outside the apps dir is direct.
+	other := filepath.Join(home, "bin", "amq.exe")
+	if got := ClassifyInstall(other, ""); got != InstallDirect {
+		t.Fatalf("ClassifyInstall(non-scoop)=%v want %v", got, InstallDirect)
+	}
+}
+
+func TestClassifyInstallLinuxbrew(t *testing.T) {
+	for _, prefix := range []string{"/home/linuxbrew/.linuxbrew", "/home/u/.linuxbrew"} {
+		cellarPath := filepath.Join(prefix, "Cellar", "amq", "0.73.0", "bin", "amq")
+		if got := ClassifyInstall(cellarPath, prefix); got != InstallHomebrew {
+			t.Fatalf("ClassifyInstall(%q, %q)=%v want %v", cellarPath, prefix, got, InstallHomebrew)
+		}
+		binPath := filepath.Join(prefix, "bin", "amq")
+		if got := ClassifyInstall(binPath, prefix); got != InstallHomebrew {
+			t.Fatalf("ClassifyInstall(%q, %q)=%v want %v", binPath, prefix, got, InstallHomebrew)
+		}
 	}
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,9 +1,13 @@
 package update
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestCompareVersions(t *testing.T) {
@@ -136,6 +140,16 @@ func TestAssetNameForCompanions(t *testing.T) {
 	if _, err := AssetNameFor("amq", "", "darwin", "arm64"); err == nil {
 		t.Fatal("AssetNameFor(empty tag) want error")
 	}
+	for _, binary := range []string{"../amq", `amq\escape`, "amq/escape", "amq.exe"} {
+		if _, err := AssetNameFor(binary, "v0.1.0", "darwin", "arm64"); err == nil {
+			t.Fatalf("AssetNameFor(%q) want invalid binary error", binary)
+		}
+	}
+	for _, tag := range []string{"../../victim", "v0.1", "v01.2.3", "v0.1.0/escape", "v0.1.0?bad"} {
+		if _, err := AssetNameFor("amq", tag, "darwin", "arm64"); err == nil {
+			t.Fatalf("AssetNameFor tag %q want invalid release error", tag)
+		}
+	}
 }
 
 func TestClassifyInstall(t *testing.T) {
@@ -151,7 +165,7 @@ func TestClassifyInstall(t *testing.T) {
 		want   InstallKind
 	}{
 		{"cellar binary", cellarPath, prefix, InstallHomebrew},
-		{"prefix bin", binPath, prefix, InstallHomebrew},
+		{"regular prefix bin remains ambiguous", binPath, prefix, InstallDirect},
 		{"manual install", manualPath, prefix, InstallDirect},
 		{"manual install no prefix", manualPath, "", InstallDirect},
 		{"empty path", "", prefix, InstallDirect},
@@ -200,7 +214,40 @@ func TestClassifyInstallResolvesSymlinkIntoCellar(t *testing.T) {
 	}
 }
 
+func TestClassifyInstallAgainstPrefixesFindsAnyCellar(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	path := filepath.Join(second, "Cellar", "amq", "0.73.0", "bin", "amq")
+	if got := ClassifyInstallAgainstPrefixes(path, []string{first, second}); got != InstallHomebrew {
+		t.Fatalf("ClassifyInstallAgainstPrefixes(%q)=%v want %v", path, got, InstallHomebrew)
+	}
+}
+
+func TestClassifyInstallDoesNotTreatDirectSymlinkInHomebrewBinAsOwned(t *testing.T) {
+	prefix := t.TempDir()
+	target := filepath.Join(t.TempDir(), "versions", "amq")
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("direct"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(prefix, "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if got := ClassifyInstall(link, prefix); got != InstallDirect {
+		t.Fatalf("ClassifyInstall(%q, %q)=%v want direct", link, prefix, got)
+	}
+}
+
 func TestClassifyInstallScoop(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Scoop classification is Windows-only")
+	}
 	home := t.TempDir()
 	t.Setenv("SCOOP", home)
 	appsDir := filepath.Join(home, "apps", "amq", "current")
@@ -222,8 +269,76 @@ func TestClassifyInstallLinuxbrew(t *testing.T) {
 			t.Fatalf("ClassifyInstall(%q, %q)=%v want %v", cellarPath, prefix, got, InstallHomebrew)
 		}
 		binPath := filepath.Join(prefix, "bin", "amq")
-		if got := ClassifyInstall(binPath, prefix); got != InstallHomebrew {
-			t.Fatalf("ClassifyInstall(%q, %q)=%v want %v", binPath, prefix, got, InstallHomebrew)
+		if got := ClassifyInstall(binPath, prefix); got != InstallDirect {
+			t.Fatalf("ClassifyInstall(%q, %q)=%v want %v for a regular-file path", binPath, prefix, got, InstallDirect)
 		}
+	}
+}
+
+func TestDefaultCachePathUsesAMQCacheDirPrecedence(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv(EnvCacheDir, override)
+	oldUserCacheDir := userCacheDirForUpdate
+	userCacheDirForUpdate = func() (string, error) {
+		t.Fatal("DefaultCachePath consulted the platform cache despite AMQ_CACHE_DIR")
+		return "", nil
+	}
+	t.Cleanup(func() { userCacheDirForUpdate = oldUserCacheDir })
+
+	got, err := DefaultCachePath()
+	if err != nil {
+		t.Fatalf("DefaultCachePath: %v", err)
+	}
+	want := filepath.Join(override, "amq", "update.json")
+	if got != want {
+		t.Fatalf("DefaultCachePath()=%q want %q", got, want)
+	}
+}
+
+func TestDefaultCachePathRefusesInvalidAMQCacheDir(t *testing.T) {
+	t.Run("abs failure", func(t *testing.T) {
+		t.Setenv(EnvCacheDir, "relative-cache")
+		oldAbs := absPathForCacheDir
+		absPathForCacheDir = func(string) (string, error) { return "", errors.New("working directory is unavailable") }
+		t.Cleanup(func() { absPathForCacheDir = oldAbs })
+
+		if _, err := DefaultCachePath(); err == nil {
+			t.Fatal("DefaultCachePath accepted an unresolvable AMQ_CACHE_DIR")
+		}
+	})
+	t.Run("whitespace", func(t *testing.T) {
+		t.Setenv(EnvCacheDir, " ")
+		if _, err := DefaultCachePath(); err == nil {
+			t.Fatal("DefaultCachePath accepted a whitespace AMQ_CACHE_DIR")
+		}
+	})
+}
+
+func TestSaveCacheWritesToIsolatedDefaultPath(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv(EnvCacheDir, override)
+	path, err := DefaultCachePath()
+	if err != nil {
+		t.Fatalf("DefaultCachePath: %v", err)
+	}
+	want := &Cache{CheckedAt: time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC), LatestVersion: "v0.1.0"}
+	if err := SaveCache(path, want); err != nil {
+		t.Fatalf("SaveCache: %v", err)
+	}
+	got, err := LoadCache(path)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if got == nil || !got.CheckedAt.Equal(want.CheckedAt) || got.LatestVersion != want.LatestVersion {
+		t.Fatalf("cache = %#v want %#v", got, want)
+	}
+}
+
+func TestDownloadReleaseAssetRejectsUnsafeAssetBeforeNetwork(t *testing.T) {
+	if err := DownloadReleaseAsset(context.Background(), nil, "v0.1.0", "../victim", filepath.Join(t.TempDir(), "asset")); err == nil {
+		t.Fatal("DownloadReleaseAsset accepted a traversal asset name")
+	}
+	if err := DownloadReleaseAsset(context.Background(), nil, "v0.1.0/escape", "amq_0.1.0_darwin_arm64.tar.gz", filepath.Join(t.TempDir(), "asset")); err == nil {
+		t.Fatal("DownloadReleaseAsset accepted a traversal release tag")
 	}
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -262,6 +262,54 @@ func TestClassifyInstallScoop(t *testing.T) {
 	}
 }
 
+func TestClassifyInstallScoopScopesWithInjectedRoots(t *testing.T) {
+	userRoot := filepath.Join(t.TempDir(), "user", "apps")
+	globalRoot := filepath.Join(t.TempDir(), "global", "apps")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(globalRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	roots := []ScoopInstallRoot{
+		{Path: userRoot, Scope: ScoopScopeUser},
+		{Path: globalRoot, Scope: ScoopScopeGlobal},
+	}
+	cases := []struct {
+		name string
+		path string
+		want InstallKind
+	}{
+		{"user", filepath.Join(userRoot, "amq", "current", "amq.exe"), InstallScoop},
+		{"global", filepath.Join(globalRoot, "amq", "current", "amq.exe"), InstallScoopGlobal},
+		{"unknown scoop-shaped", filepath.Join(t.TempDir(), "scoop", "apps", "amq", "current", "amq.exe"), InstallScoopUnknown},
+		{"outside", filepath.Join(t.TempDir(), "bin", "amq.exe"), InstallDirect},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInstallAgainstPrefixesAndScoopRoots(tc.path, nil, roots, true)
+			if got != tc.want {
+				t.Fatalf("classifyInstall(%q)=%v want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScoopInstallRootsForWindowsUsesConfiguredScopes(t *testing.T) {
+	userRoot := filepath.Join(t.TempDir(), "user-scoop")
+	globalRoot := filepath.Join(t.TempDir(), "global-scoop")
+	roots := scoopInstallRootsFor("windows", userRoot, globalRoot, t.TempDir())
+	if len(roots) != 2 {
+		t.Fatalf("Scoop roots = %#v, want user and global roots", roots)
+	}
+	if roots[0].Path != filepath.Join(userRoot, "apps") || roots[0].Scope != ScoopScopeUser {
+		t.Fatalf("user Scoop root = %#v", roots[0])
+	}
+	if roots[1].Path != filepath.Join(globalRoot, "apps") || roots[1].Scope != ScoopScopeGlobal {
+		t.Fatalf("global Scoop root = %#v", roots[1])
+	}
+}
+
 func TestClassifyInstallLinuxbrew(t *testing.T) {
 	for _, prefix := range []string{"/home/linuxbrew/.linuxbrew", "/home/u/.linuxbrew"} {
 		cellarPath := filepath.Join(prefix, "Cellar", "amq", "0.73.0", "bin", "amq")


### PR DESCRIPTION
## Summary

`amq upgrade` detects how the running binary was installed (Homebrew Cellar, Scoop apps dir, or direct) from the resolved executable path and delegates to the package manager instead of overwriting a Cellar binary. The new `--all` flag upgrades companion binaries from the same release tag.

## Package-manager detection

`internal/update` gains `InstallKind` (direct | homebrew | scoop) and `ClassifyInstall(resolvedPath, homebrewPrefix)`, decided from the resolved path matching the brew prefix `<prefix>/bin` or `<prefix>/Cellar`, or the Scoop apps dir. A symlink into the Cellar is Cellar-owned (classified by its resolved target). `runUpgrade` classifies from BOTH the resolved path and the pre-resolution path, so a user-made `~/bin/amq -> /opt/homebrew/bin/amq` link classifies as Homebrew. Linuxbrew prefixes (`/home/linuxbrew/.linuxbrew` and `~/.linuxbrew`) are included.

- **Homebrew/Scoop**: prints the delegate command (`brew update` then `brew upgrade amq`, or `scoop update amq`); with `-y` runs it argv-based (no shell, so a future dynamic value cannot inject) and propagates the exit code.
- **Direct**: keeps the existing download + sha256 + atomic-replace path.

## `--all` companions

`--all` upgrades `amq-keepalive`, `amq-bridge`, `amq-acp` present next to a direct-install `amq` or in `~/.local/bin`, from the same release tag with checksum verification. Missing companions are skipped with a line. A symlinked companion is replaced at its resolved target (preserving the link). A running `amq-keepalive` is never killed: the atomic rename swaps the path while the running process keeps the old image; per #672 a running supervisor picks up the new image on its next supervise pass (self-upgrade), and a `--no-self-upgrade` supervisor is restarted with `amq-keepalive install-launchd`. Companions are direct-installed only; `--all` under a package-managed install is a no-op with an explanatory line.

## Cache-poisoning incident + fix (bead ild)

A test driving `runUpgrade` with a stubbed fetch tag wrote `v9.9.9` to the real `~/Library/Caches/amq/update.json`, surfacing a false "update available" on the operator's shell (#646 class). Fixed at the owning layer:
- `DefaultCachePath` honors `AMQ_CACHE_DIR` env before `os.UserCacheDir` (darwin's UserCacheDir ignores HOME).
- `internal/cli` `TestMain` sets `AMQ_CACHE_DIR` + `XDG_CACHE_HOME` to an isolated temp dir.
- Sentinel test `TestUpgradeDoesNotTouchRealCacheWhenIsolated` pre-seeds the real cache path and asserts byte-identity after an upgrade.
- Cache write order: only after download+checksum+replace succeeds; the delegate path writes nothing.
- Fixture versions are `v0.0.0-test` (parses to 0.0.0, never newer than any real release).

## Tests

Classifier (Cellar/bin/manual/scoop/Linuxbrew/symlink-into-Cellar/prefix-sibling); direct install → replace; homebrew → delegate with `-y` (argv, zero writes, zero fetches); user symlink → Homebrew; `--all` → companions replaced + missing skipped + keepalive self-upgrade remedy; symlinked companion → target replaced, link preserved; cache sentinel.

## Docs

README "Updating" + INSTALL.md updated (present tense): PM detection/delegation, `--all` semantics, `AMQ_CACHE_DIR` override, keepalive self-upgrade behavior.

Refs beads 3x1 and ild.
