### PR TITLE
fix(cli): isolate nested worktree root discovery

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -105,7 +105,9 @@ Equivalent explicit root form: `--root .agent-mail/<session>`.
 
 That isolation also applies across git worktrees. A relative project root such
 as `{"root":".agent-mail"}` resolves separately inside every worktree, even when
-the session names match. To share a mailbox intentionally, configure the same
+the session names match. A nested or linked worktree under a parent that
+already has `.amqrc` uses its own config or fails closed; it does not adopt
+the parent live queue. To share a mailbox intentionally, configure the same
 absolute `.amqrc` root in each worktree, or remove the relative project config
 and set `AMQ_GLOBAL_ROOT` to one absolute base. Use `amq doctor --ops` when a
 delivery receipt times out; it can name divergent same-session roots when a

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -118,7 +118,9 @@ directory that already owns its config is the project root. A parent `.amqrc`
 found above an explicit project root (or a cwd that owns its config) is
 ignored, not adopted, so the parent tree stays byte-identical; the implicit
 case still refuses an upward-discovered parent `.amqrc` with the parent path
-named.
+named. A nested or linked Git worktree is the same ceiling without the flag:
+discovery uses that worktree's own config or fails closed, and does not adopt
+the parent live base root.
 
 ```json
 {

--- a/docs/session-routing.md
+++ b/docs/session-routing.md
@@ -10,9 +10,11 @@ exact root and `AM_SESSION` is empty. Do not set the identity tokens manually.
 
 Root precedence is explicit `--root`, `AM_ROOT`, project `.amqrc`,
 `AMQ_GLOBAL_ROOT`, then eligible implicit fallbacks. Within a Git checkout,
-only repo-local implicit state is eligible. An unreadable or invalid project
-`.amqrc` blocks lower-precedence fallback; an explicit `--root` or `AM_ROOT`
-can override it intentionally.
+only repo-local implicit state is eligible. A nested or linked Git worktree
+is its own discovery ceiling: a parent checkout's `.amqrc` or `.agent-mail`
+is not adopted. An unreadable or invalid project `.amqrc` blocks
+lower-precedence fallback; an explicit `--root` or `AM_ROOT` can override it
+intentionally.
 
 A direct `--root` selects a queue. It is not a federation route. `send` refuses
 an explicit root in a different base tree when the caller has an active

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -417,10 +417,17 @@ func absPath(path string) string {
 
 func findRootInParents(startDir, relative string) (string, bool) {
 	dir := startDir
+	ceiling := ""
+	if top, insideGit := gitWorktreeRootFrom(startDir); insideGit {
+		ceiling = top
+	}
 	for {
 		candidate := filepath.Join(dir, relative)
 		if dirExists(candidate) {
 			return absPath(candidate), true
+		}
+		if ceiling != "" && sameCleanPath(dir, ceiling) {
+			break
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -416,11 +416,14 @@ func absPath(path string) string {
 }
 
 func findRootInParents(startDir, relative string) (string, bool) {
-	dir := startDir
 	ceiling := ""
 	if top, insideGit := gitWorktreeRootFrom(startDir); insideGit {
 		ceiling = top
+		if resolved, resolveErr := filepath.EvalSymlinks(startDir); resolveErr == nil {
+			startDir = resolved
+		}
 	}
+	dir := startDir
 	for {
 		candidate := filepath.Join(dir, relative)
 		if dirExists(candidate) {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -590,11 +590,27 @@ func gitWorktreeRootFromCWD() (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	if resolved, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
-		cwd = resolved
+	return gitWorktreeRootFrom(cwd)
+}
+
+// gitWorktreeRootFrom returns the innermost Git worktree or bare-repository
+// boundary that contains path. A nested or linked worktree is its own
+// ceiling, so a parent checkout's .amqrc or .agent-mail is not inferred.
+func gitWorktreeRootFrom(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+	path = abs
+	if resolved, resolveErr := filepath.EvalSymlinks(path); resolveErr == nil {
+		path = resolved
 	}
 	bareCandidate := ""
-	for dir := cwd; ; dir = filepath.Dir(dir) {
+	for dir := path; ; dir = filepath.Dir(dir) {
 		marker := filepath.Join(dir, ".git")
 		_, statErr := gitMarkerLstat(marker)
 		if statErr == nil {
@@ -1075,8 +1091,12 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 		if absErr != nil {
 			return amqrcResult{}, absErr
 		}
+		ceiling := ""
+		if top, insideGit := gitWorktreeRootFrom(absRoot); insideGit {
+			ceiling = top
+		}
 		dir := absRoot
-		for !isHomeConfigDir(dir) {
+		for ceiling != "" || !isHomeConfigDir(dir) {
 			rcPath := filepath.Join(dir, ".amqrc")
 			if info, statErr := amqrcLstat(rcPath); statErr == nil {
 				if err := validateAmqrcInfo(rcPath, info); err != nil {
@@ -1100,6 +1120,9 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 			if !os.IsNotExist(readErr) {
 				// Permission or I/O error — report it, don't mask it.
 				return amqrcResult{}, fmt.Errorf("cannot read .amqrc at %s: %w", rcPath, readErr)
+			}
+			if ceiling != "" && sameCleanPath(dir, ceiling) {
+				break
 			}
 			parent := filepath.Dir(dir)
 			if parent == dir {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1094,6 +1094,9 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 		ceiling := ""
 		if top, insideGit := gitWorktreeRootFrom(absRoot); insideGit {
 			ceiling = top
+			if resolved, resolveErr := filepath.EvalSymlinks(absRoot); resolveErr == nil {
+				absRoot = resolved
+			}
 		}
 		dir := absRoot
 		for ceiling != "" || !isHomeConfigDir(dir) {

--- a/internal/cli/nested_worktree_discovery_test.go
+++ b/internal/cli/nested_worktree_discovery_test.go
@@ -96,6 +96,52 @@ func TestNestedWorktreeDoesNotAdoptParentLiveBaseRoot(t *testing.T) {
 		assertDoesNotAdoptParentLiveRoot(t, parent, parentMail, nested)
 	})
 
+	t.Run("symlinked path into nested worktree does not adopt parent", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedIndependentWorktree(t)
+		if err := os.MkdirAll(filepath.Join(nested, defaultCoopRoot, "agents"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		alias := filepath.Join(parent, "alias")
+		if err := os.Symlink(nested, alias); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		aliasAbs, err := filepath.Abs(alias)
+		if err != nil {
+			t.Fatal(err)
+		}
+		enterIsolatedDiscoveryCwd(t, alias)
+		t.Setenv("PWD", aliasAbs)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sameCleanPath(cwd, nested) {
+			t.Fatalf("os.Getwd resolved the alias to %s; need logical $PWD to exercise the ceiling comparison", cwd)
+		}
+
+		if got := resolveRoot(defaultCoopRoot); sameTreeIdentity(got, parentMail) {
+			t.Fatalf("resolveRoot(%q) from symlinked cwd adopted parent live queue %s", defaultCoopRoot, parentMail)
+		}
+		if found, ok := findRootInParents(cwd, defaultCoopRoot); ok && sameTreeIdentity(found, parentMail) {
+			t.Fatalf("findRootInParents via symlinked path escaped the ceiling: %s", found)
+		}
+		root, _, _, err := resolveEnvConfigWithSource("", "")
+		if err != nil {
+			t.Fatalf("resolveEnvConfigWithSource from alias: %v", err)
+		}
+		expectSamePath(t, root, filepath.Join(nested, defaultCoopRoot))
+		if sameTreeIdentity(root, parentMail) {
+			t.Fatalf("adopted parent live base root %s via symlink", parentMail)
+		}
+		if result, findErr := findAmqrcForRoot(filepath.Join(cwd, defaultCoopRoot)); findErr == nil {
+			t.Fatalf("findAmqrcForRoot via symlinked path adopted %s", result.Path)
+		} else if !errors.Is(findErr, errAmqrcNotFound) {
+			t.Fatalf("findAmqrcForRoot via symlink = %v, want errAmqrcNotFound", findErr)
+		}
+		assertParentMailUnchanged(t, parent, parentMail)
+	})
+
 	t.Run("relative .agent-mail does not walk into parent live queue", func(t *testing.T) {
 		parent, parentMail, nested := seedParentWithNestedIndependentWorktree(t)
 		enterIsolatedDiscoveryCwd(t, nested)

--- a/internal/cli/nested_worktree_discovery_test.go
+++ b/internal/cli/nested_worktree_discovery_test.go
@@ -1,0 +1,297 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+// leftover after #663: a nested/linked worktree under a parent that already
+// owns .amqrc must not silently adopt the parent live base root. #663 covered
+// amq setup --project-root (and cwd-owned .amq/launch.json). Omri on v0.73.0
+// still reported the same discovery seam for a nested checkout that is itself
+// a worktree, not a scratch subdirectory.
+
+func TestNestedWorktreeDoesNotAdoptParentLiveBaseRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for nested worktree discovery tests")
+	}
+
+	t.Run("nested independent checkout without local config fails closed", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedIndependentWorktree(t)
+		enterIsolatedDiscoveryCwd(t, nested)
+		assertDoesNotAdoptParentLiveRoot(t, parent, parentMail, nested)
+	})
+
+	t.Run("nested linked worktree without local config fails closed", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedLinkedWorktree(t, false)
+		enterIsolatedDiscoveryCwd(t, nested)
+		assertDoesNotAdoptParentLiveRoot(t, parent, parentMail, nested)
+	})
+
+	t.Run("nested linked worktree with own relative .amqrc stays local", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedLinkedWorktree(t, true)
+		enterIsolatedDiscoveryCwd(t, nested)
+
+		result, err := findAndLoadAmqrc()
+		if err != nil {
+			t.Fatalf("findAndLoadAmqrc: %v", err)
+		}
+		if !sameTreeIdentity(result.Dir, nested) {
+			t.Fatalf("findAndLoadAmqrc resolved %s, want nested worktree %s", result.Dir, nested)
+		}
+
+		root, source, _, err := resolveEnvConfigWithSource("", "")
+		if err != nil {
+			t.Fatalf("resolveEnvConfigWithSource: %v", err)
+		}
+		want := filepath.Join(nested, defaultCoopRoot)
+		expectSamePath(t, root, want)
+		if source != rootSourceProjectRC {
+			t.Fatalf("source = %q, want %q", source, rootSourceProjectRC)
+		}
+		if sameTreeIdentity(root, parentMail) {
+			t.Fatalf("adopted parent live base root %s", parentMail)
+		}
+
+		discovered, found, err := resolveDiscoveredBaseRoot()
+		if err != nil || !found {
+			t.Fatalf("resolveDiscoveredBaseRoot found=%v err=%v", found, err)
+		}
+		expectSamePath(t, discovered, want)
+
+		stdout, _, envErr := captureEnvOutput(t, func() error {
+			return runEnv([]string{"--me", "claude", "--json"})
+		})
+		if envErr != nil {
+			t.Fatalf("amq env: %v", envErr)
+		}
+		var out envOutput
+		if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+			t.Fatalf("env json: %v\n%s", err, stdout)
+		}
+		expectSamePath(t, out.Root, want)
+		if sameTreeIdentity(out.BaseRoot, parentMail) || sameTreeIdentity(out.Root, parentMail) {
+			t.Fatalf("amq env adopted parent live root: %+v", out)
+		}
+
+		assertParentMailUnchanged(t, parent, parentMail)
+	})
+
+	t.Run("nested checkout with cwd-owned launch.json does not adopt parent", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedIndependentWorktree(t)
+		if err := os.MkdirAll(filepath.Join(nested, ".amq"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(nested, setupConfigPath), []byte(`{"schema":1,"default_session":"collab","agents":[{"handle":"claude","adapter":"claude","command":["claude"]}]}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		enterIsolatedDiscoveryCwd(t, nested)
+		assertDoesNotAdoptParentLiveRoot(t, parent, parentMail, nested)
+	})
+
+	t.Run("relative .agent-mail does not walk into parent live queue", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedIndependentWorktree(t)
+		enterIsolatedDiscoveryCwd(t, nested)
+
+		if got := resolveRoot(defaultCoopRoot); sameTreeIdentity(got, parentMail) {
+			t.Fatalf("resolveRoot(%q) adopted parent live queue %s", defaultCoopRoot, parentMail)
+		}
+		if found, ok := findRootInParents(nested, defaultCoopRoot); ok {
+			t.Fatalf("findRootInParents crossed nested worktree ceiling to %s", found)
+		}
+
+		t.Setenv(envRoot, defaultCoopRoot)
+		root, _, _, err := resolveEnvConfigWithSource("", "")
+		if err != nil {
+			t.Fatalf("AM_ROOT=%s: %v", defaultCoopRoot, err)
+		}
+		expectSamePath(t, root, filepath.Join(nested, defaultCoopRoot))
+		if sameTreeIdentity(root, parentMail) {
+			t.Fatalf("relative AM_ROOT adopted parent live base root %s", parentMail)
+		}
+
+		if _, err := findAmqrcForRoot(filepath.Join(nested, defaultCoopRoot)); !errors.Is(err, errAmqrcNotFound) {
+			t.Fatalf("findAmqrcForRoot from nested queue path = %v, want errAmqrcNotFound", err)
+		}
+		assertParentMailUnchanged(t, parent, parentMail)
+	})
+
+	t.Run("setup without --project-root stays in nested worktree", func(t *testing.T) {
+		parent, parentMail, nested := seedParentWithNestedIndependentWorktree(t)
+		parentAmqrcBefore, err := os.ReadFile(filepath.Join(parent, ".amqrc"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		parentMailBefore := setupTreeDigest(t, parentMail)
+		enterIsolatedDiscoveryCwd(t, nested)
+		installSetupHarness(t)
+
+		_, err = captureEnvStdout(t, func() error {
+			return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--json"})
+		})
+		if err != nil {
+			t.Fatalf("setup from nested worktree: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(nested, ".amqrc")); statErr != nil {
+			t.Fatalf("nested setup did not write local .amqrc: %v", statErr)
+		}
+		if after, readErr := os.ReadFile(filepath.Join(parent, ".amqrc")); readErr != nil || string(after) != string(parentAmqrcBefore) {
+			t.Fatalf("parent .amqrc changed: before=%q after=%q err=%v", parentAmqrcBefore, after, readErr)
+		}
+		if after := setupTreeDigest(t, parentMail); after != parentMailBefore {
+			t.Fatalf("parent live base root mutated during nested setup")
+		}
+	})
+}
+
+func seedParentWithLiveQueue(t *testing.T) (parent, parentMail string) {
+	t.Helper()
+	workspace := t.TempDir()
+	parent = filepath.Join(workspace, "parent")
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parentMail = filepath.Join(parent, defaultCoopRoot)
+	if err := os.MkdirAll(filepath.Join(parentMail, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, ".amqrc"), []byte(`{"root":".agent-mail","project":"parent"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("parent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, parent, "init")
+	runGitForTest(t, parent, "add", "README.md")
+	runGitForTest(t, parent, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-m", "parent")
+	return parent, parentMail
+}
+
+func seedParentWithNestedIndependentWorktree(t *testing.T) (parent, parentMail, nested string) {
+	t.Helper()
+	parent, parentMail = seedParentWithLiveQueue(t)
+	nested = filepath.Join(parent, "nested", "checkout")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "README.md"), []byte("nested\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, nested, "init")
+	runGitForTest(t, nested, "add", "README.md")
+	runGitForTest(t, nested, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-m", "nested")
+	return parent, parentMail, nested
+}
+
+func seedParentWithNestedLinkedWorktree(t *testing.T, commitAmqrc bool) (parent, parentMail, nested string) {
+	t.Helper()
+	parent, parentMail = seedParentWithLiveQueue(t)
+	if commitAmqrc {
+		runGitForTest(t, parent, "add", ".amqrc")
+		runGitForTest(t, parent, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-m", "amqrc")
+	}
+	nested = filepath.Join(parent, "nested", "linked")
+	if err := os.MkdirAll(filepath.Dir(nested), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, parent, "worktree", "add", "-b", "linked", nested)
+	return parent, parentMail, nested
+}
+
+func enterIsolatedDiscoveryCwd(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	for _, key := range []string{envRoot, envBaseRoot, envSession, envRootID, envBaseRootID, envMe, envGlobalRoot} {
+		setOptionalEnv(t, key, "", false)
+	}
+	t.Chdir(dir)
+	resetAmqrcCache()
+	t.Cleanup(resetAmqrcCache)
+}
+
+func assertDoesNotAdoptParentLiveRoot(t *testing.T, parent, parentMail, nested string) {
+	t.Helper()
+	parentMailBefore := setupTreeDigest(t, parentMail)
+
+	if _, err := findAndLoadAmqrc(); err == nil || !errors.Is(err, errAmqrcNotFound) {
+		if err == nil {
+			t.Fatal("findAndLoadAmqrc adopted a parent .amqrc from a nested worktree")
+		}
+		t.Fatalf("findAndLoadAmqrc = %v, want errAmqrcNotFound", err)
+	}
+	if got := detectAgentMailDir(); got != "" {
+		t.Fatalf("detectAgentMailDir = %q, want empty", got)
+	}
+
+	_, _, _, err := resolveEnvConfigWithSource("", "")
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("resolveEnvConfigWithSource err = %v, want context mismatch", err)
+	}
+	if !strings.Contains(err.Error(), nested) {
+		t.Fatalf("refusal must name the nested worktree %s: %v", nested, err)
+	}
+	if strings.Contains(err.Error(), parentMail) {
+		t.Fatalf("refusal leaked parent live root %s: %v", parentMail, err)
+	}
+
+	if _, found, err := resolveDiscoveredBaseRoot(); err == nil || found || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("resolveDiscoveredBaseRoot found=%v err=%v, want context mismatch", found, err)
+	}
+	if _, err := resolveDefaultRoot(); err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("resolveDefaultRoot err = %v, want context mismatch", err)
+	}
+
+	stdout, _, envErr := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--me", "claude", "--json"})
+	})
+	if envErr == nil || GetExitCode(envErr) != ExitContextMismatch || stdout != "" {
+		t.Fatalf("amq env stdout=%q err=%v, want empty stdout and exit 5", stdout, envErr)
+	}
+
+	if after := setupTreeDigest(t, parentMail); after != parentMailBefore {
+		t.Fatalf("parent live base root mutated during nested discovery")
+	}
+	assertParentMailUnchanged(t, parent, parentMail)
+}
+
+func assertParentMailUnchanged(t *testing.T, parent, parentMail string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(parent, ".amqrc")); err != nil {
+		t.Fatalf("parent .amqrc missing: %v", err)
+	}
+	if _, err := os.Stat(parentMail); err != nil {
+		t.Fatalf("parent live queue missing: %v", err)
+	}
+}
+
+func installSetupHarness(t *testing.T) {
+	t.Helper()
+	setupHarnessAdapters = func() []launch.HarnessAdapter {
+		return []launch.HarnessAdapter{setupFixtureAdapter{name: "claude"}}
+	}
+	setupLookPath = func(string) (string, error) { return "", os.ErrNotExist }
+	setupCmuxAvailable = func() bool { return false }
+	setupGhosttyAvailable = func() bool { return false }
+	setupCommitStepHook = nil
+	t.Cleanup(func() {
+		setupHarnessAdapters = func() []launch.HarnessAdapter {
+			return []launch.HarnessAdapter{
+				launch.NewClaudeAdapter(launch.ClaudeProvider),
+				launch.NewCodexAdapter(launch.CodexProvider),
+				launch.NewCursorAdapter(setupCursorCommand()),
+				launch.NewGrokAdapter(launch.GrokProvider),
+			}
+		}
+		setupLookPath = execLookPathForSetup
+		setupCmuxAvailable = setupCmuxAvailableDefault
+		setupGhosttyAvailable = setupGhosttyAvailableDefault
+		setupCommitStepHook = nil
+	})
+}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -131,7 +131,10 @@ worktree's machine-local `.amqrc`, or remove the project-relative `.amqrc` and
 set `AMQ_GLOBAL_ROOT` to one absolute base. Keep the relative default when
 per-worktree isolation is intended. A Git worktree with neither local
 configuration nor a local queue fails closed instead of inheriting
-`~/.amqrc`; this prevents accidental cross-project delivery.
+`~/.amqrc`; this prevents accidental cross-project delivery. A nested or
+linked worktree under a parent that already has `.amqrc` is the same
+fail-closed ceiling: it uses its own config or refuses, and does not adopt
+the parent live queue.
 
 ## Task Routing
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#663 closed #648 for `amq setup --project-root` (explicit beats inferred; parent `.amqrc` ignored). Omri on v0.73.0 still reported the same discovery seam for a **nested git worktree** / nested checkout that is itself a worktree, not a scratch subdirectory: cwd under a parent that already has `.amqrc` could adopt the parent live base root.

## What was actually left

`.amqrc` / `.agent-mail` walk-up already stopped at the innermost `.git`. The leftover was the **relative-root** walk (`resolveRoot` → `findRootInParents`) and `findAmqrcForRoot`, which had no git ceiling. A relative `.agent-mail` or a queue path inside a nested/linked worktree could still resolve to the parent live queue.

Scratch subdirs inside the **same** worktree are unchanged (v0.61 / #663 implicit case). A nested or linked worktree is its own ceiling: own config wins, otherwise fail closed. No new config format.

## Changes

- Share `gitWorktreeRootFrom` and apply that ceiling to `findRootInParents` and `findAmqrcForRoot`
- **5381d96 (review):** `EvalSymlinks` the walk start when a ceiling exists, matching `findAndLoadAmqrc` / `detectAgentMailDir`, so a logical `$PWD` through a symlink cannot skip the break and adopt the parent live queue
- Regression: nested independent checkout, nested linked worktree, and a **symlinked path component** into the nested worktree do not adopt the parent live base root
- Existing #663 `--project-root` / symlink-refuse tests kept

## Cloud VM named check (5381d96)

```text
$ go test ./internal/cli -count=1 -timeout 30s -v -run 'TestNestedWorktreeDoesNotAdoptParentLiveBaseRoot'
--- PASS: TestNestedWorktreeDoesNotAdoptParentLiveBaseRoot (0.32s)
    --- PASS: .../symlinked_path_into_nested_worktree_does_not_adopt_parent (0.04s)
PASS
ok  	github.com/avivsinai/agent-message-queue/internal/cli	0.320s
```

Does not stack on #673 / #674 / #675. Does not merge or tag a release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d267c47a-be74-4a14-9c97-3dddac7d21b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d267c47a-be74-4a14-9c97-3dddac7d21b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

