### PR TITLE
feat(selfupgrade): crash-loop guard and darwin stage identity checks

### DIFF
--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -133,10 +133,12 @@ and an absent or unparsable incumbent version disables self-upgrade. Versioned
 omits the recorded `-ldflags` metadata required for discovery. A candidate must
 also have different bytes from the running image and must pass the same
 ownership, mode, identity, and hash checks used by wake self-upgrade. An image
-whose build-info region cannot be read defers; readable metadata does not prove
-that the rest of the executable is intact. Universal or fat Mach-O input is
-read from its first slice; AMQ release output is single-slice, and supporting
-other slices is a non-goal.
+whose build-info region cannot be read, including a truncated, non-Go, or
+otherwise unknown image, defers the upgrade; readable metadata does not prove
+that the rest of the executable is intact. Keepalive does not invoke the
+candidate with `--version` to discover its version. Universal or fat Mach-O
+input is read from its first slice; AMQ release output is single-slice, and
+supporting other slices is a non-goal.
 
 On Darwin, the private `0700` PID-scoped stage is re-verified immediately
 before pathname exec because Darwin has no `fexecve`; same-UID races in that

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -140,13 +140,11 @@ candidate with `--version` to discover its version. Universal or fat Mach-O
 input is read from its first slice; AMQ release output is single-slice, and
 supporting other slices is a non-goal.
 
-On Darwin, the private `0700` PID-scoped stage is re-verified immediately
-before pathname exec because Darwin has no `fexecve`; same-UID races in that
-narrow window are outside AMQ's threat model, as for wake self-upgrade.
-The bound stage is also checked before AMQ changes the `SIGUSR1` disposition
-with root-owned `/usr/bin/codesign --verify --strict`; a missing, unsafe, or
-failing verifier refuses the replacement. A small final bound-image
-revalidation runs inside the ignored window immediately before exec.
+On Darwin, keepalive stages the candidate in a private `0700` PID-scoped
+directory because Darwin has no `fexecve`. It verifies the bound stage with
+root-owned `/usr/bin/codesign --verify --strict` before pathname exec; a
+missing, unsafe, or failing verifier refuses the replacement. Same-UID races
+after this validation remain outside AMQ's threat model.
 
 The `register` and `attach` commands keep `executablePath()` as their default
 injector path. Only `supervise` derives its default self-upgrade locator from
@@ -163,12 +161,13 @@ upgrade.
 Before `execve`, keepalive records the candidate as an unsettled replacement
 attempt in `.selfupgrade.json` and mirrors the bounded attempt ledger in the
 separate `.selfupgrade.attempts` sidecar. If a later process reaches maintenance
-with a candidate matching that unsettled attempt, it refuses the candidate for
-24 hours to prevent an immediate crash loop. A healthy pass from the attempted
-image settles the attempt. The guard cannot help when the new image dies before
-any replacement process reaches maintenance code. Its bounded eight-entry ledger
-is scoped to the registry directory (`filepath.Dir(registryPath)`) and its
-attempt sidecars; it does not roll back the installed executable.
+with a candidate matching that unsettled attempt, it refuses the candidate while
+the attempt is fresh relative to the recorded timestamp under the current wall
+clock. A healthy pass from the attempted image settles the attempt. The guard
+cannot help when the new image dies before any replacement process reaches
+maintenance code. Its bounded eight-entry ledger is scoped to the registry
+directory (`filepath.Dir(registryPath)`); it does not roll back the installed
+executable.
 
 The primary state-file schema is version 2. New code accepts schema 1 as
 migration input and publishes schema 2 before a protected replacement exec. The
@@ -185,13 +184,13 @@ good package version.
 Reads of the candidate's `-X main.version` linker assignment that fail or
 produce unknown metadata defer and are retried after a later pass. Exec
 failures fail closed and are recorded in the private state files next to the
-registry; each replacement-attempted candidate is refused at most once per
-registry directory during the 24-hour attempt window. A new process generation
-starts with an empty refusal cache. Both state files are mode `0600`; a corrupt
-or unsafe state file is unavailable, disabling self-upgrade at startup and
-deferring a later refresh. Use `supervise --no-self-upgrade` to opt out. The
-durable attempt guard applies per registry directory; the process-local refusal
-cache is separate.
+registry. The durable attempt ledger is bounded per registry directory; an
+unsettled attempt is refused while it is fresh relative to its recorded
+timestamp under the current wall clock. A new process generation starts with
+an empty refusal cache. Both state files are mode `0600`; a corrupt or unsafe
+state file is unavailable, disabling self-upgrade at startup and deferring a
+later refresh. Use `supervise --no-self-upgrade` to opt out. The process-local
+refusal cache is separate from the durable attempt guard.
 
 ### Detached wake stderr protocol
 

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -161,9 +161,14 @@ attempt in `.selfupgrade.json`. If a later process reaches maintenance with a
 candidate matching that unsettled attempt, it refuses the candidate for 24 hours
 to prevent an immediate crash loop. A healthy pass from the attempted image
 settles the attempt. The guard cannot help when the new image dies before any
-replacement process reaches maintenance code. Its 24-hour memory is scoped to
-the keepalive install/state path and its `.selfupgrade.json` sidecar; it does
-not roll back the installed executable.
+replacement process reaches maintenance code. Its bounded eight-entry ledger
+is scoped to the registry directory (`filepath.Dir(registryPath)`) and its
+`.selfupgrade.json` sidecar; it does not roll back the installed executable.
+
+The sidecar schema is version 2. New code accepts schema 1 as migration input
+and publishes schema 2 before a protected replacement exec. Older readers fail
+closed on the schema mismatch, so mixed-version operation can still require
+operator or package-manager recovery.
 
 AMQ does not write the executable or retain the previous image, so it cannot
 roll back a successful replacement. Recovery from a bad installed image is an
@@ -173,9 +178,9 @@ good package version.
 Reads of the candidate's `-X main.version` linker assignment that fail or
 produce unknown metadata defer and are retried after a later pass. Exec
 failures fail closed and are recorded in the private `.selfupgrade.json`
-sidecar next to the registry; each exec-attempted candidate is refused at most
-once per generation. A new process generation starts with an empty refusal
-set. The sidecar is mode `0600`; a corrupt or unsafe sidecar disables
+sidecar next to the registry; each replacement-attempted candidate is refused
+at most once per generation. A new process generation starts with an empty
+refusal set. The sidecar is mode `0600`; a corrupt or unsafe sidecar disables
 self-upgrade for that process. Use
 `supervise --no-self-upgrade` to opt out.
 

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -154,6 +154,15 @@ only when they are not marked close-on-exec. Registry reconciliation must
 finish before this check; an uncertain pass or candidate identity defers the
 upgrade.
 
+Before `execve`, keepalive records the candidate as an unsettled replacement
+attempt in `.selfupgrade.json`. If a later process reaches maintenance with a
+candidate matching that unsettled attempt, it refuses the candidate for 24 hours
+to prevent an immediate crash loop. A healthy pass from the attempted image
+settles the attempt. The guard cannot help when the new image dies before any
+replacement process reaches maintenance code. Its 24-hour memory is scoped to
+the keepalive install/state path and its `.selfupgrade.json` sidecar; it does
+not roll back the installed executable.
+
 AMQ does not write the executable or retain the previous image, so it cannot
 roll back a successful replacement. Recovery from a bad installed image is an
 operator or package-manager action, such as reinstalling or selecting a known

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -143,6 +143,10 @@ supporting other slices is a non-goal.
 On Darwin, the private `0700` PID-scoped stage is re-verified immediately
 before pathname exec because Darwin has no `fexecve`; same-UID races in that
 narrow window are outside AMQ's threat model, as for wake self-upgrade.
+The bound stage is also checked before AMQ changes the `SIGUSR1` disposition
+with root-owned `/usr/bin/codesign --verify --strict`; a missing, unsafe, or
+failing verifier refuses the replacement. A small final bound-image
+revalidation runs inside the ignored window immediately before exec.
 
 The `register` and `attach` commands keep `executablePath()` as their default
 injector path. Only `supervise` derives its default self-upgrade locator from
@@ -157,18 +161,21 @@ finish before this check; an uncertain pass or candidate identity defers the
 upgrade.
 
 Before `execve`, keepalive records the candidate as an unsettled replacement
-attempt in `.selfupgrade.json`. If a later process reaches maintenance with a
-candidate matching that unsettled attempt, it refuses the candidate for 24 hours
-to prevent an immediate crash loop. A healthy pass from the attempted image
-settles the attempt. The guard cannot help when the new image dies before any
-replacement process reaches maintenance code. Its bounded eight-entry ledger
+attempt in `.selfupgrade.json` and mirrors the bounded attempt ledger in the
+separate `.selfupgrade.attempts` sidecar. If a later process reaches maintenance
+with a candidate matching that unsettled attempt, it refuses the candidate for
+24 hours to prevent an immediate crash loop. A healthy pass from the attempted
+image settles the attempt. The guard cannot help when the new image dies before
+any replacement process reaches maintenance code. Its bounded eight-entry ledger
 is scoped to the registry directory (`filepath.Dir(registryPath)`) and its
-`.selfupgrade.json` sidecar; it does not roll back the installed executable.
+attempt sidecars; it does not roll back the installed executable.
 
-The sidecar schema is version 2. New code accepts schema 1 as migration input
-and publishes schema 2 before a protected replacement exec. Older readers fail
-closed on the schema mismatch, so mixed-version operation can still require
-operator or package-manager recovery.
+The primary state-file schema is version 2. New code accepts schema 1 as
+migration input and publishes schema 2 before a protected replacement exec. The
+separate attempt sidecar is written by new code only. An already-running
+schema-1 writer cannot erase an unsettled attempt marker when it rewrites the primary
+file. Older readers fail closed when they reopen schema 2, so mixed-version
+operation can still require operator or package-manager recovery.
 
 AMQ does not write the executable or retain the previous image, so it cannot
 roll back a successful replacement. Recovery from a bad installed image is an
@@ -177,12 +184,14 @@ good package version.
 
 Reads of the candidate's `-X main.version` linker assignment that fail or
 produce unknown metadata defer and are retried after a later pass. Exec
-failures fail closed and are recorded in the private `.selfupgrade.json`
-sidecar next to the registry; each replacement-attempted candidate is refused
-at most once per generation. A new process generation starts with an empty
-refusal set. The sidecar is mode `0600`; a corrupt or unsafe sidecar disables
-self-upgrade for that process. Use
-`supervise --no-self-upgrade` to opt out.
+failures fail closed and are recorded in the private state files next to the
+registry; each replacement-attempted candidate is refused at most once per
+registry directory during the 24-hour attempt window. A new process generation
+starts with an empty refusal cache. Both state files are mode `0600`; a corrupt
+or unsafe state file is unavailable, disabling self-upgrade at startup and
+deferring a later refresh. Use `supervise --no-self-upgrade` to opt out. The
+durable attempt guard applies per registry directory; the process-local refusal
+cache is separate.
 
 ### Detached wake stderr protocol
 

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -622,6 +622,16 @@ schema-2 wake/doctor JSON reports the latest decision under `self_upgrade`.
 The separate `amq-keepalive` supervisor has its own direct-image self-upgrade
 contract documented in `docs/amq-keepalive.md`.
 
+Before the in-place exec, wake writes a private `.wake.selfupgrade.attempt`
+sidecar. If wake exits after the exec before its first quiescent maintenance
+boundary, a later wake that reaches maintenance refuses the matching image for
+24 hours in that wake generation. The guard cannot help when the new image dies
+before any replacement wake reaches the maintenance code. Its 24-hour memory is
+scoped to the wake agent directory. Wake has no KeepAlive supervisor and does
+not retry or roll back the replacement automatically. The first quiescent
+boundary from the attempted image settles the attempt; an operator or package
+manager must restore a known-good image after a refusal.
+
 AMQ does not write the executable or retain the previous image, so neither wake
 self-upgrade path has an in-process rollback. Recovery from a bad installed
 image is an operator or package-manager action, such as reinstalling or

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -627,8 +627,9 @@ contract documented in `docs/amq-keepalive.md`.
 
 Before the in-place exec, wake writes a private `.wake.selfupgrade.attempt`
 sidecar. If wake exits after the exec before its first quiescent maintenance
-boundary, a later wake that reaches maintenance refuses the matching image for
-24 hours in that wake agent directory. The guard cannot help when the new image dies
+boundary, a later wake that reaches maintenance refuses the matching image while
+the attempt is fresh relative to its recorded timestamp under the current wall
+clock. The guard cannot help when the new image dies
 before any replacement wake reaches the maintenance code. Its bounded
 eight-entry ledger is scoped to the wake agent directory. The wake itself has
 no in-process rollback or retry; an external supervisor may restart it. The
@@ -638,8 +639,8 @@ operator or package manager must restore a known-good image after a refusal.
 On Darwin, the bound wake stage is checked with the root-owned
 `/usr/bin/codesign --verify --strict`; a missing, unsafe, or failing verifier
 refuses the restart. Cleanup uses the root-owned `/bin/ps` with a conservative
-command-name check. The expensive signature probe runs while `SIGUSR1` remains
-delivered, followed by a small final bound-image revalidation before exec.
+command-name check. The signature probe runs before wake ignores `SIGUSR1`,
+followed by a small final bound-image revalidation before exec.
 
 The wake attempt sidecar accepts the single-attempt schema 1 as migration input
 and writes the bounded ledger schema 2. A pre-feature wake ignores this marker,

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -628,12 +628,18 @@ contract documented in `docs/amq-keepalive.md`.
 Before the in-place exec, wake writes a private `.wake.selfupgrade.attempt`
 sidecar. If wake exits after the exec before its first quiescent maintenance
 boundary, a later wake that reaches maintenance refuses the matching image for
-24 hours in that wake generation. The guard cannot help when the new image dies
+24 hours in that wake agent directory. The guard cannot help when the new image dies
 before any replacement wake reaches the maintenance code. Its bounded
 eight-entry ledger is scoped to the wake agent directory. The wake itself has
 no in-process rollback or retry; an external supervisor may restart it. The
 first quiescent boundary from the attempted image settles the attempt; an
 operator or package manager must restore a known-good image after a refusal.
+
+On Darwin, the bound wake stage is checked with the root-owned
+`/usr/bin/codesign --verify --strict`; a missing, unsafe, or failing verifier
+refuses the restart. Cleanup uses the root-owned `/bin/ps` with a conservative
+command-name check. The expensive signature probe runs while `SIGUSR1` remains
+delivered, followed by a small final bound-image revalidation before exec.
 
 The wake attempt sidecar accepts the single-attempt schema 1 as migration input
 and writes the bounded ledger schema 2. A pre-feature wake ignores this marker,

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -592,19 +592,22 @@ rule: the incumbent may still use its `Main.Version` fallback, including for
 self-upgrade. Versioned `go install` and `-trimpath` builds are unsupported
 candidates; `-trimpath` omits the recorded `-ldflags` metadata required for
 discovery. The candidate is not executed to discover its version; an image
-whose build-info region cannot be read defers, while readable metadata does not
-prove that the rest of the executable is intact. Universal or fat Mach-O input
-is read from its first slice; AMQ release output is single-slice, and
-supporting other slices is a non-goal. An inconclusive live-image comparison or
-a hash-time identity change defers and retries on the next maintenance tick; it
-does not consume refusal memory.
+whose build-info region cannot be read, including a truncated, non-Go, or
+otherwise unknown image, defers, while readable metadata does not prove that the
+rest of the executable is intact. Wake does not invoke an untrusted candidate
+with `--version` for version discovery. Universal or fat Mach-O input is read
+from its first slice; AMQ release output is single-slice, and supporting other
+slices is a non-goal. An inconclusive live-image comparison or a hash-time
+identity change defers and retries on the next maintenance tick; it does not
+consume refusal memory.
 
-Two child executions remain on the wake side: a post-bind `--version`
-preflight and a launch-contract preflight. Both have a bounded process-group lifetime
-and run only after the image is bound and verified; neither discovers a
-version from an untrusted candidate. A descendant that leaves the process group
-(setsid or setpgid) can escape it, which remains an explicit limitation of
-bounded probe cleanup.
+Two child executions remain on the wake side. A post-bind `--version`
+preflight executes the already verified image to confirm the tentative recorded
+version. A separate launch-contract preflight confirms the exact wake argv and
+bootstrap. Both have a bounded process-group lifetime and run only after the
+image is bound and verified; neither discovers a version from an untrusted
+candidate. A descendant that leaves the process group (setsid or setpgid) can
+escape it, which remains an explicit limitation of bounded probe cleanup.
 
 Darwin treats a still-running, identity-confirmed wake whose recorded path is
 gone (`proc_pidpath` ENOENT or ESRCH after an installer unlink) as a

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -629,11 +629,16 @@ Before the in-place exec, wake writes a private `.wake.selfupgrade.attempt`
 sidecar. If wake exits after the exec before its first quiescent maintenance
 boundary, a later wake that reaches maintenance refuses the matching image for
 24 hours in that wake generation. The guard cannot help when the new image dies
-before any replacement wake reaches the maintenance code. Its 24-hour memory is
-scoped to the wake agent directory. Wake has no KeepAlive supervisor and does
-not retry or roll back the replacement automatically. The first quiescent
-boundary from the attempted image settles the attempt; an operator or package
-manager must restore a known-good image after a refusal.
+before any replacement wake reaches the maintenance code. Its bounded
+eight-entry ledger is scoped to the wake agent directory. The wake itself has
+no in-process rollback or retry; an external supervisor may restart it. The
+first quiescent boundary from the attempted image settles the attempt; an
+operator or package manager must restore a known-good image after a refusal.
+
+The wake attempt sidecar accepts the single-attempt schema 1 as migration input
+and writes the bounded ledger schema 2. A pre-feature wake ignores this marker,
+so mixed-version operation does not provide the new crash-loop protection on
+both faces until both faces run the upgraded code.
 
 AMQ does not write the executable or retain the previous image, so neither wake
 self-upgrade path has an in-process rollback. Recovery from a bad installed

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -674,7 +674,7 @@ func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
 	if err != nil || !committed {
 		return err
 	}
-	if err := removeWakeSelfUpgradeDiagnosticGuarded(inspection.Root, inspection.Agent); err != nil {
+	if err := removeWakeSelfUpgradeArtifactsGuarded(inspection.Root, inspection.Agent); err != nil {
 		_ = writeStderr(
 			"warning: removed wake lock for %s but left diagnostic-only self-upgrade residue: %v\n",
 			inspection.Agent,

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -309,12 +309,12 @@ func removeWakeLockIfUnchangedGuardedAtOutcome(
 	if detachedValidationErr != nil {
 		outcome.Err = newWakeDetachedCleanupOnlyError(detachedValidationErr)
 	}
-	if err := removeWakeSelfUpgradeDiagnosticAt(dirfd); err != nil {
+	if err := removeWakeSelfUpgradeArtifactsAt(dirfd); err != nil {
 		outcome.Err = errors.Join(
 			outcome.Err,
 			newWakeLockResidueError(
 				wakeLockResidueSelfUpgradeDiagnostic,
-				fmt.Errorf("remove wake self-upgrade diagnostic after lock removal: %w", err),
+				fmt.Errorf("remove wake self-upgrade metadata after lock removal: %w", err),
 			),
 		)
 	}

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -559,10 +559,10 @@ func removeAuthoritativeWakeClaimAt(
 	}
 	cleanupErr := preparedSnapshotErr
 	cleaned := false
-	if err := removeWakeSelfUpgradeDiagnosticAt(dirfd); err != nil {
+	if err := removeWakeSelfUpgradeArtifactsAt(dirfd); err != nil {
 		diagnosticCleanupErr := newWakeLockResidueError(
 			wakeLockResidueSelfUpgradeDiagnostic,
-			fmt.Errorf("remove wake self-upgrade diagnostic after authoritative lock release: %w", err),
+			fmt.Errorf("remove wake self-upgrade metadata after authoritative lock release: %w", err),
 		)
 		_ = writeStderr(
 			"warning: removed authoritative wake lock for %s but left diagnostic-only self-upgrade residue: %v\n",

--- a/internal/cli/wake_restart_codesign_darwin.go
+++ b/internal/cli/wake_restart_codesign_darwin.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
+)
+
+var verifyWakeRestartBoundImage = verifyWakeRestartBoundImageDefault
+
+func verifyWakeRestartBoundImagePlatform(image *wakeRestartBoundImage) error {
+	return verifyWakeRestartBoundImage(image)
+}
+
+func verifyWakeRestartBoundImageDefault(image *wakeRestartBoundImage) error {
+	if image == nil || image.file == nil || image.executionPath == "" {
+		return fmt.Errorf("bound Darwin wake restart image is missing")
+	}
+	if err := revalidateBoundWakeRestartImagePlatform(image); err != nil {
+		return err
+	}
+	return selfupgrade.VerifyDarwinCodeSignature(image.executionPath)
+}

--- a/internal/cli/wake_restart_codesign_linux.go
+++ b/internal/cli/wake_restart_codesign_linux.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package cli
+
+func verifyWakeRestartBoundImagePlatform(*wakeRestartBoundImage) error { return nil }

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -22,6 +22,56 @@ func TestDarwinWakeRestartBoundPayload(t *testing.T) {
 	_, _ = os.Stdout.WriteString("BOUND_IMAGE_A\n")
 }
 
+func TestDarwinWakeRestartVerifiesBoundStageBeforeExec(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	writeWakeRestartLoopCandidateCopy(t, &fixture)
+	fixture.record.Source = wakeRestartSourceForeign
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, fixture.record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	verificationCalls := 0
+	execCalls := 0
+	sentinel := errors.New("codesign: invalid signature")
+	previousVerify := verifyWakeRestartBoundImage
+	previousPreflight := wakeRestartBoundPreflight
+	previousExec := wakeRestartExec
+	verifyWakeRestartBoundImage = func(bound *wakeRestartBoundImage) error {
+		verificationCalls++
+		if bound == nil || bound.executionPath == "" {
+			t.Fatalf("verified bound image = %#v", bound)
+		}
+		return sentinel
+	}
+	wakeRestartBoundPreflight = func(*wakeRestartBoundImage, []string, wakeResumeBootstrap) error {
+		return nil
+	}
+	wakeRestartExec = func(string, []string, []string) error {
+		execCalls++
+		return errors.New("unexpected exec")
+	}
+	t.Cleanup(func() {
+		verifyWakeRestartBoundImage = previousVerify
+		wakeRestartBoundPreflight = previousPreflight
+		wakeRestartExec = previousExec
+	})
+	runWakeRestartLoopForTest(t, fixture)
+	if verificationCalls != 1 {
+		t.Fatalf("signature verification calls = %d, want one", verificationCalls)
+	}
+	if execCalls != 0 {
+		t.Fatalf("exec calls = %d, want zero after signature refusal", execCalls)
+	}
+	record := readRefusedWakeRestartForTest(t, fixture)
+	if !strings.Contains(record.Reason, sentinel.Error()) {
+		t.Fatalf("refusal reason = %q, want codesign diagnostic", record.Reason)
+	}
+	if !strings.Contains(record.Reason, errWakeImageRefused.Error()) {
+		t.Fatalf("refusal reason = %q, want the image-refused sentinel", record.Reason)
+	}
+}
+
 func TestDarwinStagedWakeImageCTimeExceptionDoesNotWeakenIdentityOrContent(t *testing.T) {
 	base, err := captureCurrentWakeImageEvidence()
 	if err != nil {

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -37,6 +37,8 @@ func TestDarwinWakeRestartVerifiesBoundStageBeforeExec(t *testing.T) {
 	previousVerify := verifyWakeRestartBoundImage
 	previousPreflight := wakeRestartBoundPreflight
 	previousExec := wakeRestartExec
+	previousIgnore := wakeRestartIgnore
+	ignoreCalls := 0
 	verifyWakeRestartBoundImage = func(bound *wakeRestartBoundImage) error {
 		verificationCalls++
 		if bound == nil || bound.executionPath == "" {
@@ -51,10 +53,12 @@ func TestDarwinWakeRestartVerifiesBoundStageBeforeExec(t *testing.T) {
 		execCalls++
 		return errors.New("unexpected exec")
 	}
+	wakeRestartIgnore = func(...os.Signal) { ignoreCalls++ }
 	t.Cleanup(func() {
 		verifyWakeRestartBoundImage = previousVerify
 		wakeRestartBoundPreflight = previousPreflight
 		wakeRestartExec = previousExec
+		wakeRestartIgnore = previousIgnore
 	})
 	runWakeRestartLoopForTest(t, fixture)
 	if verificationCalls != 1 {
@@ -62,6 +66,9 @@ func TestDarwinWakeRestartVerifiesBoundStageBeforeExec(t *testing.T) {
 	}
 	if execCalls != 0 {
 		t.Fatalf("exec calls = %d, want zero after signature refusal", execCalls)
+	}
+	if ignoreCalls != 0 {
+		t.Fatalf("signal ignore calls = %d, want verifier to run before ignored window", ignoreCalls)
 	}
 	record := readRefusedWakeRestartForTest(t, fixture)
 	if !strings.Contains(record.Reason, sentinel.Error()) {

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -612,6 +612,10 @@ func wakeRestartLoopConfigForTest(fixture wakeRestartFixture) wakeConfig {
 		terminalGeneration: fixture.lock.Lock.Generation,
 		retainedAgent:      fixture.agentDir,
 		retainedInbox:      fixture.inboxDir,
+		selfUpgrade: wakeSelfUpgradeState{
+			Enabled:  true,
+			Eligible: true,
+		},
 		inspectTerminalGeneration: func() wakeLockInspection {
 			return inspectWakeLock(fixture.root, fixture.agent)
 		},

--- a/internal/cli/wake_restart_stage_diagnostic_unix.go
+++ b/internal/cli/wake_restart_stage_diagnostic_unix.go
@@ -192,10 +192,10 @@ func fixWakeRestartResidueWithoutLock(root, agent string) error {
 			return fmt.Errorf("wake lock appeared before restart residue fix; preserving restart state")
 		}
 		var diagnosticErr error
-		if err := removeWakeSelfUpgradeDiagnosticAt(dirfd); err != nil {
+		if err := removeWakeSelfUpgradeArtifactsAt(dirfd); err != nil {
 			diagnosticErr = newWakeLockResidueError(
 				wakeLockResidueSelfUpgradeDiagnostic,
-				fmt.Errorf("remove wake self-upgrade diagnostic after confirming no lock: %w", err),
+				fmt.Errorf("remove wake self-upgrade metadata after confirming no lock: %w", err),
 			)
 		}
 

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -86,6 +86,7 @@ type wakeRestartReadiness struct {
 
 var (
 	errWakeRestartSchemaTooNew = errors.New("wake restart schema is newer than supported")
+	errWakeImageRefused        = errors.New("wake restart image refused")
 
 	wakeRestartNow            = time.Now
 	wakeRestartSleep          = time.Sleep
@@ -1409,6 +1410,12 @@ func executeWakeRestart(
 	// bootstrap installs Notify before it rotates and advertises the successor
 	// generation. If exec fails, restore delivery to the incumbent loop.
 	signal.Ignore(syscall.SIGUSR1)
+	if err := verifyWakeRestartBoundImagePlatform(bound); err != nil {
+		if restartSignals != nil {
+			signal.Notify(restartSignals, syscall.SIGUSR1)
+		}
+		return fmt.Errorf("%w: verify wake restart image signature: %w", errWakeImageRefused, err)
+	}
 	err = wakeRestartExec(bound.executionPath, append([]string(nil), argv...), env)
 	if restartSignals != nil {
 		signal.Notify(restartSignals, syscall.SIGUSR1)
@@ -1652,7 +1659,7 @@ func handleWakeRestartAtLoopBoundary(
 		return
 	}
 	if record.Source == wakeRestartSourceSelf {
-		attempt, attemptErr := persistWakeSelfUpgradeAttemptAtBoundary(agentDir, cfg.inspectTerminalGeneration(), record)
+		attempts, attemptErr := persistWakeSelfUpgradeAttemptAtBoundary(agentDir, cfg.inspectTerminalGeneration(), record)
 		if attemptErr != nil {
 			recordSelfUpgradeDecision(
 				wakeSelfUpgradeActionDeferred,
@@ -1660,7 +1667,7 @@ func handleWakeRestartAtLoopBoundary(
 			)
 			return
 		}
-		cfg.selfUpgrade.attempt = &attempt
+		cfg.selfUpgrade.attempts = attempts
 	}
 	if err := executeWakeRestart(record, os.Args, cfg.terminalImageVersion, cfg.restartSignals); err != nil {
 		if errors.Is(err, errWakeImageChangedWhileHashing) && record.Source == wakeRestartSourceSelf {
@@ -1735,8 +1742,28 @@ func maintainWakeSelfUpgradeAtLoopBoundary(
 		cfg.selfUpgrade.restartPending = false
 	}
 	if cfg.selfUpgrade.Enabled && cfg.selfUpgrade.Eligible {
-		attemptPending := cfg.selfUpgrade.attempt != nil &&
-			cfg.selfUpgrade.attempt.Status == selfupgrade.AttemptStatusAttempt
+		for _, attempt := range cfg.selfUpgrade.attempts {
+			if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(wakeSelfUpgradeNow()) {
+				cfg.selfUpgrade.Eligible = false
+				cfg.selfUpgrade.Reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+				return recordWakeSelfUpgradeDecision(
+					agentDir,
+					cfg.inspectTerminalGeneration(),
+					cfg.selfUpgrade,
+					wakeSelfUpgradeDecision{
+						Action: wakeSelfUpgradeActionIneligible,
+						Reason: cfg.selfUpgrade.Reason,
+					},
+				)
+			}
+		}
+		attemptPending := false
+		for _, attempt := range cfg.selfUpgrade.attempts {
+			if attempt.Status == selfupgrade.AttemptStatusAttempt {
+				attemptPending = true
+				break
+			}
+		}
 		if attemptPending {
 			quiescence := classifyWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
 			if quiescence.Disposition != wakeResumeProceed {

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -1377,6 +1377,7 @@ func executeWakeRestart(
 	argv []string,
 	incumbentVersion string,
 	restartSignals chan os.Signal,
+	armSelfUpgradeAttempt func(wakeRestartRecord) error,
 ) (returnErr error) {
 	bootstrapValue := wakeResumeBootstrap{
 		Schema:             wakeRestartSchemaV1,
@@ -1422,6 +1423,16 @@ func executeWakeRestart(
 			wakeRestartSignalNotify(restartSignals, syscall.SIGUSR1)
 		}
 		return fmt.Errorf("%w: revalidate wake restart image: %w", errWakeImageRefused, err)
+	}
+	// Bind/hash failures must not arm durable crash-loop debt. Arm only after
+	// bound-image validation completes, immediately before process replacement.
+	if armSelfUpgradeAttempt != nil {
+		if err := armSelfUpgradeAttempt(record); err != nil {
+			if restartSignals != nil {
+				wakeRestartSignalNotify(restartSignals, syscall.SIGUSR1)
+			}
+			return fmt.Errorf("arm wake self-upgrade attempt: %w", err)
+		}
 	}
 	err = wakeRestartExec(bound.executionPath, append([]string(nil), argv...), env)
 	if restartSignals != nil {
@@ -1665,18 +1676,70 @@ func handleWakeRestartAtLoopBoundary(
 		recordSelfUpgradeDecision(wakeSelfUpgradeActionRefused, reason)
 		return
 	}
-	if record.Source == wakeRestartSourceSelf {
-		attempts, attemptErr := persistWakeSelfUpgradeAttemptAtBoundary(agentDir, cfg.inspectTerminalGeneration(), record)
-		if attemptErr != nil {
-			recordSelfUpgradeDecision(
-				wakeSelfUpgradeActionDeferred,
-				"replacement attempt was not persisted: "+attemptErr.Error(),
-			)
-			return
+	if record.Source == wakeRestartSourceSelf &&
+		(!cfg.selfUpgrade.Enabled || !cfg.selfUpgrade.Eligible) {
+		reason := cfg.selfUpgrade.Reason
+		if reason == "" {
+			reason = "self-upgrade is unavailable"
 		}
-		cfg.selfUpgrade.attempts = attempts
+		recordSelfUpgradeDecision(wakeSelfUpgradeActionIneligible, reason)
+		return
 	}
-	if err := executeWakeRestart(record, os.Args, cfg.terminalImageVersion, cfg.restartSignals); err != nil {
+	var armSelfUpgradeAttempt func(wakeRestartRecord) error
+	if record.Source == wakeRestartSourceSelf {
+		armSelfUpgradeAttempt = func(boundRecord wakeRestartRecord) error {
+			attempts, err := persistWakeSelfUpgradeAttemptAtBoundary(
+				agentDir,
+				cfg.inspectTerminalGeneration(),
+				boundRecord,
+			)
+			if err == nil {
+				cfg.selfUpgrade.attempts = attempts
+			}
+			return err
+		}
+	}
+	if err := executeWakeRestart(
+		record,
+		os.Args,
+		cfg.terminalImageVersion,
+		cfg.restartSignals,
+		armSelfUpgradeAttempt,
+	); err != nil {
+		if record.Source == wakeRestartSourceSelf {
+			var refusal wakeSelfUpgradeAttemptRefusalError
+			if errors.As(err, &refusal) {
+				reason := wakeRestartReasonWithRemedy(refusal.Error(), cfg.root, cfg.me)
+				refuseErr := refuseWakeRestartRecord(agentDir, record, reason)
+				if refuseErr == nil {
+					cfg.selfUpgrade.refusalPending = nil
+					cfg.selfUpgrade.restartPending = false
+					recordSelfUpgradeDecision(wakeSelfUpgradeActionRefused, reason)
+				} else {
+					cfg.selfUpgrade.refusalPending = &wakeSelfUpgradeRefusalPending{
+						Record: record,
+						Reason: reason,
+					}
+					recordSelfUpgradeDecision(
+						wakeSelfUpgradeActionRefusalPending,
+						fmt.Sprintf("%s; refusal persistence pending: %v", reason, refuseErr),
+					)
+				}
+				return
+			}
+			if errors.Is(err, errWakeSelfUpgradeAttemptTimestampUncertain) {
+				cfg.selfUpgrade.Eligible = false
+				cfg.selfUpgrade.Reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+				recordSelfUpgradeDecision(wakeSelfUpgradeActionIneligible, cfg.selfUpgrade.Reason)
+				return
+			}
+			if errors.Is(err, errWakeSelfUpgradeAttemptNotFresh) {
+				cfg.selfUpgrade.Eligible = false
+				cfg.selfUpgrade.Reason = "self-upgrade unavailable: replacement attempt is not fresh"
+				recordSelfUpgradeDecision(wakeSelfUpgradeActionIneligible, cfg.selfUpgrade.Reason)
+				return
+			}
+		}
 		if errors.Is(err, errWakeImageChangedWhileHashing) && record.Source == wakeRestartSourceSelf {
 			recordSelfUpgradeDecision(
 				wakeSelfUpgradeActionDeferred,

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -95,6 +95,8 @@ var (
 	wakeRestartPreflight      = preflightWakeRestartCandidate
 	wakeRestartBind           = bindWakeRestartCandidateForRecord
 	wakeRestartBoundPreflight = preflightBoundWakeRestartCandidate
+	wakeRestartIgnore         = signal.Ignore
+	wakeRestartSignalNotify   = signal.Notify
 )
 
 func runWakeRestart(args []string) error {
@@ -1406,19 +1408,24 @@ func executeWakeRestart(
 		return err
 	}
 	env := setEnvVar(unsetEnvVar(os.Environ(), envWakeResumeBootstrap), envWakeResumeBootstrap, bootstrap)
+	if err := verifyWakeRestartBoundImagePlatform(bound); err != nil {
+		return fmt.Errorf("%w: verify wake restart image signature: %w", errWakeImageRefused, err)
+	}
 	// An ignored disposition survives exec, unlike a caught disposition. The
 	// bootstrap installs Notify before it rotates and advertises the successor
-	// generation. If exec fails, restore delivery to the incumbent loop.
-	signal.Ignore(syscall.SIGUSR1)
-	if err := verifyWakeRestartBoundImagePlatform(bound); err != nil {
+	// generation. Keep the expensive platform probe outside the ignored window;
+	// only the final bound-image revalidation runs before exec. If exec fails,
+	// restore delivery to the incumbent loop.
+	wakeRestartIgnore(syscall.SIGUSR1)
+	if err := revalidateBoundWakeRestartImagePlatform(bound); err != nil {
 		if restartSignals != nil {
-			signal.Notify(restartSignals, syscall.SIGUSR1)
+			wakeRestartSignalNotify(restartSignals, syscall.SIGUSR1)
 		}
-		return fmt.Errorf("%w: verify wake restart image signature: %w", errWakeImageRefused, err)
+		return fmt.Errorf("%w: revalidate wake restart image: %w", errWakeImageRefused, err)
 	}
 	err = wakeRestartExec(bound.executionPath, append([]string(nil), argv...), env)
 	if restartSignals != nil {
-		signal.Notify(restartSignals, syscall.SIGUSR1)
+		wakeRestartSignalNotify(restartSignals, syscall.SIGUSR1)
 	}
 	if err != nil {
 		return fmt.Errorf("exec wake restart candidate: %w", err)

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
 	"golang.org/x/sys/unix"
 )
 
@@ -1650,6 +1651,17 @@ func handleWakeRestartAtLoopBoundary(
 		recordSelfUpgradeDecision(wakeSelfUpgradeActionRefused, reason)
 		return
 	}
+	if record.Source == wakeRestartSourceSelf {
+		attempt, attemptErr := persistWakeSelfUpgradeAttemptAtBoundary(agentDir, cfg.inspectTerminalGeneration(), record)
+		if attemptErr != nil {
+			recordSelfUpgradeDecision(
+				wakeSelfUpgradeActionDeferred,
+				"replacement attempt was not persisted: "+attemptErr.Error(),
+			)
+			return
+		}
+		cfg.selfUpgrade.attempt = &attempt
+	}
 	if err := executeWakeRestart(record, os.Args, cfg.terminalImageVersion, cfg.restartSignals); err != nil {
 		if errors.Is(err, errWakeImageChangedWhileHashing) && record.Source == wakeRestartSourceSelf {
 			recordSelfUpgradeDecision(
@@ -1723,6 +1735,35 @@ func maintainWakeSelfUpgradeAtLoopBoundary(
 		cfg.selfUpgrade.restartPending = false
 	}
 	if cfg.selfUpgrade.Enabled && cfg.selfUpgrade.Eligible {
+		attemptPending := cfg.selfUpgrade.attempt != nil &&
+			cfg.selfUpgrade.attempt.Status == selfupgrade.AttemptStatusAttempt
+		if attemptPending {
+			quiescence := classifyWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
+			if quiescence.Disposition != wakeResumeProceed {
+				return recordWakeSelfUpgradeDecision(
+					agentDir,
+					cfg.inspectTerminalGeneration(),
+					cfg.selfUpgrade,
+					wakeSelfUpgradeDecision{
+						Action: wakeSelfUpgradeActionDeferred,
+						Reason: quiescence.Reason,
+					},
+				)
+			}
+			inspection := cfg.inspectTerminalGeneration()
+			var running wakeImageEvidenceV1
+			if inspection.Lock.RunningImageEvidence != nil {
+				running = *inspection.Lock.RunningImageEvidence
+			}
+			if err := settleWakeSelfUpgradeAttemptAtBoundary(
+				&cfg.selfUpgrade,
+				agentDir,
+				inspection,
+				running,
+			); err != nil {
+				return err
+			}
+		}
 		probe, probeErr := probeWakeSelfUpgradeLocator(cfg.selfUpgrade.Locator)
 		if probeErr != nil {
 			return recordWakeSelfUpgradeDecision(
@@ -1738,17 +1779,19 @@ func maintainWakeSelfUpgradeAtLoopBoundary(
 		if sameWakeSelfUpgradeProbe(cfg.selfUpgrade.lastProbe, probe) {
 			return nil
 		}
-		quiescence := classifyWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
-		if quiescence.Disposition != wakeResumeProceed {
-			return recordWakeSelfUpgradeDecision(
-				agentDir,
-				cfg.inspectTerminalGeneration(),
-				cfg.selfUpgrade,
-				wakeSelfUpgradeDecision{
-					Action: wakeSelfUpgradeActionDeferred,
-					Reason: quiescence.Reason,
-				},
-			)
+		if !attemptPending {
+			quiescence := classifyWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
+			if quiescence.Disposition != wakeResumeProceed {
+				return recordWakeSelfUpgradeDecision(
+					agentDir,
+					cfg.inspectTerminalGeneration(),
+					cfg.selfUpgrade,
+					wakeSelfUpgradeDecision{
+						Action: wakeSelfUpgradeActionDeferred,
+						Reason: quiescence.Reason,
+					},
+				)
+			}
 		}
 	}
 	decision, err := maintainWakeSelfUpgrade(

--- a/internal/cli/wake_retire_unix.go
+++ b/internal/cli/wake_retire_unix.go
@@ -387,6 +387,12 @@ func removeWakeRetireArtifactsAt(
 			Err:     expected.StateSnapshotErr,
 		}
 	}
+	if err := removeWakeSelfUpgradeAttemptAt(dirfd); err != nil {
+		return wakeRetireCleanupOutcome{
+			Residue: []string{wakeSelfUpgradeAttemptFileName},
+			Err:     fmt.Errorf("remove retired wake self-upgrade attempt: %w", err),
+		}
+	}
 	if err := syncWakeOwnerDirFD(dirfd); err != nil {
 		return wakeRetireCleanupOutcome{
 			Residue: []string{"wake artifact durability"},

--- a/internal/cli/wake_self_upgrade_attempt_unix.go
+++ b/internal/cli/wake_self_upgrade_attempt_unix.go
@@ -18,6 +18,19 @@ const (
 	wakeSelfUpgradeAttemptSchema   = 2
 )
 
+var (
+	errWakeSelfUpgradeAttemptTimestampUncertain = errors.New("wake self-upgrade attempt timestamp is uncertain")
+	errWakeSelfUpgradeAttemptNotFresh           = errors.New("wake self-upgrade attempt is not fresh")
+)
+
+type wakeSelfUpgradeAttemptRefusalError struct {
+	attempt selfupgrade.Attempt
+}
+
+func (err wakeSelfUpgradeAttemptRefusalError) Error() string {
+	return err.attempt.RefusalReason()
+}
+
 type wakeSelfUpgradeAttemptFile struct {
 	Schema    int                           `json:"schema"`
 	Attempts  []selfupgrade.Attempt         `json:"attempts,omitempty"`
@@ -174,7 +187,7 @@ func loadWakeSelfUpgradeAttemptAtStartup(
 			if attempt.Status == selfupgrade.AttemptStatusAttempt &&
 				attempt.IsFresh(wakeSelfUpgradeNow()) && attempt.Matches(running) {
 				state.startupRefusalReason = fmt.Sprintf(
-					"refused unsettled wake self-upgrade image for 24h after a replacement attempt (candidate=%s)",
+					"refused unsettled wake self-upgrade image while the attempt is fresh relative to its recorded timestamp under the current wall clock (candidate=%s)",
 					wakeSelfUpgradeEvidenceIdentityString(running),
 				)
 				break
@@ -192,10 +205,6 @@ func persistWakeSelfUpgradeAttemptAtBoundary(
 	if record.Source != wakeRestartSourceSelf {
 		return nil, errors.New("wake self-upgrade attempt requires a self restart record")
 	}
-	attempt := selfupgrade.NewAttempt(record.Candidate, wakeSelfUpgradeNow())
-	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
-		return nil, err
-	}
 	var installedAttempts []selfupgrade.Attempt
 	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
@@ -206,7 +215,8 @@ func persistWakeSelfUpgradeAttemptAtBoundary(
 		if err != nil {
 			return err
 		}
-		if !exists || !sameWakeRestartRecord(record, currentRecord) {
+		if !exists || record.Status != wakeRestartPending || currentRecord.Status != wakeRestartPending ||
+			!sameWakeRestartAttemptIdentity(record, currentRecord) {
 			return fmt.Errorf("wake restart request changed before self-upgrade attempt publication")
 		}
 		currentAttempts, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
@@ -216,7 +226,34 @@ func persistWakeSelfUpgradeAttemptAtBoundary(
 		if !exists {
 			currentAttempts = nil
 		}
-		installedAttempts, err = selfupgrade.AddAttempt(currentAttempts, attempt, wakeSelfUpgradeNow())
+		now := wakeSelfUpgradeNow()
+		for _, existing := range currentAttempts {
+			if existing.Status == selfupgrade.AttemptStatusAttempt && existing.IsFutureUncertain(now) {
+				return fmt.Errorf("%w: refusing to modify the wake attempt ledger", errWakeSelfUpgradeAttemptTimestampUncertain)
+			}
+		}
+		for _, existing := range currentAttempts {
+			if !existing.Matches(record.Candidate) {
+				continue
+			}
+			switch existing.Status {
+			case selfupgrade.AttemptStatusSettled:
+				installedAttempts = append([]selfupgrade.Attempt(nil), currentAttempts...)
+				return nil
+			case selfupgrade.AttemptStatusAttempt:
+				if existing.IsFresh(now) {
+					return wakeSelfUpgradeAttemptRefusalError{attempt: existing}
+				}
+			}
+		}
+		attempt := selfupgrade.NewAttempt(record.Candidate, now)
+		if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+			return err
+		}
+		if !attempt.IsFresh(now) {
+			return fmt.Errorf("%w: refusing to publish an expired attempt", errWakeSelfUpgradeAttemptNotFresh)
+		}
+		installedAttempts, err = selfupgrade.AddAttempt(currentAttempts, attempt, now)
 		if err != nil {
 			return err
 		}
@@ -260,8 +297,17 @@ func settleWakeSelfUpgradeAttemptAtBoundary(
 		if !exists {
 			return nil
 		}
+		now := wakeSelfUpgradeNow()
+		for _, attempt := range attempts {
+			if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(now) {
+				state.Eligible = false
+				state.Reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+				settled = append([]selfupgrade.Attempt(nil), attempts...)
+				return nil
+			}
+		}
 		originalAttempts := append([]selfupgrade.Attempt(nil), attempts...)
-		attempts = selfupgrade.PruneExpiredAttempts(attempts, wakeSelfUpgradeNow())
+		attempts = selfupgrade.PruneExpiredAttempts(attempts, now)
 		for index := range attempts {
 			if attempts[index].Status == selfupgrade.AttemptStatusAttempt &&
 				attempts[index].Matches(running) {

--- a/internal/cli/wake_self_upgrade_attempt_unix.go
+++ b/internal/cli/wake_self_upgrade_attempt_unix.go
@@ -15,38 +15,44 @@ import (
 const (
 	wakeSelfUpgradeAttemptFileName = ".wake.selfupgrade.attempt"
 	wakeSelfUpgradeAttemptSchemaV1 = 1
+	wakeSelfUpgradeAttemptSchema   = 2
 )
 
 type wakeSelfUpgradeAttemptFile struct {
-	Schema    int                          `json:"schema"`
-	Status    string                       `json:"status"`
-	Candidate selfupgrade.RefusedCandidate `json:"candidate"`
-	UnixTime  int64                        `json:"unix_time"`
+	Schema    int                           `json:"schema"`
+	Attempts  []selfupgrade.Attempt         `json:"attempts,omitempty"`
+	Status    string                        `json:"status,omitempty"`
+	Candidate *selfupgrade.RefusedCandidate `json:"candidate,omitempty"`
+	UnixTime  int64                         `json:"unix_time,omitempty"`
 }
 
-func wakeSelfUpgradeAttemptFileFromAttempt(attempt selfupgrade.Attempt) wakeSelfUpgradeAttemptFile {
+func wakeSelfUpgradeAttemptFileFromAttempts(attempts []selfupgrade.Attempt) wakeSelfUpgradeAttemptFile {
 	return wakeSelfUpgradeAttemptFile{
-		Schema:    wakeSelfUpgradeAttemptSchemaV1,
-		Status:    attempt.Status,
-		Candidate: attempt.Candidate,
-		UnixTime:  attempt.UnixTime,
+		Schema:   wakeSelfUpgradeAttemptSchema,
+		Attempts: append([]selfupgrade.Attempt(nil), attempts...),
 	}
 }
 
-func (file wakeSelfUpgradeAttemptFile) attempt() selfupgrade.Attempt {
-	return selfupgrade.Attempt{
-		Status:    file.Status,
-		Candidate: file.Candidate,
-		UnixTime:  file.UnixTime,
+func (file wakeSelfUpgradeAttemptFile) attempts() []selfupgrade.Attempt {
+	if file.Schema == wakeSelfUpgradeAttemptSchemaV1 {
+		if file.Status == "" || file.Candidate == nil {
+			return nil
+		}
+		return []selfupgrade.Attempt{{
+			Status:    file.Status,
+			Candidate: *file.Candidate,
+			UnixTime:  file.UnixTime,
+		}}
 	}
+	return append([]selfupgrade.Attempt(nil), file.Attempts...)
 }
 
 func readWakeSelfUpgradeAttemptAt(
 	dirfd int,
 	agentDir *wakeAgentDir,
-) (selfupgrade.Attempt, bool, error) {
+) ([]selfupgrade.Attempt, bool, error) {
 	if agentDir == nil {
-		return selfupgrade.Attempt{}, false, errors.New("wake self-upgrade attempt agent directory is missing")
+		return nil, false, errors.New("wake self-upgrade attempt agent directory is missing")
 	}
 	path := filepath.Join(agentDir.path, wakeSelfUpgradeAttemptFileName)
 	raw, _, exists, err := readWakeRepairMetadataAt(
@@ -57,31 +63,41 @@ func readWakeSelfUpgradeAttemptAt(
 		maxWakeMetadataFileBytes,
 	)
 	if err != nil || !exists {
-		return selfupgrade.Attempt{}, exists, err
+		return nil, exists, err
 	}
 	var file wakeSelfUpgradeAttemptFile
 	if err := json.Unmarshal(raw, &file); err != nil {
-		return selfupgrade.Attempt{}, true, fmt.Errorf("parse wake self-upgrade attempt: %w", err)
+		return nil, true, fmt.Errorf("parse wake self-upgrade attempt: %w", err)
 	}
-	if file.Schema != wakeSelfUpgradeAttemptSchemaV1 {
-		return selfupgrade.Attempt{}, true, fmt.Errorf("wake self-upgrade attempt schema %d is unsupported", file.Schema)
+	if file.Schema != wakeSelfUpgradeAttemptSchemaV1 && file.Schema != wakeSelfUpgradeAttemptSchema {
+		return nil, true, fmt.Errorf("wake self-upgrade attempt schema %d is unsupported", file.Schema)
 	}
-	attempt := file.attempt()
-	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
-		return selfupgrade.Attempt{}, true, err
+	if file.Schema == wakeSelfUpgradeAttemptSchemaV1 && len(file.Attempts) != 0 {
+		return nil, true, errors.New("wake self-upgrade attempt schema 1 contains a ledger")
 	}
-	return attempt, true, nil
+	attempts := file.attempts()
+	if file.Schema == wakeSelfUpgradeAttemptSchemaV1 && len(attempts) == 0 {
+		return nil, true, errors.New("wake self-upgrade attempt schema 1 is missing an attempt")
+	}
+	if file.Schema == wakeSelfUpgradeAttemptSchema &&
+		(file.Status != "" || file.Candidate != nil || file.UnixTime != 0) {
+		return nil, true, errors.New("wake self-upgrade attempt schema 2 contains legacy fields")
+	}
+	if err := selfupgrade.ValidateAttempts(attempts); err != nil {
+		return nil, true, err
+	}
+	return attempts, true, nil
 }
 
 func writeWakeSelfUpgradeAttemptAt(
 	dirfd int,
 	agentDir *wakeAgentDir,
-	attempt selfupgrade.Attempt,
+	attempts []selfupgrade.Attempt,
 ) error {
-	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+	if err := selfupgrade.ValidateAttempts(attempts); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(wakeSelfUpgradeAttemptFileFromAttempt(attempt), "", "  ")
+	data, err := json.MarshalIndent(wakeSelfUpgradeAttemptFileFromAttempts(attempts), "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal wake self-upgrade attempt: %w", err)
 	}
@@ -110,10 +126,7 @@ func removeWakeSelfUpgradeAttemptAt(dirfd int) error {
 }
 
 func removeWakeSelfUpgradeArtifactsAt(dirfd int) error {
-	return errors.Join(
-		removeWakeSelfUpgradeDiagnosticAt(dirfd),
-		removeWakeSelfUpgradeAttemptAt(dirfd),
-	)
+	return removeWakeSelfUpgradeDiagnosticAt(dirfd)
 }
 
 func removeWakeSelfUpgradeArtifactsGuarded(root, agent string) error {
@@ -141,17 +154,31 @@ func loadWakeSelfUpgradeAttemptAtStartup(
 		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
 			return fmt.Errorf("wake changed before self-upgrade attempt inspection")
 		}
-		attempt, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+		attempts, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
 		if err != nil || !exists {
 			return err
 		}
-		state.attempt = &attempt
-		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
-			attempt.IsFresh(wakeSelfUpgradeNow()) && attempt.Matches(running) {
-			state.startupRefusalReason = fmt.Sprintf(
-				"refused unsettled wake self-upgrade image for 24h after a replacement attempt (candidate=%s)",
-				wakeSelfUpgradeEvidenceIdentityString(running),
-			)
+		pruned := selfupgrade.PruneExpiredAttempts(attempts, wakeSelfUpgradeNow())
+		if len(pruned) != len(attempts) {
+			if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, pruned); err != nil {
+				return err
+			}
+		}
+		state.attempts = pruned
+		for _, attempt := range pruned {
+			if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(wakeSelfUpgradeNow()) {
+				state.Eligible = false
+				state.Reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+				continue
+			}
+			if attempt.Status == selfupgrade.AttemptStatusAttempt &&
+				attempt.IsFresh(wakeSelfUpgradeNow()) && attempt.Matches(running) {
+				state.startupRefusalReason = fmt.Sprintf(
+					"refused unsettled wake self-upgrade image for 24h after a replacement attempt (candidate=%s)",
+					wakeSelfUpgradeEvidenceIdentityString(running),
+				)
+				break
+			}
 		}
 		return nil
 	})
@@ -161,14 +188,15 @@ func persistWakeSelfUpgradeAttemptAtBoundary(
 	agentDir *wakeAgentDir,
 	expected wakeLockInspection,
 	record wakeRestartRecord,
-) (selfupgrade.Attempt, error) {
+) ([]selfupgrade.Attempt, error) {
 	if record.Source != wakeRestartSourceSelf {
-		return selfupgrade.Attempt{}, errors.New("wake self-upgrade attempt requires a self restart record")
+		return nil, errors.New("wake self-upgrade attempt requires a self restart record")
 	}
 	attempt := selfupgrade.NewAttempt(record.Candidate, wakeSelfUpgradeNow())
 	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
-		return selfupgrade.Attempt{}, err
+		return nil, err
 	}
+	var installedAttempts []selfupgrade.Attempt
 	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
 		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
@@ -181,22 +209,33 @@ func persistWakeSelfUpgradeAttemptAtBoundary(
 		if !exists || !sameWakeRestartRecord(record, currentRecord) {
 			return fmt.Errorf("wake restart request changed before self-upgrade attempt publication")
 		}
-		if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, attempt); err != nil {
+		currentAttempts, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			currentAttempts = nil
+		}
+		installedAttempts, err = selfupgrade.AddAttempt(currentAttempts, attempt, wakeSelfUpgradeNow())
+		if err != nil {
+			return err
+		}
+		if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, installedAttempts); err != nil {
 			return err
 		}
 		installed, installedExists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
 		if err != nil {
 			return err
 		}
-		if !installedExists || installed != attempt {
+		if !installedExists || !sameSelfUpgradeAttempts(installed, installedAttempts) {
 			return fmt.Errorf("wake self-upgrade attempt changed after publication")
 		}
 		return nil
 	})
 	if err != nil {
-		return selfupgrade.Attempt{}, err
+		return nil, err
 	}
-	return attempt, nil
+	return installedAttempts, nil
 }
 
 func settleWakeSelfUpgradeAttemptAtBoundary(
@@ -208,44 +247,59 @@ func settleWakeSelfUpgradeAttemptAtBoundary(
 	if state == nil || agentDir == nil || !state.Enabled || !state.Eligible {
 		return nil
 	}
-	var settled *selfupgrade.Attempt
+	var settled []selfupgrade.Attempt
 	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
 		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
 			return fmt.Errorf("wake changed before self-upgrade attempt settlement")
 		}
-		attempt, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+		attempts, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
 		if err != nil {
 			return err
 		}
 		if !exists {
 			return nil
 		}
-		if attempt.Status == selfupgrade.AttemptStatusAttempt {
-			if !attempt.Matches(running) {
-				settled = &attempt
-				return nil
+		originalAttempts := append([]selfupgrade.Attempt(nil), attempts...)
+		attempts = selfupgrade.PruneExpiredAttempts(attempts, wakeSelfUpgradeNow())
+		for index := range attempts {
+			if attempts[index].Status == selfupgrade.AttemptStatusAttempt &&
+				attempts[index].Matches(running) {
+				attempts[index].Status = selfupgrade.AttemptStatusSettled
 			}
-			attempt.Status = selfupgrade.AttemptStatusSettled
-			if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, attempt); err != nil {
+		}
+		if !sameSelfUpgradeAttempts(originalAttempts, attempts) {
+			if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, attempts); err != nil {
 				return err
 			}
 			installed, installedExists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
 			if err != nil {
 				return err
 			}
-			if !installedExists || installed != attempt {
+			if !installedExists || !sameSelfUpgradeAttempts(installed, attempts) {
 				return fmt.Errorf("settled wake self-upgrade attempt changed after publication")
 			}
 		}
-		settled = &attempt
+		settled = attempts
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 	if settled != nil {
-		state.attempt = settled
+		state.attempts = settled
 	}
 	return nil
+}
+
+func sameSelfUpgradeAttempts(first, second []selfupgrade.Attempt) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for index := range first {
+		if first[index] != second[index] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/wake_self_upgrade_attempt_unix.go
+++ b/internal/cli/wake_self_upgrade_attempt_unix.go
@@ -1,0 +1,251 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	wakeSelfUpgradeAttemptFileName = ".wake.selfupgrade.attempt"
+	wakeSelfUpgradeAttemptSchemaV1 = 1
+)
+
+type wakeSelfUpgradeAttemptFile struct {
+	Schema    int                          `json:"schema"`
+	Status    string                       `json:"status"`
+	Candidate selfupgrade.RefusedCandidate `json:"candidate"`
+	UnixTime  int64                        `json:"unix_time"`
+}
+
+func wakeSelfUpgradeAttemptFileFromAttempt(attempt selfupgrade.Attempt) wakeSelfUpgradeAttemptFile {
+	return wakeSelfUpgradeAttemptFile{
+		Schema:    wakeSelfUpgradeAttemptSchemaV1,
+		Status:    attempt.Status,
+		Candidate: attempt.Candidate,
+		UnixTime:  attempt.UnixTime,
+	}
+}
+
+func (file wakeSelfUpgradeAttemptFile) attempt() selfupgrade.Attempt {
+	return selfupgrade.Attempt{
+		Status:    file.Status,
+		Candidate: file.Candidate,
+		UnixTime:  file.UnixTime,
+	}
+}
+
+func readWakeSelfUpgradeAttemptAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (selfupgrade.Attempt, bool, error) {
+	if agentDir == nil {
+		return selfupgrade.Attempt{}, false, errors.New("wake self-upgrade attempt agent directory is missing")
+	}
+	path := filepath.Join(agentDir.path, wakeSelfUpgradeAttemptFileName)
+	raw, _, exists, err := readWakeRepairMetadataAt(
+		dirfd,
+		wakeSelfUpgradeAttemptFileName,
+		"wake self-upgrade attempt",
+		path,
+		maxWakeMetadataFileBytes,
+	)
+	if err != nil || !exists {
+		return selfupgrade.Attempt{}, exists, err
+	}
+	var file wakeSelfUpgradeAttemptFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return selfupgrade.Attempt{}, true, fmt.Errorf("parse wake self-upgrade attempt: %w", err)
+	}
+	if file.Schema != wakeSelfUpgradeAttemptSchemaV1 {
+		return selfupgrade.Attempt{}, true, fmt.Errorf("wake self-upgrade attempt schema %d is unsupported", file.Schema)
+	}
+	attempt := file.attempt()
+	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+		return selfupgrade.Attempt{}, true, err
+	}
+	return attempt, true, nil
+}
+
+func writeWakeSelfUpgradeAttemptAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	attempt selfupgrade.Attempt,
+) error {
+	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(wakeSelfUpgradeAttemptFileFromAttempt(attempt), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal wake self-upgrade attempt: %w", err)
+	}
+	return writeWakeRepairMetadataAt(
+		dirfd,
+		agentDir,
+		wakeSelfUpgradeAttemptFileName,
+		"wake self-upgrade attempt",
+		append(data, '\n'),
+		maxWakeMetadataFileBytes,
+	)
+}
+
+func removeWakeSelfUpgradeAttemptAt(dirfd int) error {
+	err := unix.Unlinkat(dirfd, wakeSelfUpgradeAttemptFileName, 0)
+	if err == unix.ENOENT {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("remove wake self-upgrade attempt: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync wake self-upgrade attempt removal: %w", err)
+	}
+	return nil
+}
+
+func removeWakeSelfUpgradeArtifactsAt(dirfd int) error {
+	return errors.Join(
+		removeWakeSelfUpgradeDiagnosticAt(dirfd),
+		removeWakeSelfUpgradeAttemptAt(dirfd),
+	)
+}
+
+func removeWakeSelfUpgradeArtifactsGuarded(root, agent string) error {
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return agentDir.withFD(func(dirfd int) error {
+		return removeWakeSelfUpgradeArtifactsAt(dirfd)
+	})
+}
+
+func loadWakeSelfUpgradeAttemptAtStartup(
+	state *wakeSelfUpgradeState,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	running wakeImageEvidenceV1,
+) error {
+	if state == nil || agentDir == nil || !state.Enabled || !state.Eligible {
+		return nil
+	}
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
+		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+			return fmt.Errorf("wake changed before self-upgrade attempt inspection")
+		}
+		attempt, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+		if err != nil || !exists {
+			return err
+		}
+		state.attempt = &attempt
+		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
+			attempt.IsFresh(wakeSelfUpgradeNow()) && attempt.Matches(running) {
+			state.startupRefusalReason = fmt.Sprintf(
+				"refused unsettled wake self-upgrade image for 24h after a replacement attempt (candidate=%s)",
+				wakeSelfUpgradeEvidenceIdentityString(running),
+			)
+		}
+		return nil
+	})
+}
+
+func persistWakeSelfUpgradeAttemptAtBoundary(
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	record wakeRestartRecord,
+) (selfupgrade.Attempt, error) {
+	if record.Source != wakeRestartSourceSelf {
+		return selfupgrade.Attempt{}, errors.New("wake self-upgrade attempt requires a self restart record")
+	}
+	attempt := selfupgrade.NewAttempt(record.Candidate, wakeSelfUpgradeNow())
+	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+		return selfupgrade.Attempt{}, err
+	}
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
+		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+			return fmt.Errorf("wake changed before self-upgrade attempt publication")
+		}
+		currentRecord, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || !sameWakeRestartRecord(record, currentRecord) {
+			return fmt.Errorf("wake restart request changed before self-upgrade attempt publication")
+		}
+		if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, attempt); err != nil {
+			return err
+		}
+		installed, installedExists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !installedExists || installed != attempt {
+			return fmt.Errorf("wake self-upgrade attempt changed after publication")
+		}
+		return nil
+	})
+	if err != nil {
+		return selfupgrade.Attempt{}, err
+	}
+	return attempt, nil
+}
+
+func settleWakeSelfUpgradeAttemptAtBoundary(
+	state *wakeSelfUpgradeState,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	running wakeImageEvidenceV1,
+) error {
+	if state == nil || agentDir == nil || !state.Enabled || !state.Eligible {
+		return nil
+	}
+	var settled *selfupgrade.Attempt
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
+		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+			return fmt.Errorf("wake changed before self-upgrade attempt settlement")
+		}
+		attempt, exists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return nil
+		}
+		if attempt.Status == selfupgrade.AttemptStatusAttempt {
+			if !attempt.Matches(running) {
+				settled = &attempt
+				return nil
+			}
+			attempt.Status = selfupgrade.AttemptStatusSettled
+			if err := writeWakeSelfUpgradeAttemptAt(dirfd, agentDir, attempt); err != nil {
+				return err
+			}
+			installed, installedExists, err := readWakeSelfUpgradeAttemptAt(dirfd, agentDir)
+			if err != nil {
+				return err
+			}
+			if !installedExists || installed != attempt {
+				return fmt.Errorf("settled wake self-upgrade attempt changed after publication")
+			}
+		}
+		settled = &attempt
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if settled != nil {
+		state.attempt = settled
+	}
+	return nil
+}

--- a/internal/cli/wake_self_upgrade_attempt_unix_test.go
+++ b/internal/cli/wake_self_upgrade_attempt_unix_test.go
@@ -175,6 +175,89 @@ func TestWakeSelfUpgradeAttemptPersistsBeforeRestartExec(t *testing.T) {
 	}
 }
 
+func TestWakeSelfUpgradeSettledCandidateDoesNotRearmAttempt(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1_700_000_000, 0).UTC()
+	setWakeSelfUpgradeAttemptClock(t, now)
+	settled := selfupgrade.NewAttempt(record.Candidate, now.Add(-time.Second))
+	settled.Status = selfupgrade.AttemptStatusSettled
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, settled)
+	before, err := os.ReadFile(filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attempts, err := persistWakeSelfUpgradeAttemptAtBoundary(fixture.agentDir, fixture.lock, record)
+	if err != nil {
+		t.Fatalf("persistWakeSelfUpgradeAttemptAtBoundary() error = %v", err)
+	}
+	if len(attempts) != 1 || attempts[0] != settled {
+		t.Fatalf("attempts = %#v, want unchanged settled entry", attempts)
+	}
+	after, err := os.ReadFile(filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("settled wake attempt changed during classification:\nbefore=%safter=%s", before, after)
+	}
+}
+
+func TestWakeSelfUpgradeAttemptBoundaryPreservesFutureUncertainEntry(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1_700_000_000, 0).UTC()
+	setWakeSelfUpgradeAttemptClock(t, now)
+	future := selfupgrade.NewAttempt(record.Candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second))
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, future)
+
+	if _, err := persistWakeSelfUpgradeAttemptAtBoundary(fixture.agentDir, fixture.lock, record); !errors.Is(err, errWakeSelfUpgradeAttemptTimestampUncertain) {
+		t.Fatalf("persistWakeSelfUpgradeAttemptAtBoundary() error = %v, want timestamp uncertainty", err)
+	}
+	if got := readWakeSelfUpgradeAttemptForTest(t, fixture); got != future {
+		t.Fatalf("future attempt = %#v, want preserved entry", got)
+	}
+}
+
+func TestWakeSelfUpgradeSettlementPreservesFutureUncertainEntry(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	setWakeSelfUpgradeAttemptClock(t, now)
+	future := selfupgrade.NewAttempt(fixture.candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second))
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, future)
+	state := wakeSelfUpgradeState{
+		Enabled:  true,
+		Eligible: true,
+		attempts: []selfupgrade.Attempt{future},
+	}
+
+	if err := settleWakeSelfUpgradeAttemptAtBoundary(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
+		t.Fatalf("settleWakeSelfUpgradeAttemptAtBoundary() error = %v", err)
+	}
+	if state.Eligible || state.Reason != "self-upgrade unavailable: replacement attempt timestamp is uncertain" {
+		t.Fatalf("state = %#v, want unavailable", state)
+	}
+	if got := readWakeSelfUpgradeAttemptForTest(t, fixture); got != future {
+		t.Fatalf("future attempt after settlement = %#v, want preserved entry", got)
+	}
+}
+
 func TestWakeSelfUpgradeAttemptSettlesAtFirstQuiescentBoundary(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)

--- a/internal/cli/wake_self_upgrade_attempt_unix_test.go
+++ b/internal/cli/wake_self_upgrade_attempt_unix_test.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +12,136 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
 )
+
+func TestWakeSelfUpgradeAttemptSurvivesStaleLockReclaimAndRefusesOldWake(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	candidatePath := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
+	candidate, err := captureWakeImageEvidence(candidatePath, "0.57.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	record.Candidate = candidate
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1_700_000_001, 0)
+	setWakeSelfUpgradeAttemptClock(t, now)
+	if _, err := persistWakeSelfUpgradeAttemptAtBoundary(fixture.agentDir, fixture.lock, record); err != nil {
+		t.Fatalf("persist replacement attempt: %v", err)
+	}
+	if got := readWakeSelfUpgradeAttemptForTest(t, fixture); got.Status != selfupgrade.AttemptStatusAttempt ||
+		!got.Matches(candidate) {
+		t.Fatalf("persisted attempt = %#v, want unsettled candidate B", got)
+	}
+
+	staleLock := fixture.lock.Lock
+	staleLock.PID = 66121
+	staleLock.ProcessStart = "stale-process"
+	staleLock.BootID = "stale-boot"
+	writeWakeLockForTest(t, fixture.root, fixture.agent, staleLock)
+	staleInspection := inspectWakeLock(fixture.root, fixture.agent)
+	if staleInspection.Status != wakeLockStale {
+		t.Fatalf("stale lock inspection = %#v, want stale", staleInspection)
+	}
+
+	newAgentDir, newCleanup, err := acquireWakeLockWithOptionsRetained(
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:       wakeInjectModeNone,
+			resumeEligible: true,
+			requestedOwner: &fixture.owner,
+		},
+	)
+	if err != nil {
+		t.Fatalf("new old-image wake reclaiming stale lock: %v", err)
+	}
+	defer func() {
+		newCleanup()
+		_ = newAgentDir.Close()
+	}()
+	if got := readWakeSelfUpgradeAttemptForTest(t, fixture); got.Status != selfupgrade.AttemptStatusAttempt ||
+		!got.Matches(candidate) {
+		t.Fatalf("attempt after stale-lock reclaim = %#v, want preserved candidate B", got)
+	}
+	newInspection := inspectWakeLock(fixture.root, fixture.agent)
+	if !newInspection.IdentityConfirmed || newInspection.Status != wakeLockValid {
+		t.Fatalf("new wake inspection = %#v, want valid identity-confirmed wake", newInspection)
+	}
+	if newInspection.Lock.RunningImageEvidence == nil ||
+		!sameWakeImageEvidence(*newInspection.Lock.RunningImageEvidence, fixture.candidate) {
+		t.Fatalf("new wake running image = %#v, want old image A", newInspection.Lock.RunningImageEvidence)
+	}
+
+	state := selfUpgradeStateForCandidate(t, candidatePath)
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+	if err := loadWakeSelfUpgradeAttemptAtStartup(
+		&state,
+		newAgentDir,
+		newInspection,
+		*newInspection.Lock.RunningImageEvidence,
+	); err != nil {
+		t.Fatalf("load preserved attempt in new wake: %v", err)
+	}
+	if len(state.attempts) != 1 || state.attempts[0].Status != selfupgrade.AttemptStatusAttempt ||
+		!state.attempts[0].Matches(candidate) {
+		t.Fatalf("new wake attempt state = %#v, want candidate B", state.attempts)
+	}
+
+	newInboxDir, err := openWakeRepairInboxDir(newAgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = newInboxDir.Close() }()
+	execCalls := 0
+	previousExec := wakeRestartExec
+	wakeRestartExec = func(string, []string, []string) error {
+		execCalls++
+		return errors.New("unexpected exec")
+	}
+	t.Cleanup(func() { wakeRestartExec = previousExec })
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            newInspection.Lock.ResumeOwner,
+		terminalGeneration:   newInspection.Lock.Generation,
+		terminalImageVersion: newInspection.Lock.ImageVersion,
+		retainedAgent:        newAgentDir,
+		retainedInbox:        newInboxDir,
+		selfUpgrade:          state,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		newAgentDir,
+		fixedWakeAdmissionWatcher{errors: make(chan error)},
+		false,
+		false,
+	); err != nil {
+		t.Fatalf("maintenance after stale-lock reclaim: %v", err)
+	}
+	if execCalls != 0 {
+		t.Fatalf("exec calls = %d, want zero after attempt refusal", execCalls)
+	}
+	if !wakeSelfUpgradeRefusedCandidatesContain(cfg.selfUpgrade.refused, candidate) {
+		t.Fatalf("refusal memory = %#v, want candidate B", cfg.selfUpgrade.refused)
+	}
+	if got := readWakeSelfUpgradeAttemptForTest(t, fixture); got.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("attempt after maintenance = %#v, want unsettled diagnostic record", got)
+	}
+	if _, err := os.Lstat(filepath.Join(newAgentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
+		t.Fatalf("maintenance created restart record after refusal: %v", err)
+	}
+}
 
 func TestWakeSelfUpgradeAttemptPersistsBeforeRestartExec(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
@@ -23,16 +155,16 @@ func TestWakeSelfUpgradeAttemptPersistsBeforeRestartExec(t *testing.T) {
 	}
 	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_000, 0))
 
-	attempt, err := persistWakeSelfUpgradeAttemptAtBoundary(fixture.agentDir, fixture.lock, record)
+	attempts, err := persistWakeSelfUpgradeAttemptAtBoundary(fixture.agentDir, fixture.lock, record)
 	if err != nil {
 		t.Fatalf("persistWakeSelfUpgradeAttemptAtBoundary() error = %v", err)
 	}
-	if attempt.Status != selfupgrade.AttemptStatusAttempt || !attempt.Matches(record.Candidate) {
-		t.Fatalf("attempt = %#v, want current candidate attempt", attempt)
+	if len(attempts) != 1 || attempts[0].Status != selfupgrade.AttemptStatusAttempt || !attempts[0].Matches(record.Candidate) {
+		t.Fatalf("attempts = %#v, want current candidate attempt", attempts)
 	}
 	installed := readWakeSelfUpgradeAttemptForTest(t, fixture)
-	if installed != attempt {
-		t.Fatalf("installed attempt = %#v, want %#v", installed, attempt)
+	if installed != attempts[0] {
+		t.Fatalf("installed attempt = %#v, want %#v", installed, attempts[0])
 	}
 	info, err := os.Stat(filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName))
 	if err != nil {
@@ -64,7 +196,7 @@ func TestWakeSelfUpgradeAttemptSettlesAtFirstQuiescentBoundary(t *testing.T) {
 		Eligible:  true,
 		Locator:   locator,
 		lastProbe: probe,
-		attempt:   &attempt,
+		attempts:  []selfupgrade.Attempt{attempt},
 	}
 	cfg := wakeConfig{
 		me:                   fixture.agent,
@@ -94,8 +226,8 @@ func TestWakeSelfUpgradeAttemptSettlesAtFirstQuiescentBoundary(t *testing.T) {
 	if installed.Status != selfupgrade.AttemptStatusSettled {
 		t.Fatalf("installed attempt status = %q, want settled", installed.Status)
 	}
-	if cfg.selfUpgrade.attempt == nil || cfg.selfUpgrade.attempt.Status != selfupgrade.AttemptStatusSettled {
-		t.Fatalf("state attempt = %#v, want settled", cfg.selfUpgrade.attempt)
+	if len(cfg.selfUpgrade.attempts) != 1 || cfg.selfUpgrade.attempts[0].Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("state attempts = %#v, want one settled attempt", cfg.selfUpgrade.attempts)
 	}
 }
 
@@ -110,8 +242,8 @@ func TestLoadWakeSelfUpgradeUnsettledAttemptRefusesMatchingImage(t *testing.T) {
 	if err := loadWakeSelfUpgradeAttemptAtStartup(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
 		t.Fatalf("loadWakeSelfUpgradeAttemptAtStartup() error = %v", err)
 	}
-	if state.attempt == nil || state.attempt.Status != selfupgrade.AttemptStatusAttempt {
-		t.Fatalf("loaded attempt = %#v, want unsettled attempt", state.attempt)
+	if len(state.attempts) != 1 || state.attempts[0].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("loaded attempts = %#v, want one unsettled attempt", state.attempts)
 	}
 	if len(state.refused) != 0 {
 		t.Fatalf("startup refusal memory = %#v, want diagnostic-only load", state.refused)
@@ -136,11 +268,58 @@ func TestLoadWakeSelfUpgradeSettledAttemptDoesNotRefuseMatchingImage(t *testing.
 	if err := loadWakeSelfUpgradeAttemptAtStartup(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
 		t.Fatalf("loadWakeSelfUpgradeAttemptAtStartup() error = %v", err)
 	}
-	if state.attempt == nil || state.attempt.Status != selfupgrade.AttemptStatusSettled {
-		t.Fatalf("loaded attempt = %#v, want settled attempt", state.attempt)
+	if len(state.attempts) != 1 || state.attempts[0].Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("loaded attempts = %#v, want one settled attempt", state.attempts)
 	}
 	if len(state.refused) != 0 || state.startupRefusalReason != "" {
 		t.Fatalf("settled startup state = %#v, want no refusal", state)
+	}
+}
+
+func TestLoadWakeSelfUpgradeSchema1AttemptAsLedger(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	now := time.Unix(1_700_000_001, 0)
+	setWakeSelfUpgradeAttemptClock(t, now)
+	attempt := selfupgrade.NewAttempt(fixture.candidate, now.Add(-time.Second))
+	legacy := wakeSelfUpgradeAttemptFile{
+		Schema:    wakeSelfUpgradeAttemptSchemaV1,
+		Status:    attempt.Status,
+		Candidate: &attempt.Candidate,
+		UnixTime:  attempt.UnixTime,
+	}
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName), append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state := wakeSelfUpgradeState{Enabled: true, Eligible: true}
+	if err := loadWakeSelfUpgradeAttemptAtStartup(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
+		t.Fatalf("load schema 1 attempt: %v", err)
+	}
+	if len(state.attempts) != 1 || state.attempts[0] != attempt {
+		t.Fatalf("loaded attempts = %#v, want %#v", state.attempts, attempt)
+	}
+}
+
+func TestLoadWakeSelfUpgradeFutureAttemptDisablesEligibility(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	now := time.Unix(1_700_000_001, 0)
+	setWakeSelfUpgradeAttemptClock(t, now)
+	attempt := selfupgrade.NewAttempt(fixture.candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second))
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, attempt)
+	state := wakeSelfUpgradeState{Enabled: true, Eligible: true}
+	if err := loadWakeSelfUpgradeAttemptAtStartup(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
+		t.Fatalf("load future attempt: %v", err)
+	}
+	if state.Eligible || state.Reason != "self-upgrade unavailable: replacement attempt timestamp is uncertain" {
+		t.Fatalf("future attempt state = %#v, want unavailable", state)
+	}
+	if len(state.attempts) != 1 || state.attempts[0] != attempt {
+		t.Fatalf("future attempt ledger = %#v, want preserved record", state.attempts)
 	}
 }
 
@@ -182,7 +361,7 @@ func TestWakeSelfUpgradeMaintenanceRefusesUnsettledAttemptMatchingCandidate(t *t
 	}
 	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_001, 0))
 	attempt := selfupgrade.NewAttempt(evidence, time.Unix(1_700_000_000, 0))
-	state.attempt = &attempt
+	state.attempts = []selfupgrade.Attempt{attempt}
 
 	decision, err := maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
 	if err != nil {
@@ -194,8 +373,8 @@ func TestWakeSelfUpgradeMaintenanceRefusesUnsettledAttemptMatchingCandidate(t *t
 	if !wakeSelfUpgradeRefusedCandidatesContain(state.refused, evidence) {
 		t.Fatalf("refusal memory = %#v, want candidate", state.refused)
 	}
-	if state.attempt == nil || state.attempt.Status != selfupgrade.AttemptStatusAttempt {
-		t.Fatalf("attempt state = %#v, want unsettled attempt", state.attempt)
+	if len(state.attempts) != 1 || state.attempts[0].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("attempt state = %#v, want one unsettled attempt", state.attempts)
 	}
 	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
 		t.Fatalf("unsettled-attempt refusal created restart record: %v", err)
@@ -227,7 +406,7 @@ func TestWakeSelfUpgradeAttemptDoesNotSettleDifferentRunningImage(t *testing.T) 
 		Eligible:  true,
 		Locator:   locator,
 		lastProbe: probe,
-		attempt:   &attempt,
+		attempts:  []selfupgrade.Attempt{attempt},
 	}
 	cfg := wakeConfig{
 		me:                   fixture.agent,
@@ -257,8 +436,8 @@ func TestWakeSelfUpgradeAttemptDoesNotSettleDifferentRunningImage(t *testing.T) 
 	if installed.Status != selfupgrade.AttemptStatusAttempt {
 		t.Fatalf("installed attempt status = %q, want unsettled", installed.Status)
 	}
-	if cfg.selfUpgrade.attempt == nil || cfg.selfUpgrade.attempt.Status != selfupgrade.AttemptStatusAttempt {
-		t.Fatalf("state attempt = %#v, want unsettled", cfg.selfUpgrade.attempt)
+	if len(cfg.selfUpgrade.attempts) != 1 || cfg.selfUpgrade.attempts[0].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("state attempts = %#v, want one unsettled attempt", cfg.selfUpgrade.attempts)
 	}
 }
 
@@ -276,6 +455,14 @@ func TestWakeSelfUpgradeAttemptCleanupAfterLockRemoval(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName)); err != nil {
+		t.Fatalf("self-upgrade attempt after generic lock removal = %v, want preserved", err)
+	}
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return removeWakeSelfUpgradeAttemptAt(dirfd)
+	}); err != nil {
+		t.Fatalf("explicit wake retire attempt removal: %v", err)
+	}
 	assertPathMissingForTest(t, filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName))
 }
 
@@ -289,7 +476,7 @@ func setWakeSelfUpgradeAttemptClock(t *testing.T, now time.Time) {
 func writeWakeSelfUpgradeAttemptForTest(t *testing.T, fixture wakeRestartFixture, attempt selfupgrade.Attempt) {
 	t.Helper()
 	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
-		return writeWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir, attempt)
+		return writeWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir, []selfupgrade.Attempt{attempt})
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -297,11 +484,11 @@ func writeWakeSelfUpgradeAttemptForTest(t *testing.T, fixture wakeRestartFixture
 
 func readWakeSelfUpgradeAttemptForTest(t *testing.T, fixture wakeRestartFixture) selfupgrade.Attempt {
 	t.Helper()
-	var attempt selfupgrade.Attempt
+	var attempts []selfupgrade.Attempt
 	if err := fixture.agentDir.withFD(func(dirfd int) error {
 		var exists bool
 		var err error
-		attempt, exists, err = readWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir)
+		attempts, exists, err = readWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir)
 		if err != nil {
 			return err
 		}
@@ -312,7 +499,10 @@ func readWakeSelfUpgradeAttemptForTest(t *testing.T, fixture wakeRestartFixture)
 	}); err != nil {
 		t.Fatal(err)
 	}
-	return attempt
+	if len(attempts) != 1 {
+		t.Fatalf("attempt ledger = %#v, want one attempt", attempts)
+	}
+	return attempts[0]
 }
 
 func writeWakeSelfUpgradeAttemptForGenericCleanupTest(
@@ -322,7 +512,7 @@ func writeWakeSelfUpgradeAttemptForGenericCleanupTest(
 ) {
 	t.Helper()
 	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
-		return writeWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir, attempt)
+		return writeWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir, []selfupgrade.Attempt{attempt})
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wake_self_upgrade_attempt_unix_test.go
+++ b/internal/cli/wake_self_upgrade_attempt_unix_test.go
@@ -1,0 +1,329 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
+)
+
+func TestWakeSelfUpgradeAttemptPersistsBeforeRestartExec(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_000, 0))
+
+	attempt, err := persistWakeSelfUpgradeAttemptAtBoundary(fixture.agentDir, fixture.lock, record)
+	if err != nil {
+		t.Fatalf("persistWakeSelfUpgradeAttemptAtBoundary() error = %v", err)
+	}
+	if attempt.Status != selfupgrade.AttemptStatusAttempt || !attempt.Matches(record.Candidate) {
+		t.Fatalf("attempt = %#v, want current candidate attempt", attempt)
+	}
+	installed := readWakeSelfUpgradeAttemptForTest(t, fixture)
+	if installed != attempt {
+		t.Fatalf("installed attempt = %#v, want %#v", installed, attempt)
+	}
+	info, err := os.Stat(filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("attempt mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestWakeSelfUpgradeAttemptSettlesAtFirstQuiescentBoundary(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	dir := t.TempDir()
+	candidate := writeWakeSelfUpgradeCandidate(t, dir, "candidate")
+	locator := filepath.Join(dir, "amq")
+	if err := os.Symlink(candidate, locator); err != nil {
+		t.Fatal(err)
+	}
+	probe, err := probeWakeSelfUpgradeLocator(locator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_000, 0))
+	attempt := selfupgrade.NewAttempt(fixture.candidate, time.Unix(1_700_000_000, 0))
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, attempt)
+	state := wakeSelfUpgradeState{
+		Enabled:   true,
+		Eligible:  true,
+		Locator:   locator,
+		lastProbe: probe,
+		attempt:   &attempt,
+	}
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade:          state,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+	}
+
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		fixedWakeAdmissionWatcher{errors: make(chan error)},
+		false,
+		false,
+	); err != nil {
+		t.Fatalf("maintainWakeSelfUpgradeAtLoopBoundary() error = %v", err)
+	}
+	installed := readWakeSelfUpgradeAttemptForTest(t, fixture)
+	if installed.Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("installed attempt status = %q, want settled", installed.Status)
+	}
+	if cfg.selfUpgrade.attempt == nil || cfg.selfUpgrade.attempt.Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("state attempt = %#v, want settled", cfg.selfUpgrade.attempt)
+	}
+}
+
+func TestLoadWakeSelfUpgradeUnsettledAttemptRefusesMatchingImage(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_001, 0))
+	attempt := selfupgrade.NewAttempt(fixture.candidate, time.Unix(1_700_000_000, 0))
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, attempt)
+	state := wakeSelfUpgradeState{Enabled: true, Eligible: true}
+
+	if err := loadWakeSelfUpgradeAttemptAtStartup(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
+		t.Fatalf("loadWakeSelfUpgradeAttemptAtStartup() error = %v", err)
+	}
+	if state.attempt == nil || state.attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("loaded attempt = %#v, want unsettled attempt", state.attempt)
+	}
+	if len(state.refused) != 0 {
+		t.Fatalf("startup refusal memory = %#v, want diagnostic-only load", state.refused)
+	}
+	if state.startupRefusalReason == "" {
+		t.Fatal("startup refusal reason is empty")
+	}
+	if state.lastProbe != (wakeSelfUpgradeProbe{}) {
+		t.Fatalf("last probe = %#v, want unchanged diagnostic-only state", state.lastProbe)
+	}
+}
+
+func TestLoadWakeSelfUpgradeSettledAttemptDoesNotRefuseMatchingImage(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_001, 0))
+	attempt := selfupgrade.NewAttempt(fixture.candidate, time.Unix(1_700_000_000, 0))
+	attempt.Status = selfupgrade.AttemptStatusSettled
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, attempt)
+	state := wakeSelfUpgradeState{Enabled: true, Eligible: true}
+
+	if err := loadWakeSelfUpgradeAttemptAtStartup(&state, fixture.agentDir, fixture.lock, fixture.candidate); err != nil {
+		t.Fatalf("loadWakeSelfUpgradeAttemptAtStartup() error = %v", err)
+	}
+	if state.attempt == nil || state.attempt.Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("loaded attempt = %#v, want settled attempt", state.attempt)
+	}
+	if len(state.refused) != 0 || state.startupRefusalReason != "" {
+		t.Fatalf("settled startup state = %#v, want no refusal", state)
+	}
+}
+
+func TestWakeSelfUpgradeMaintenanceHonorsRefusalMemory(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	dir := t.TempDir()
+	candidate := writeWakeSelfUpgradeCandidate(t, dir, "candidate")
+	state := selfUpgradeStateForCandidate(t, candidate)
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+	evidence, err := captureWakeImageEvidence(candidate, "0.57.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.refused = rememberWakeSelfUpgradeRefusal(nil, evidence)
+
+	decision, err := maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
+	if err != nil {
+		t.Fatalf("maintainWakeSelfUpgrade() error = %v", err)
+	}
+	if decision.Action != wakeSelfUpgradeActionRefusedMemory || decision.Reason != "candidate was already refused for this wake generation" {
+		t.Fatalf("decision = %#v, want refusal memory", decision)
+	}
+	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
+		t.Fatalf("startup refusal created restart record: %v", err)
+	}
+}
+
+func TestWakeSelfUpgradeMaintenanceRefusesUnsettledAttemptMatchingCandidate(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	dir := t.TempDir()
+	candidate := writeWakeSelfUpgradeCandidate(t, dir, "candidate")
+	state := selfUpgradeStateForCandidate(t, candidate)
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+	evidence, err := captureWakeImageEvidence(candidate, "0.57.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_001, 0))
+	attempt := selfupgrade.NewAttempt(evidence, time.Unix(1_700_000_000, 0))
+	state.attempt = &attempt
+
+	decision, err := maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
+	if err != nil {
+		t.Fatalf("maintainWakeSelfUpgrade() error = %v", err)
+	}
+	if decision.Action != wakeSelfUpgradeActionRefusedMemory || decision.Reason != attempt.RefusalReason() {
+		t.Fatalf("decision = %#v, want unsettled-attempt refusal", decision)
+	}
+	if !wakeSelfUpgradeRefusedCandidatesContain(state.refused, evidence) {
+		t.Fatalf("refusal memory = %#v, want candidate", state.refused)
+	}
+	if state.attempt == nil || state.attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("attempt state = %#v, want unsettled attempt", state.attempt)
+	}
+	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
+		t.Fatalf("unsettled-attempt refusal created restart record: %v", err)
+	}
+}
+
+func TestWakeSelfUpgradeAttemptDoesNotSettleDifferentRunningImage(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	dir := t.TempDir()
+	candidate := writeWakeSelfUpgradeCandidate(t, dir, "candidate")
+	locator := filepath.Join(dir, "amq")
+	if err := os.Symlink(candidate, locator); err != nil {
+		t.Fatal(err)
+	}
+	probe, err := probeWakeSelfUpgradeLocator(locator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setWakeSelfUpgradeAttemptClock(t, time.Unix(1_700_000_000, 0))
+	evidence, err := captureWakeImageEvidence(candidate, "0.57.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempt := selfupgrade.NewAttempt(evidence, time.Unix(1_700_000_000, 0))
+	writeWakeSelfUpgradeAttemptForTest(t, fixture, attempt)
+	state := wakeSelfUpgradeState{
+		Enabled:   true,
+		Eligible:  true,
+		Locator:   locator,
+		lastProbe: probe,
+		attempt:   &attempt,
+	}
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade:          state,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+	}
+
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		fixedWakeAdmissionWatcher{errors: make(chan error)},
+		false,
+		false,
+	); err != nil {
+		t.Fatalf("maintainWakeSelfUpgradeAtLoopBoundary() error = %v", err)
+	}
+	installed := readWakeSelfUpgradeAttemptForTest(t, fixture)
+	if installed.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("installed attempt status = %q, want unsettled", installed.Status)
+	}
+	if cfg.selfUpgrade.attempt == nil || cfg.selfUpgrade.attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("state attempt = %#v, want unsettled", cfg.selfUpgrade.attempt)
+	}
+}
+
+func TestWakeSelfUpgradeAttemptCleanupAfterLockRemoval(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, false)
+	evidence, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempt := selfupgrade.NewAttempt(evidence, time.Now())
+	writeWakeSelfUpgradeAttemptForGenericCleanupTest(t, fixture, attempt)
+
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return removeWakeLockIfUnchangedGuardedAt(dirfd, fixture.agentDir, fixture.created)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertPathMissingForTest(t, filepath.Join(fixture.agentDir.path, wakeSelfUpgradeAttemptFileName))
+}
+
+func setWakeSelfUpgradeAttemptClock(t *testing.T, now time.Time) {
+	t.Helper()
+	previous := wakeSelfUpgradeNow
+	wakeSelfUpgradeNow = func() time.Time { return now }
+	t.Cleanup(func() { wakeSelfUpgradeNow = previous })
+}
+
+func writeWakeSelfUpgradeAttemptForTest(t *testing.T, fixture wakeRestartFixture, attempt selfupgrade.Attempt) {
+	t.Helper()
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir, attempt)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readWakeSelfUpgradeAttemptForTest(t *testing.T, fixture wakeRestartFixture) selfupgrade.Attempt {
+	t.Helper()
+	var attempt selfupgrade.Attempt
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var exists bool
+		var err error
+		attempt, exists, err = readWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return os.ErrNotExist
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return attempt
+}
+
+func writeWakeSelfUpgradeAttemptForGenericCleanupTest(
+	t *testing.T,
+	fixture *genericWakePreparedCleanupFixture,
+	attempt selfupgrade.Attempt,
+) {
+	t.Helper()
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeSelfUpgradeAttemptAt(dirfd, fixture.agentDir, attempt)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/wake_self_upgrade_other.go
+++ b/internal/cli/wake_self_upgrade_other.go
@@ -12,6 +12,6 @@ func newWakeLockResidueError(_ wakeLockRemovalResidue, err error) error {
 	return err
 }
 
-func removeWakeSelfUpgradeDiagnosticGuarded(string, string) error {
+func removeWakeSelfUpgradeArtifactsGuarded(string, string) error {
 	return nil
 }

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -46,7 +46,7 @@ type wakeSelfUpgradeState struct {
 	Reason               string
 	lastProbe            wakeSelfUpgradeProbe
 	refused              []wakeSelfUpgradeRefusedCandidate
-	attempt              *selfupgrade.Attempt
+	attempts             []selfupgrade.Attempt
 	startupRefusalReason string
 	restartPending       bool
 	refusalPending       *wakeSelfUpgradeRefusalPending
@@ -441,6 +441,15 @@ func maintainWakeSelfUpgrade(
 		decision.Action = wakeSelfUpgradeActionIneligible
 		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 	}
+	for _, attempt := range state.attempts {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(wakeSelfUpgradeNow()) {
+			state.Eligible = false
+			state.Reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+			decision.Action = wakeSelfUpgradeActionIneligible
+			decision.Reason = state.Reason
+			return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
+		}
+	}
 	if agentDir == nil {
 		return wakeSelfUpgradeDecision{}, fmt.Errorf("wake self-upgrade agent directory capability is missing")
 	}
@@ -497,13 +506,15 @@ func maintainWakeSelfUpgrade(
 		)
 		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 	}
-	if state.attempt != nil && state.attempt.Status == selfupgrade.AttemptStatusAttempt &&
-		state.attempt.IsFresh(wakeSelfUpgradeNow()) && state.attempt.Matches(evidence) {
-		state.refused = rememberWakeSelfUpgradeRefusal(state.refused, evidence)
-		state.lastProbe = probe
-		decision.Action = wakeSelfUpgradeActionRefusedMemory
-		decision.Reason = state.attempt.RefusalReason()
-		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
+	for _, attempt := range state.attempts {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
+			attempt.IsFresh(wakeSelfUpgradeNow()) && attempt.Matches(evidence) {
+			state.refused = rememberWakeSelfUpgradeRefusal(state.refused, evidence)
+			state.lastProbe = probe
+			decision.Action = wakeSelfUpgradeActionRefusedMemory
+			decision.Reason = attempt.RefusalReason()
+			return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
+		}
 	}
 	if wakeSelfUpgradeRefusedCandidatesContain(state.refused, evidence) {
 		state.lastProbe = probe

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -40,13 +40,16 @@ const (
 // once, before the wake loop starts; it is intentionally not derived from the
 // resolved image recorded in .wake.lock.
 type wakeSelfUpgradeState struct {
-	Enabled        bool
-	Eligible       bool
-	Locator        string
-	Reason         string
-	lastProbe      wakeSelfUpgradeProbe
-	restartPending bool
-	refusalPending *wakeSelfUpgradeRefusalPending
+	Enabled              bool
+	Eligible             bool
+	Locator              string
+	Reason               string
+	lastProbe            wakeSelfUpgradeProbe
+	refused              []wakeSelfUpgradeRefusedCandidate
+	attempt              *selfupgrade.Attempt
+	startupRefusalReason string
+	restartPending       bool
+	refusalPending       *wakeSelfUpgradeRefusalPending
 }
 
 type wakeSelfUpgradeRefusalPending struct {
@@ -494,7 +497,20 @@ func maintainWakeSelfUpgrade(
 		)
 		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 	}
-
+	if state.attempt != nil && state.attempt.Status == selfupgrade.AttemptStatusAttempt &&
+		state.attempt.IsFresh(wakeSelfUpgradeNow()) && state.attempt.Matches(evidence) {
+		state.refused = rememberWakeSelfUpgradeRefusal(state.refused, evidence)
+		state.lastProbe = probe
+		decision.Action = wakeSelfUpgradeActionRefusedMemory
+		decision.Reason = state.attempt.RefusalReason()
+		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
+	}
+	if wakeSelfUpgradeRefusedCandidatesContain(state.refused, evidence) {
+		state.lastProbe = probe
+		decision.Action = wakeSelfUpgradeActionRefusedMemory
+		decision.Reason = "candidate was already refused for this wake generation"
+		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
+	}
 	different, comparisonErr := wakeSelfUpgradeLiveDifference(inspection, probe)
 	if comparisonErr != nil {
 		// Inconclusive identity is transient (Homebrew Cellar unlink, proc_pidpath
@@ -780,15 +796,4 @@ func removeWakeSelfUpgradeDiagnosticAt(dirfd int) error {
 		return fmt.Errorf("sync wake self-upgrade diagnostic removal: %w", err)
 	}
 	return nil
-}
-
-func removeWakeSelfUpgradeDiagnosticGuarded(root, agent string) error {
-	agentDir, err := openWakeAgentDir(root, agent)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = agentDir.Close() }()
-	return agentDir.withFD(func(dirfd int) error {
-		return removeWakeSelfUpgradeDiagnosticAt(dirfd)
-	})
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -2466,6 +2466,15 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		),
 		resumeEligible,
 	)
+	if err := loadWakeSelfUpgradeAttemptAtStartup(
+		&selfUpgrade,
+		activeAgentDir,
+		currentWake,
+		runningImageEvidence,
+	); err != nil {
+		selfUpgrade.Eligible = false
+		selfUpgrade.Reason = "wake self-upgrade attempt state is unavailable: " + err.Error()
+	}
 	if strings.Contains(selfUpgrade.Reason, "pinned resolved image") {
 		selfUpgrade.Reason += fmt.Sprintf(
 			"; request a safe refresh with amq wake restart --root %s --me %s",
@@ -2777,6 +2786,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	} else if !selfUpgrade.Eligible {
 		initialSelfUpgradeDecision.Action = wakeSelfUpgradeActionIneligible
 		initialSelfUpgradeDecision.Reason = selfUpgrade.Reason
+	} else if selfUpgrade.startupRefusalReason != "" {
+		initialSelfUpgradeDecision.Action = wakeSelfUpgradeActionRefusedMemory
+		initialSelfUpgradeDecision.Reason = selfUpgrade.startupRefusalReason
 	}
 	if err := recordWakeSelfUpgradeDecision(
 		activeAgentDir,

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -744,11 +744,19 @@ func (a App) supervise(ctx context.Context, args []string) error {
 	if selfUpgrade.enabled && !selfUpgrade.eligible && selfUpgrade.reason != "" {
 		_, _ = fmt.Fprintf(a.Stderr, "amq-keepalive self-upgrade unavailable: %s\n", selfUpgrade.reason)
 	}
+	if selfUpgrade.startupRefusalReason != "" {
+		_, _ = fmt.Fprintf(a.Stderr, "amq-keepalive self-upgrade refused: %s\n", selfUpgrade.startupRefusalReason)
+	}
 
 	runOnce := func(emitJSON bool) error {
 		results, err := a.superviseOnce(ctx, *registryPath, amq.NewCLI(*amqPath), *self, *wakeTimeout)
 		if err != nil {
 			return err
+		}
+		if selfUpgradeHealthyPass(results) {
+			if err := selfUpgrade.markSettled(); err != nil {
+				return err
+			}
 		}
 		if emitJSON {
 			return printJSON(a.Stdout, results)
@@ -773,6 +781,15 @@ func (a App) supervise(ctx context.Context, args []string) error {
 		case <-timer.C:
 		}
 	}
+}
+
+func selfUpgradeHealthyPass(results []supervisor.Result) bool {
+	for _, result := range results {
+		if result.Error != nil || result.Action != supervisor.ActionEnsured {
+			return false
+		}
+	}
+	return true
 }
 
 func (a App) superviseOnce(ctx context.Context, registryPath string, wake supervisor.WakeRunner, self string, wakeTimeout time.Duration) ([]supervisor.Result, error) {

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -3071,6 +3071,25 @@ func TestSuperviseRejectsNonPositiveInterval(t *testing.T) {
 	}
 }
 
+func TestSuperviseOnceNoSelfUpgradePublishesJSONWithoutState(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	registryPath := filepath.Join(dir, "registry.json")
+	var stdout, stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(
+		context.Background(),
+		[]string{"supervise", "--registry", registryPath, "--once", "--no-self-upgrade"},
+	)
+	if code != 0 {
+		t.Fatalf("code=%d stderr=%q, want successful one-shot pass", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "[]" {
+		t.Fatalf("stdout=%q, want empty JSON results", got)
+	}
+}
+
 func TestContinuousSuperviseLogsPersistentPassErrorsAndContinues(t *testing.T) {
 	registryPath := testRegistryTempPath(t)
 	if err := os.Mkdir(registryPath, 0o700); err != nil {

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -1962,6 +1962,26 @@ func TestSuperviseUsesInjectedClockOnWakeFailure(t *testing.T) {
 	}
 }
 
+func TestSelfUpgradeHealthyPassRequiresEnsuredResults(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []supervisor.Result
+		want    bool
+	}{
+		{name: "empty", want: true},
+		{name: "ensured", results: []supervisor.Result{{Action: supervisor.ActionEnsured}}, want: true},
+		{name: "deferred", results: []supervisor.Result{{Action: supervisor.ActionDeferred}}, want: false},
+		{name: "failed", results: []supervisor.Result{{Action: supervisor.ActionStartFailed, Error: errors.New("start failed")}}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := selfUpgradeHealthyPass(test.results); got != test.want {
+				t.Fatalf("selfUpgradeHealthyPass(%#v) = %t, want %t", test.results, got, test.want)
+			}
+		})
+	}
+}
+
 func TestSuperviseWarnsOncePerPersistentFailureTransition(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := testRegistryPath(t, dir)

--- a/internal/keepalive/app/selfupgrade.go
+++ b/internal/keepalive/app/selfupgrade.go
@@ -19,13 +19,22 @@ import (
 )
 
 const (
-	selfUpgradeStateSchema     = 2
-	selfUpgradeStateSchemaV1   = 1
-	selfUpgradeStateFileName   = ".selfupgrade.json"
-	selfUpgradeStateLockName   = ".selfupgrade.lock"
-	selfUpgradeActionUnchanged = "unchanged"
-	selfUpgradeActionRefused   = "refused"
-	selfUpgradeActionExec      = "exec"
+	selfUpgradeStateSchema      = 2
+	selfUpgradeStateSchemaV1    = 1
+	selfUpgradeStateFileName    = ".selfupgrade.json"
+	selfUpgradeAttemptsFileName = ".selfupgrade.attempts"
+	selfUpgradeStateLockName    = ".selfupgrade.lock"
+	selfUpgradeActionUnchanged  = "unchanged"
+	selfUpgradeActionRefused    = "refused"
+	selfUpgradeActionExec       = "exec"
+	selfUpgradeAttemptsSchema   = 1
+)
+
+var (
+	errSelfUpgradeAttemptTimestampUncertain = errors.New("replacement attempt timestamp is uncertain")
+	errSelfUpgradeNoMatchingAttempt         = errors.New("no matching self-upgrade attempt")
+	errSelfUpgradeAttemptSettled            = errors.New("replacement attempt is already settled")
+	errSelfUpgradeCandidateRefused          = errors.New("candidate is already refused")
 )
 
 var (
@@ -66,14 +75,29 @@ type selfUpgradeObservation struct {
 	action   string
 }
 
+type selfUpgradeAttemptRefusalError struct {
+	attempt selfupgrade.Attempt
+}
+
+func (err selfUpgradeAttemptRefusalError) Error() string {
+	return err.attempt.RefusalReason()
+}
+
 type selfUpgradeStateFile struct {
-	Schema            int                            `json:"schema"`
-	Generation        string                         `json:"generation"`
-	IncumbentVersion  string                         `json:"incumbent_version"`
-	IncumbentSHA256   string                         `json:"incumbent_sha256"`
-	RefusedCandidates []selfupgrade.RefusedCandidate `json:"refused_candidates,omitempty"`
-	Attempts          []selfupgrade.Attempt          `json:"attempts,omitempty"`
-	Attempt           *selfupgrade.Attempt           `json:"attempt,omitempty"`
+	Schema                      int                            `json:"schema"`
+	Generation                  string                         `json:"generation"`
+	IncumbentVersion            string                         `json:"incumbent_version"`
+	IncumbentSHA256             string                         `json:"incumbent_sha256"`
+	RefusedCandidates           []selfupgrade.RefusedCandidate `json:"refused_candidates,omitempty"`
+	Attempts                    []selfupgrade.Attempt          `json:"attempts,omitempty"`
+	Attempt                     *selfupgrade.Attempt           `json:"attempt,omitempty"`
+	attemptsSidecarExists       bool
+	attemptsSidecarSynchronized bool
+}
+
+type selfUpgradeAttemptsFile struct {
+	Schema   int                   `json:"schema"`
+	Attempts []selfupgrade.Attempt `json:"attempts,omitempty"`
 }
 
 func newSelfUpgradeController(registryPath, locator, version string, enabled bool) *selfUpgradeController {
@@ -204,37 +228,108 @@ func newSelfUpgradeGeneration() (string, error) {
 
 func loadSelfUpgradeState(controller *selfUpgradeController) error {
 	state, exists, err := readSelfUpgradeStateFile(controller.statePath)
-	if err != nil || !exists {
+	if err != nil {
 		return err
 	}
-	controller.attempts = selfupgrade.PruneExpiredAttempts(state.Attempts, selfUpgradeNow())
+	return controller.applySelfUpgradeState(state, exists, true)
+}
+
+func (controller *selfUpgradeController) applySelfUpgradeState(
+	state selfUpgradeStateFile,
+	exists bool,
+	startup bool,
+) error {
+	if !exists {
+		controller.attempts = nil
+		controller.refused = nil
+		controller.statePublished = false
+		return nil
+	}
+	now := selfUpgradeNow()
+	controller.attempts = selfupgrade.PruneExpiredAttempts(state.Attempts, now)
 	if state.Generation == controller.generation {
 		controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
+	} else {
+		controller.refused = nil
 	}
 	controller.statePublished = state.Schema == selfUpgradeStateSchema &&
 		state.Generation == controller.generation &&
+		state.attemptsSidecarExists &&
+		state.attemptsSidecarSynchronized &&
 		len(controller.attempts) == len(state.Attempts)
 	for _, attempt := range controller.attempts {
-		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(selfUpgradeNow()) {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(now) {
 			controller.reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
 			controller.eligible = false
-			break
 		}
-		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
-			attempt.IsFresh(selfUpgradeNow()) && attempt.Matches(controller.incumbent) {
+		if startup && controller.startupRefusalReason == "" &&
+			attempt.Status == selfupgrade.AttemptStatusAttempt &&
+			attempt.IsFresh(now) && attempt.Matches(controller.incumbent) {
 			controller.startupRefusalReason = fmt.Sprintf(
 				"refused unsettled self-upgrade image for 24h after a replacement attempt (candidate=%s)",
 				selfUpgradeEvidenceIdentityString(controller.incumbent),
 			)
-			break
 		}
 	}
 	return nil
 }
 
+func (controller *selfUpgradeController) refreshSelfUpgradeState() error {
+	release, err := selfUpgradeAcquireLock(controller.statePath)
+	if err != nil {
+		return err
+	}
+	state, exists, readErr := readSelfUpgradeStateFile(controller.statePath)
+	if readErr == nil {
+		readErr = controller.applySelfUpgradeState(state, exists, false)
+	}
+	releaseErr := release()
+	return errors.Join(readErr, releaseErr)
+}
+
+func selfUpgradeAttemptsPath(statePath string) string {
+	return filepath.Join(filepath.Dir(statePath), selfUpgradeAttemptsFileName)
+}
+
+func readSelfUpgradeAttemptsFile(statePath string) ([]selfupgrade.Attempt, bool, error) {
+	path := selfUpgradeAttemptsPath(statePath)
+	info, err := selfUpgradeStateFileInfo(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return nil, true, errors.New("self-upgrade attempt state is not a private regular file")
+	}
+	raw, err := selfUpgradeStateReadFile(path)
+	if err != nil {
+		return nil, true, err
+	}
+	var state selfUpgradeAttemptsFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, true, err
+	}
+	if state.Schema != selfUpgradeAttemptsSchema {
+		return nil, true, errors.New("self-upgrade attempt state schema is invalid")
+	}
+	if err := selfupgrade.ValidateAttempts(state.Attempts); err != nil {
+		return nil, true, err
+	}
+	return state.Attempts, true, nil
+}
+
 func readSelfUpgradeStateFile(path string) (selfUpgradeStateFile, bool, error) {
 	info, err := selfUpgradeStateFileInfo(path)
 	if errors.Is(err, os.ErrNotExist) {
+		_, attemptsExists, attemptsErr := readSelfUpgradeAttemptsFile(path)
+		if attemptsErr != nil {
+			return selfUpgradeStateFile{}, true, attemptsErr
+		}
+		if attemptsExists {
+			return selfUpgradeStateFile{}, true, errors.New("self-upgrade attempt state exists without refusal state")
+		}
 		return selfUpgradeStateFile{}, false, nil
 	}
 	if err != nil {
@@ -275,6 +370,20 @@ func readSelfUpgradeStateFile(path string) (selfUpgradeStateFile, bool, error) {
 	if err := selfupgrade.ValidateAttempts(state.Attempts); err != nil {
 		return selfUpgradeStateFile{}, true, err
 	}
+	primaryAttempts := append([]selfupgrade.Attempt(nil), state.Attempts...)
+	attempts, attemptsExists, err := readSelfUpgradeAttemptsFile(path)
+	if err != nil {
+		return selfUpgradeStateFile{}, true, err
+	}
+	if attemptsExists {
+		merged, err := selfupgrade.MergeAttempts(state.Attempts, attempts, selfUpgradeNow())
+		if err != nil {
+			return selfUpgradeStateFile{}, true, err
+		}
+		state.Attempts = nilIfEmptySelfUpgradeAttempts(merged)
+	}
+	state.attemptsSidecarExists = attemptsExists
+	state.attemptsSidecarSynchronized = attemptsExists && reflect.DeepEqual(primaryAttempts, attempts)
 	return state, true, nil
 }
 
@@ -296,6 +405,15 @@ func validateSelfUpgradeRefusals(candidates []selfupgrade.RefusedCandidate) erro
 			return errors.New("self-upgrade refusal state contains a duplicate candidate")
 		}
 		seen[candidate] = struct{}{}
+	}
+	return nil
+}
+
+func validateSelfUpgradeAttemptTimes(attempts []selfupgrade.Attempt, now time.Time) error {
+	for _, attempt := range attempts {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(now) {
+			return errSelfUpgradeAttemptTimestampUncertain
+		}
 	}
 	return nil
 }
@@ -378,10 +496,17 @@ func (controller *selfUpgradeController) mergeState(
 		RefusedCandidates: append([]selfupgrade.RefusedCandidate(nil), controller.refused...),
 		Attempts:          append([]selfupgrade.Attempt(nil), controller.attempts...),
 	}
+	now := selfUpgradeNow()
+	if err := validateSelfUpgradeAttemptTimes(desired.Attempts, now); err != nil {
+		return selfUpgradeStateFile{}, err
+	}
 	if !exists {
 		return desired, nil
 	}
-	mergedAttempts, err := selfupgrade.MergeAttempts(current.Attempts, desired.Attempts, selfUpgradeNow())
+	if err := validateSelfUpgradeAttemptTimes(current.Attempts, now); err != nil {
+		return selfUpgradeStateFile{}, err
+	}
+	mergedAttempts, err := selfupgrade.MergeAttempts(current.Attempts, desired.Attempts, now)
 	if err != nil {
 		return selfUpgradeStateFile{}, err
 	}
@@ -442,7 +567,37 @@ func (controller *selfUpgradeController) writeState(state selfUpgradeStateFile) 
 		return err
 	}
 	data = append(data, '\n')
-	dir := filepath.Dir(controller.statePath)
+	attemptsData, err := json.MarshalIndent(selfUpgradeAttemptsFile{
+		Schema:   selfUpgradeAttemptsSchema,
+		Attempts: nilIfEmptySelfUpgradeAttempts(state.Attempts),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	attemptsData = append(attemptsData, '\n')
+	if err := writeSelfUpgradeJSONFile(selfUpgradeAttemptsPath(controller.statePath), attemptsData); err != nil {
+		return fmt.Errorf("write self-upgrade attempt state: %w", err)
+	}
+	if err := writeSelfUpgradeJSONFile(controller.statePath, data); err != nil {
+		return err
+	}
+	installed, exists, err := readSelfUpgradeStateFile(controller.statePath)
+	if err != nil {
+		return fmt.Errorf("read back self-upgrade state: %w", err)
+	}
+	if !exists || installed.Schema != selfUpgradeStateSchema ||
+		installed.Generation != state.Generation ||
+		installed.IncumbentVersion != state.IncumbentVersion ||
+		installed.IncumbentSHA256 != state.IncumbentSHA256 ||
+		!reflect.DeepEqual(installed.RefusedCandidates, state.RefusedCandidates) ||
+		!reflect.DeepEqual(installed.Attempts, state.Attempts) {
+		return errors.New("self-upgrade state changed after publication")
+	}
+	return nil
+}
+
+func writeSelfUpgradeJSONFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
 	tmp, err := selfUpgradeStateCreateTemp(dir, ".selfupgrade-*.tmp")
 	if err != nil {
 		return err
@@ -464,23 +619,11 @@ func (controller *selfUpgradeController) writeState(state selfUpgradeStateFile) 
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := selfUpgradeStateRename(tmpName, controller.statePath); err != nil {
+	if err := selfUpgradeStateRename(tmpName, path); err != nil {
 		return err
 	}
 	if err := selfUpgradeSyncDir(dir); err != nil {
 		return fmt.Errorf("sync self-upgrade state directory: %w", err)
-	}
-	installed, exists, err := readSelfUpgradeStateFile(controller.statePath)
-	if err != nil {
-		return fmt.Errorf("read back self-upgrade state: %w", err)
-	}
-	if !exists || installed.Schema != selfUpgradeStateSchema ||
-		installed.Generation != state.Generation ||
-		installed.IncumbentVersion != state.IncumbentVersion ||
-		installed.IncumbentSHA256 != state.IncumbentSHA256 ||
-		!reflect.DeepEqual(installed.RefusedCandidates, state.RefusedCandidates) ||
-		!reflect.DeepEqual(installed.Attempts, state.Attempts) {
-		return errors.New("self-upgrade state changed after publication")
 	}
 	return nil
 }
@@ -495,6 +638,17 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 			return nil
 		default:
 		}
+	}
+	if err := controller.refreshSelfUpgradeState(); err != nil {
+		controller.lastObservation = nil
+		if errors.Is(err, errSelfUpgradeAttemptTimestampUncertain) {
+			controller.eligible = false
+			controller.reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+		}
+		return fmt.Errorf("self-upgrade deferred: refresh refusal state: %w", err)
+	}
+	if !controller.eligible {
+		return nil
 	}
 	if err := controller.ensureStatePublished(); err != nil {
 		return fmt.Errorf("self-upgrade deferred: %w", err)
@@ -530,12 +684,6 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 		controller.lastObservation.action = selfUpgradeActionUnchanged
 		return nil
 	}
-	for _, attempt := range controller.attempts {
-		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
-			attempt.IsFresh(selfUpgradeNow()) && attempt.Matches(candidate) {
-			return controller.refuse(candidate, errors.New(attempt.RefusalReason()))
-		}
-	}
 	if selfupgrade.RefusedCandidatesContain(controller.refused, candidate) {
 		controller.lastObservation.action = selfUpgradeActionRefused
 		return nil
@@ -551,6 +699,30 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 	env := append([]string(nil), os.Environ()...)
 	release, err := controller.recordAttempt(candidate)
 	if err != nil {
+		controller.lastObservation = nil
+		var refusal selfUpgradeAttemptRefusalError
+		if errors.As(err, &refusal) {
+			return controller.refuse(candidate, refusal)
+		}
+		if errors.Is(err, errSelfUpgradeCandidateRefused) {
+			controller.lastObservation = &selfUpgradeObservation{
+				evidence: candidate,
+				action:   selfUpgradeActionRefused,
+			}
+			return nil
+		}
+		if errors.Is(err, errSelfUpgradeAttemptSettled) {
+			controller.lastObservation = &selfUpgradeObservation{
+				evidence: candidate,
+				action:   selfUpgradeActionUnchanged,
+			}
+			return nil
+		}
+		if errors.Is(err, errSelfUpgradeAttemptTimestampUncertain) {
+			controller.eligible = false
+			controller.reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+			return fmt.Errorf("self-upgrade unavailable: %w", err)
+		}
 		return fmt.Errorf("self-upgrade deferred: persist replacement attempt: %w", err)
 	}
 	execErr := selfUpgradeExecImage(candidate, argv, env)
@@ -581,14 +753,37 @@ func (controller *selfUpgradeController) recordAttempt(candidate selfupgrade.Ima
 		return nil, err
 	}
 	if err := controller.publishStateLocked(func(state *selfUpgradeStateFile) error {
-		attempts, err := selfupgrade.AddAttempt(state.Attempts, attempt, selfUpgradeNow())
+		now := selfUpgradeNow()
+		if selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidate) {
+			return errSelfUpgradeCandidateRefused
+		}
+		for _, existing := range state.Attempts {
+			if !existing.Matches(candidate) {
+				continue
+			}
+			switch existing.Status {
+			case selfupgrade.AttemptStatusAttempt:
+				if existing.IsFresh(now) {
+					return selfUpgradeAttemptRefusalError{attempt: existing}
+				}
+			case selfupgrade.AttemptStatusSettled:
+				return errSelfUpgradeAttemptSettled
+			}
+		}
+		attempts, err := selfupgrade.AddAttempt(state.Attempts, attempt, now)
 		if err != nil {
+			return err
+		}
+		if err := validateSelfUpgradeAttemptTimes(attempts, now); err != nil {
 			return err
 		}
 		state.Attempts = attempts
 		return nil
 	}); err != nil {
-		_ = release()
+		releaseErr := release()
+		if releaseErr != nil {
+			return nil, errors.Join(err, fmt.Errorf("release self-upgrade state lock: %w", releaseErr))
+		}
 		return nil, err
 	}
 	return release, nil
@@ -598,38 +793,45 @@ func (controller *selfUpgradeController) markSettled() error {
 	if controller == nil {
 		return nil
 	}
-	settle := false
-	for _, attempt := range controller.attempts {
-		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.Matches(controller.incumbent) {
-			settle = true
-			break
-		}
-	}
-	if !settle {
-		return nil
-	}
 	if err := controller.publishState(func(state *selfUpgradeStateFile) error {
+		settle := false
 		for index := range state.Attempts {
 			if state.Attempts[index].Status == selfupgrade.AttemptStatusAttempt &&
 				state.Attempts[index].Matches(controller.incumbent) {
 				state.Attempts[index].Status = selfupgrade.AttemptStatusSettled
+				settle = true
 			}
+		}
+		if !settle {
+			return errSelfUpgradeNoMatchingAttempt
 		}
 		return nil
 	}); err != nil {
+		if errors.Is(err, errSelfUpgradeNoMatchingAttempt) {
+			return nil
+		}
+		if errors.Is(err, errSelfUpgradeAttemptTimestampUncertain) {
+			controller.eligible = false
+			controller.reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+		}
 		return fmt.Errorf("persist settled self-upgrade attempt: %w", err)
 	}
 	return nil
 }
 
 func (controller *selfUpgradeController) refuse(candidate selfupgrade.ImageEvidence, cause error) error {
-	controller.lastObservation = &selfUpgradeObservation{evidence: candidate, action: selfUpgradeActionRefused}
 	if err := controller.publishState(func(state *selfUpgradeStateFile) error {
 		state.RefusedCandidates = selfupgrade.RememberRefusal(state.RefusedCandidates, candidate)
 		return nil
 	}); err != nil {
+		controller.lastObservation = nil
+		if errors.Is(err, errSelfUpgradeAttemptTimestampUncertain) {
+			controller.eligible = false
+			controller.reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+		}
 		return errors.Join(cause, fmt.Errorf("persist self-upgrade refusal: %w", err))
 	}
+	controller.lastObservation = &selfUpgradeObservation{evidence: candidate, action: selfUpgradeActionRefused}
 	return cause
 }
 

--- a/internal/keepalive/app/selfupgrade.go
+++ b/internal/keepalive/app/selfupgrade.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -67,12 +68,14 @@ type selfUpgradeController struct {
 	attempts             []selfupgrade.Attempt
 	startupRefusalReason string
 	statePublished       bool
+	ledgerVersion        string
 	lastObservation      *selfUpgradeObservation
 }
 
 type selfUpgradeObservation struct {
-	evidence selfupgrade.ImageEvidence
-	action   string
+	evidence      selfupgrade.ImageEvidence
+	action        string
+	ledgerVersion string
 }
 
 type selfUpgradeAttemptRefusalError struct {
@@ -243,6 +246,7 @@ func (controller *selfUpgradeController) applySelfUpgradeState(
 		controller.attempts = nil
 		controller.refused = nil
 		controller.statePublished = false
+		controller.ledgerVersion = selfUpgradeLedgerVersion(controller.generation, nil, nil)
 		return nil
 	}
 	now := selfUpgradeNow()
@@ -252,6 +256,7 @@ func (controller *selfUpgradeController) applySelfUpgradeState(
 	} else {
 		controller.refused = nil
 	}
+	controller.ledgerVersion = selfUpgradeLedgerVersion(state.Generation, controller.refused, controller.attempts)
 	controller.statePublished = state.Schema == selfUpgradeStateSchema &&
 		state.Generation == controller.generation &&
 		state.attemptsSidecarExists &&
@@ -266,7 +271,7 @@ func (controller *selfUpgradeController) applySelfUpgradeState(
 			attempt.Status == selfupgrade.AttemptStatusAttempt &&
 			attempt.IsFresh(now) && attempt.Matches(controller.incumbent) {
 			controller.startupRefusalReason = fmt.Sprintf(
-				"refused unsettled self-upgrade image for 24h after a replacement attempt (candidate=%s)",
+				"refused unsettled self-upgrade image while the attempt is fresh relative to its recorded timestamp under the current wall clock (candidate=%s)",
 				selfUpgradeEvidenceIdentityString(controller.incumbent),
 			)
 		}
@@ -275,6 +280,7 @@ func (controller *selfUpgradeController) applySelfUpgradeState(
 }
 
 func (controller *selfUpgradeController) refreshSelfUpgradeState() error {
+	previousVersion := controller.ledgerVersion
 	release, err := selfUpgradeAcquireLock(controller.statePath)
 	if err != nil {
 		return err
@@ -282,6 +288,10 @@ func (controller *selfUpgradeController) refreshSelfUpgradeState() error {
 	state, exists, readErr := readSelfUpgradeStateFile(controller.statePath)
 	if readErr == nil {
 		readErr = controller.applySelfUpgradeState(state, exists, false)
+		if readErr == nil && controller.lastObservation != nil &&
+			previousVersion != controller.ledgerVersion {
+			controller.lastObservation = nil
+		}
 	}
 	releaseErr := release()
 	return errors.Join(readErr, releaseErr)
@@ -481,12 +491,21 @@ func (controller *selfUpgradeController) publishStateLocked(mutator func(*selfUp
 	controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
 	controller.attempts = append([]selfupgrade.Attempt(nil), state.Attempts...)
 	controller.statePublished = true
+	controller.ledgerVersion = selfUpgradeLedgerVersion(state.Generation, state.RefusedCandidates, state.Attempts)
 	return nil
 }
 
 func (controller *selfUpgradeController) mergeState(
 	current selfUpgradeStateFile,
 	exists bool,
+) (selfUpgradeStateFile, error) {
+	return controller.mergeStateAt(current, exists, selfUpgradeNow())
+}
+
+func (controller *selfUpgradeController) mergeStateAt(
+	current selfUpgradeStateFile,
+	exists bool,
+	now time.Time,
 ) (selfUpgradeStateFile, error) {
 	desired := selfUpgradeStateFile{
 		Schema:            selfUpgradeStateSchema,
@@ -496,7 +515,6 @@ func (controller *selfUpgradeController) mergeState(
 		RefusedCandidates: append([]selfupgrade.RefusedCandidate(nil), controller.refused...),
 		Attempts:          append([]selfupgrade.Attempt(nil), controller.attempts...),
 	}
-	now := selfUpgradeNow()
 	if err := validateSelfUpgradeAttemptTimes(desired.Attempts, now); err != nil {
 		return selfUpgradeStateFile{}, err
 	}
@@ -556,6 +574,35 @@ func nilIfEmptySelfUpgradeRefusals(candidates []selfupgrade.RefusedCandidate) []
 		return nil
 	}
 	return candidates
+}
+
+func selfUpgradeLedgerVersion(
+	generation string,
+	refused []selfupgrade.RefusedCandidate,
+	attempts []selfupgrade.Attempt,
+) string {
+	data, _ := json.Marshal(struct {
+		Generation string                         `json:"generation"`
+		Refused    []selfupgrade.RefusedCandidate `json:"refused"`
+		Attempts   []selfupgrade.Attempt          `json:"attempts"`
+	}{
+		Generation: generation,
+		Refused:    refused,
+		Attempts:   attempts,
+	})
+	digest := sha256.Sum256(data)
+	return string(digest[:])
+}
+
+func (controller *selfUpgradeController) observe(
+	evidence selfupgrade.ImageEvidence,
+	action string,
+) *selfUpgradeObservation {
+	return &selfUpgradeObservation{
+		evidence:      evidence,
+		action:        action,
+		ledgerVersion: controller.ledgerVersion,
+	}
 }
 
 func (controller *selfUpgradeController) writeState(state selfUpgradeStateFile) error {
@@ -659,11 +706,12 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 		return nil
 	}
 	if controller.lastObservation != nil &&
+		controller.lastObservation.ledgerVersion == controller.ledgerVersion &&
 		sameSelfUpgradeFileIdentity(controller.lastObservation.evidence, preflight) {
 		return nil
 	}
 	if sameSelfUpgradeContent(controller.incumbent, preflight) {
-		controller.lastObservation = &selfUpgradeObservation{evidence: preflight, action: selfUpgradeActionUnchanged}
+		controller.lastObservation = controller.observe(preflight, selfUpgradeActionUnchanged)
 		return nil
 	}
 	candidate, err := selfUpgradeCaptureCandidate(controller.locator)
@@ -675,7 +723,7 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 		controller.lastObservation = nil
 		return nil
 	}
-	controller.lastObservation = &selfUpgradeObservation{evidence: candidate}
+	controller.lastObservation = controller.observe(candidate, "")
 	if sameSelfUpgradeContent(controller.incumbent, candidate) {
 		controller.lastObservation.action = selfUpgradeActionUnchanged
 		return nil
@@ -699,23 +747,18 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 	env := append([]string(nil), os.Environ()...)
 	release, err := controller.recordAttempt(candidate)
 	if err != nil {
-		controller.lastObservation = nil
 		var refusal selfUpgradeAttemptRefusalError
 		if errors.As(err, &refusal) {
-			return controller.refuse(candidate, refusal)
+			controller.lastObservation = controller.observe(candidate, selfUpgradeActionRefused)
+			return err
 		}
+		controller.lastObservation = nil
 		if errors.Is(err, errSelfUpgradeCandidateRefused) {
-			controller.lastObservation = &selfUpgradeObservation{
-				evidence: candidate,
-				action:   selfUpgradeActionRefused,
-			}
+			controller.lastObservation = controller.observe(candidate, selfUpgradeActionRefused)
 			return nil
 		}
 		if errors.Is(err, errSelfUpgradeAttemptSettled) {
-			controller.lastObservation = &selfUpgradeObservation{
-				evidence: candidate,
-				action:   selfUpgradeActionUnchanged,
-			}
+			controller.lastObservation = controller.observe(candidate, selfUpgradeActionUnchanged)
 			return nil
 		}
 		if errors.Is(err, errSelfUpgradeAttemptTimestampUncertain) {
@@ -725,6 +768,7 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 		}
 		return fmt.Errorf("self-upgrade deferred: persist replacement attempt: %w", err)
 	}
+	controller.lastObservation.ledgerVersion = controller.ledgerVersion
 	execErr := selfUpgradeExecImage(candidate, argv, env)
 	releaseErr := release()
 	if releaseErr != nil {
@@ -744,53 +788,91 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 }
 
 func (controller *selfUpgradeController) recordAttempt(candidate selfupgrade.ImageEvidence) (func() error, error) {
-	attempt := selfupgrade.NewAttempt(candidate, selfUpgradeNow())
-	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
-		return nil, err
-	}
 	release, err := selfUpgradeAcquireLock(controller.statePath)
 	if err != nil {
 		return nil, err
 	}
-	if err := controller.publishStateLocked(func(state *selfUpgradeStateFile) error {
-		now := selfUpgradeNow()
-		if selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidate) {
-			return errSelfUpgradeCandidateRefused
-		}
-		for _, existing := range state.Attempts {
-			if !existing.Matches(candidate) {
-				continue
-			}
-			switch existing.Status {
-			case selfupgrade.AttemptStatusAttempt:
-				if existing.IsFresh(now) {
-					return selfUpgradeAttemptRefusalError{attempt: existing}
-				}
-			case selfupgrade.AttemptStatusSettled:
-				return errSelfUpgradeAttemptSettled
-			}
-		}
-		attempts, err := selfupgrade.AddAttempt(state.Attempts, attempt, now)
-		if err != nil {
-			return err
-		}
-		if err := validateSelfUpgradeAttemptTimes(attempts, now); err != nil {
-			return err
-		}
-		state.Attempts = attempts
-		return nil
-	}); err != nil {
+	releaseWithError := func(failure error) (func() error, error) {
 		releaseErr := release()
 		if releaseErr != nil {
-			return nil, errors.Join(err, fmt.Errorf("release self-upgrade state lock: %w", releaseErr))
+			return nil, errors.Join(failure, fmt.Errorf("release self-upgrade state lock: %w", releaseErr))
 		}
-		return nil, err
+		return nil, failure
+	}
+	current, exists, err := readSelfUpgradeStateFile(controller.statePath)
+	if err != nil {
+		return releaseWithError(err)
+	}
+	now := selfUpgradeNow()
+	attempt := selfupgrade.NewAttempt(candidate, now)
+	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+		return releaseWithError(err)
+	}
+	state, err := controller.mergeStateAt(current, exists, now)
+	if err != nil {
+		return releaseWithError(err)
+	}
+	for _, existing := range state.Attempts {
+		if existing.Status != selfupgrade.AttemptStatusSettled || !existing.Matches(candidate) {
+			continue
+		}
+		controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
+		controller.attempts = append([]selfupgrade.Attempt(nil), state.Attempts...)
+		controller.ledgerVersion = selfUpgradeLedgerVersion(state.Generation, state.RefusedCandidates, state.Attempts)
+		return release, nil
+	}
+	if selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidate) {
+		return releaseWithError(errSelfUpgradeCandidateRefused)
+	}
+	var refusal *selfUpgradeAttemptRefusalError
+	for _, existing := range state.Attempts {
+		if existing.Status != selfupgrade.AttemptStatusAttempt || !existing.Matches(candidate) {
+			continue
+		}
+		if existing.IsFresh(now) {
+			state.RefusedCandidates = selfupgrade.RememberRefusal(state.RefusedCandidates, candidate)
+			candidateRefusal := selfUpgradeAttemptRefusalError{attempt: existing}
+			refusal = &candidateRefusal
+		}
+		if refusal != nil {
+			break
+		}
+	}
+	if refusal == nil {
+		attempts, err := selfupgrade.AddAttempt(state.Attempts, attempt, now)
+		if err != nil {
+			return releaseWithError(err)
+		}
+		if err := validateSelfUpgradeAttemptTimes(attempts, now); err != nil {
+			return releaseWithError(err)
+		}
+		state.Attempts = attempts
+	}
+	state.Schema = selfUpgradeStateSchema
+	state.Attempt = nil
+	state.Attempts = nilIfEmptySelfUpgradeAttempts(state.Attempts)
+	state.RefusedCandidates = nilIfEmptySelfUpgradeRefusals(state.RefusedCandidates)
+	if err := validateSelfUpgradeRefusals(state.RefusedCandidates); err != nil {
+		return releaseWithError(err)
+	}
+	if err := selfupgrade.ValidateAttempts(state.Attempts); err != nil {
+		return releaseWithError(err)
+	}
+	if err := controller.writeState(state); err != nil {
+		return releaseWithError(err)
+	}
+	controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
+	controller.attempts = append([]selfupgrade.Attempt(nil), state.Attempts...)
+	controller.statePublished = true
+	controller.ledgerVersion = selfUpgradeLedgerVersion(state.Generation, state.RefusedCandidates, state.Attempts)
+	if refusal != nil {
+		return releaseWithError(*refusal)
 	}
 	return release, nil
 }
 
 func (controller *selfUpgradeController) markSettled() error {
-	if controller == nil {
+	if controller == nil || !controller.enabled || !controller.eligible || controller.statePath == "" {
 		return nil
 	}
 	if err := controller.publishState(func(state *selfUpgradeStateFile) error {
@@ -831,7 +913,7 @@ func (controller *selfUpgradeController) refuse(candidate selfupgrade.ImageEvide
 		}
 		return errors.Join(cause, fmt.Errorf("persist self-upgrade refusal: %w", err))
 	}
-	controller.lastObservation = &selfUpgradeObservation{evidence: candidate, action: selfUpgradeActionRefused}
+	controller.lastObservation = controller.observe(candidate, selfUpgradeActionRefused)
 	return cause
 }
 

--- a/internal/keepalive/app/selfupgrade.go
+++ b/internal/keepalive/app/selfupgrade.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"time"
@@ -18,8 +19,10 @@ import (
 )
 
 const (
-	selfUpgradeStateSchema     = 1
+	selfUpgradeStateSchema     = 2
+	selfUpgradeStateSchemaV1   = 1
 	selfUpgradeStateFileName   = ".selfupgrade.json"
+	selfUpgradeStateLockName   = ".selfupgrade.lock"
 	selfUpgradeActionUnchanged = "unchanged"
 	selfUpgradeActionRefused   = "refused"
 	selfUpgradeActionExec      = "exec"
@@ -39,6 +42,7 @@ var (
 	selfUpgradeStateRemove      = os.Remove
 	selfUpgradeStateWrite       = io.WriteString
 	selfUpgradeSyncDir          = syncSelfUpgradeDir
+	selfUpgradeAcquireLock      = acquireSelfUpgradeStateLock
 	selfUpgradeNow              = time.Now
 )
 
@@ -51,7 +55,7 @@ type selfUpgradeController struct {
 	generation           string
 	statePath            string
 	refused              []selfupgrade.RefusedCandidate
-	attempt              *selfupgrade.Attempt
+	attempts             []selfupgrade.Attempt
 	startupRefusalReason string
 	statePublished       bool
 	lastObservation      *selfUpgradeObservation
@@ -68,6 +72,7 @@ type selfUpgradeStateFile struct {
 	IncumbentVersion  string                         `json:"incumbent_version"`
 	IncumbentSHA256   string                         `json:"incumbent_sha256"`
 	RefusedCandidates []selfupgrade.RefusedCandidate `json:"refused_candidates,omitempty"`
+	Attempts          []selfupgrade.Attempt          `json:"attempts,omitempty"`
 	Attempt           *selfupgrade.Attempt           `json:"attempt,omitempty"`
 }
 
@@ -137,6 +142,9 @@ func newSelfUpgradeController(registryPath, locator, version string, enabled boo
 		controller.reason = fmt.Sprintf("self-upgrade refusal state is unavailable: %v", err)
 		return controller
 	}
+	if controller.reason != "" {
+		return controller
+	}
 	controller.eligible = true
 	return controller
 }
@@ -195,48 +203,79 @@ func newSelfUpgradeGeneration() (string, error) {
 }
 
 func loadSelfUpgradeState(controller *selfUpgradeController) error {
-	info, err := selfUpgradeStateFileInfo(controller.statePath)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
+	state, exists, err := readSelfUpgradeStateFile(controller.statePath)
+	if err != nil || !exists {
 		return err
 	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
-		return errors.New("self-upgrade refusal state is not a private regular file")
-	}
-	raw, err := selfUpgradeStateReadFile(controller.statePath)
-	if err != nil {
-		return err
-	}
-	var state selfUpgradeStateFile
-	if err := json.Unmarshal(raw, &state); err != nil {
-		return err
-	}
-	if state.Schema != selfUpgradeStateSchema || strings.TrimSpace(state.Generation) == "" {
-		return errors.New("self-upgrade refusal state schema is invalid")
-	}
-	if err := validateSelfUpgradeRefusals(state.RefusedCandidates); err != nil {
-		return err
-	}
-	if state.Attempt != nil {
-		if err := selfupgrade.ValidateAttempt(*state.Attempt); err != nil {
-			return err
-		}
-		attempt := *state.Attempt
-		controller.attempt = &attempt
-	}
+	controller.attempts = selfupgrade.PruneExpiredAttempts(state.Attempts, selfUpgradeNow())
 	if state.Generation == controller.generation {
 		controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
 	}
-	if controller.attempt != nil && controller.attempt.Status == selfupgrade.AttemptStatusAttempt &&
-		controller.attempt.IsFresh(selfUpgradeNow()) && controller.attempt.Matches(controller.incumbent) {
-		controller.startupRefusalReason = fmt.Sprintf(
-			"refused unsettled self-upgrade image for 24h after a replacement attempt (candidate=%s)",
-			selfUpgradeEvidenceIdentityString(controller.incumbent),
-		)
+	controller.statePublished = state.Schema == selfUpgradeStateSchema &&
+		state.Generation == controller.generation &&
+		len(controller.attempts) == len(state.Attempts)
+	for _, attempt := range controller.attempts {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.IsFutureUncertain(selfUpgradeNow()) {
+			controller.reason = "self-upgrade unavailable: replacement attempt timestamp is uncertain"
+			controller.eligible = false
+			break
+		}
+		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
+			attempt.IsFresh(selfUpgradeNow()) && attempt.Matches(controller.incumbent) {
+			controller.startupRefusalReason = fmt.Sprintf(
+				"refused unsettled self-upgrade image for 24h after a replacement attempt (candidate=%s)",
+				selfUpgradeEvidenceIdentityString(controller.incumbent),
+			)
+			break
+		}
 	}
 	return nil
+}
+
+func readSelfUpgradeStateFile(path string) (selfUpgradeStateFile, bool, error) {
+	info, err := selfUpgradeStateFileInfo(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return selfUpgradeStateFile{}, false, nil
+	}
+	if err != nil {
+		return selfUpgradeStateFile{}, true, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return selfUpgradeStateFile{}, true, errors.New("self-upgrade refusal state is not a private regular file")
+	}
+	raw, err := selfUpgradeStateReadFile(path)
+	if err != nil {
+		return selfUpgradeStateFile{}, true, err
+	}
+	var state selfUpgradeStateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return selfUpgradeStateFile{}, true, err
+	}
+	if strings.TrimSpace(state.Generation) == "" {
+		return selfUpgradeStateFile{}, true, errors.New("self-upgrade refusal state schema is invalid")
+	}
+	switch state.Schema {
+	case selfUpgradeStateSchemaV1:
+		if len(state.Attempts) != 0 {
+			return selfUpgradeStateFile{}, true, errors.New("self-upgrade refusal state schema 1 contains a ledger")
+		}
+		if state.Attempt != nil {
+			state.Attempts = []selfupgrade.Attempt{*state.Attempt}
+		}
+	case selfUpgradeStateSchema:
+		if state.Attempt != nil {
+			return selfUpgradeStateFile{}, true, errors.New("self-upgrade refusal state schema 2 contains a legacy attempt")
+		}
+	default:
+		return selfUpgradeStateFile{}, true, errors.New("self-upgrade refusal state schema is invalid")
+	}
+	if err := validateSelfUpgradeRefusals(state.RefusedCandidates); err != nil {
+		return selfUpgradeStateFile{}, true, err
+	}
+	if err := selfupgrade.ValidateAttempts(state.Attempts); err != nil {
+		return selfUpgradeStateFile{}, true, err
+	}
+	return state, true, nil
 }
 
 func validateSelfUpgradeRefusals(candidates []selfupgrade.RefusedCandidate) error {
@@ -275,16 +314,128 @@ func (controller *selfUpgradeController) ensureStatePublished() error {
 }
 
 func (controller *selfUpgradeController) saveState() error {
+	return controller.publishState(nil)
+}
+
+func (controller *selfUpgradeController) publishState(mutator func(*selfUpgradeStateFile) error) error {
+	if controller == nil {
+		return errors.New("self-upgrade controller is nil")
+	}
 	if controller.statePath == "" {
 		return errors.New("self-upgrade state path is empty")
 	}
-	state := selfUpgradeStateFile{
+	release, err := selfUpgradeAcquireLock(controller.statePath)
+	if err != nil {
+		return err
+	}
+	publishErr := controller.publishStateLocked(mutator)
+	releaseErr := release()
+	return errors.Join(publishErr, releaseErr)
+}
+
+func (controller *selfUpgradeController) publishStateLocked(mutator func(*selfUpgradeStateFile) error) error {
+	current, exists, err := readSelfUpgradeStateFile(controller.statePath)
+	if err != nil {
+		return err
+	}
+	state, err := controller.mergeState(current, exists)
+	if err != nil {
+		return err
+	}
+	if mutator != nil {
+		if err := mutator(&state); err != nil {
+			return err
+		}
+	}
+	state.Schema = selfUpgradeStateSchema
+	state.Attempt = nil
+	state.Attempts = nilIfEmptySelfUpgradeAttempts(state.Attempts)
+	state.RefusedCandidates = nilIfEmptySelfUpgradeRefusals(state.RefusedCandidates)
+	if err := validateSelfUpgradeRefusals(state.RefusedCandidates); err != nil {
+		return err
+	}
+	if err := selfupgrade.ValidateAttempts(state.Attempts); err != nil {
+		return err
+	}
+	if err := controller.writeState(state); err != nil {
+		return err
+	}
+	controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
+	controller.attempts = append([]selfupgrade.Attempt(nil), state.Attempts...)
+	controller.statePublished = true
+	return nil
+}
+
+func (controller *selfUpgradeController) mergeState(
+	current selfUpgradeStateFile,
+	exists bool,
+) (selfUpgradeStateFile, error) {
+	desired := selfUpgradeStateFile{
 		Schema:            selfUpgradeStateSchema,
 		Generation:        controller.generation,
 		IncumbentVersion:  controller.incumbent.EmbeddedVersion,
 		IncumbentSHA256:   controller.incumbent.SHA256,
 		RefusedCandidates: append([]selfupgrade.RefusedCandidate(nil), controller.refused...),
-		Attempt:           controller.attempt,
+		Attempts:          append([]selfupgrade.Attempt(nil), controller.attempts...),
+	}
+	if !exists {
+		return desired, nil
+	}
+	mergedAttempts, err := selfupgrade.MergeAttempts(current.Attempts, desired.Attempts, selfUpgradeNow())
+	if err != nil {
+		return selfUpgradeStateFile{}, err
+	}
+	desired.Attempts = mergedAttempts
+	if current.Generation == controller.generation {
+		desired.RefusedCandidates = mergeSelfUpgradeRefusals(
+			current.RefusedCandidates,
+			desired.RefusedCandidates,
+		)
+	}
+	return desired, nil
+}
+
+func mergeSelfUpgradeRefusals(
+	current, desired []selfupgrade.RefusedCandidate,
+) []selfupgrade.RefusedCandidate {
+	merged := make([]selfupgrade.RefusedCandidate, 0, len(current)+len(desired))
+	for _, candidates := range [][]selfupgrade.RefusedCandidate{current, desired} {
+		for _, candidate := range candidates {
+			seen := false
+			for _, existing := range merged {
+				if existing == candidate {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				merged = append(merged, candidate)
+			}
+		}
+	}
+	if len(merged) > selfupgrade.RefusalLimit {
+		merged = append([]selfupgrade.RefusedCandidate(nil), merged[len(merged)-selfupgrade.RefusalLimit:]...)
+	}
+	return merged
+}
+
+func nilIfEmptySelfUpgradeAttempts(attempts []selfupgrade.Attempt) []selfupgrade.Attempt {
+	if len(attempts) == 0 {
+		return nil
+	}
+	return attempts
+}
+
+func nilIfEmptySelfUpgradeRefusals(candidates []selfupgrade.RefusedCandidate) []selfupgrade.RefusedCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates
+}
+
+func (controller *selfUpgradeController) writeState(state selfUpgradeStateFile) error {
+	if controller.statePath == "" {
+		return errors.New("self-upgrade state path is empty")
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -318,6 +469,18 @@ func (controller *selfUpgradeController) saveState() error {
 	}
 	if err := selfUpgradeSyncDir(dir); err != nil {
 		return fmt.Errorf("sync self-upgrade state directory: %w", err)
+	}
+	installed, exists, err := readSelfUpgradeStateFile(controller.statePath)
+	if err != nil {
+		return fmt.Errorf("read back self-upgrade state: %w", err)
+	}
+	if !exists || installed.Schema != selfUpgradeStateSchema ||
+		installed.Generation != state.Generation ||
+		installed.IncumbentVersion != state.IncumbentVersion ||
+		installed.IncumbentSHA256 != state.IncumbentSHA256 ||
+		!reflect.DeepEqual(installed.RefusedCandidates, state.RefusedCandidates) ||
+		!reflect.DeepEqual(installed.Attempts, state.Attempts) {
+		return errors.New("self-upgrade state changed after publication")
 	}
 	return nil
 }
@@ -367,9 +530,11 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 		controller.lastObservation.action = selfUpgradeActionUnchanged
 		return nil
 	}
-	if controller.attempt != nil && controller.attempt.Status == selfupgrade.AttemptStatusAttempt &&
-		controller.attempt.IsFresh(selfUpgradeNow()) && controller.attempt.Matches(candidate) {
-		return controller.refuse(candidate, errors.New(controller.attempt.RefusalReason()))
+	for _, attempt := range controller.attempts {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt &&
+			attempt.IsFresh(selfUpgradeNow()) && attempt.Matches(candidate) {
+			return controller.refuse(candidate, errors.New(attempt.RefusalReason()))
+		}
 	}
 	if selfupgrade.RefusedCandidatesContain(controller.refused, candidate) {
 		controller.lastObservation.action = selfUpgradeActionRefused
@@ -384,53 +549,85 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 	}
 	argv := append([]string(nil), os.Args...)
 	env := append([]string(nil), os.Environ()...)
-	if err := controller.recordAttempt(candidate); err != nil {
+	release, err := controller.recordAttempt(candidate)
+	if err != nil {
 		return fmt.Errorf("self-upgrade deferred: persist replacement attempt: %w", err)
 	}
-	if err := selfUpgradeExecImage(candidate, argv, env); err != nil {
-		controller.attempt = nil
-		return controller.refuse(candidate, fmt.Errorf("exec newer self-upgrade image: %w", err))
+	execErr := selfUpgradeExecImage(candidate, argv, env)
+	releaseErr := release()
+	if releaseErr != nil {
+		if execErr != nil {
+			return errors.Join(
+				fmt.Errorf("exec newer self-upgrade image: %w", execErr),
+				fmt.Errorf("release self-upgrade state lock: %w", releaseErr),
+			)
+		}
+		return fmt.Errorf("release self-upgrade state lock: %w", releaseErr)
+	}
+	if execErr != nil {
+		return controller.refuse(candidate, fmt.Errorf("exec newer self-upgrade image: %w", execErr))
 	}
 	controller.lastObservation.action = selfUpgradeActionExec
 	return nil
 }
 
-func (controller *selfUpgradeController) recordAttempt(candidate selfupgrade.ImageEvidence) error {
+func (controller *selfUpgradeController) recordAttempt(candidate selfupgrade.ImageEvidence) (func() error, error) {
 	attempt := selfupgrade.NewAttempt(candidate, selfUpgradeNow())
 	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
-		return err
+		return nil, err
 	}
-	controller.attempt = &attempt
-	if err := controller.saveState(); err != nil {
-		controller.attempt = nil
-		return err
+	release, err := selfUpgradeAcquireLock(controller.statePath)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	if err := controller.publishStateLocked(func(state *selfUpgradeStateFile) error {
+		attempts, err := selfupgrade.AddAttempt(state.Attempts, attempt, selfUpgradeNow())
+		if err != nil {
+			return err
+		}
+		state.Attempts = attempts
+		return nil
+	}); err != nil {
+		_ = release()
+		return nil, err
+	}
+	return release, nil
 }
 
 func (controller *selfUpgradeController) markSettled() error {
-	if controller == nil || controller.attempt == nil ||
-		controller.attempt.Status != selfupgrade.AttemptStatusAttempt {
+	if controller == nil {
 		return nil
 	}
-	if !controller.attempt.Matches(controller.incumbent) {
+	settle := false
+	for _, attempt := range controller.attempts {
+		if attempt.Status == selfupgrade.AttemptStatusAttempt && attempt.Matches(controller.incumbent) {
+			settle = true
+			break
+		}
+	}
+	if !settle {
 		return nil
 	}
-	previous := *controller.attempt
-	settled := previous
-	settled.Status = selfupgrade.AttemptStatusSettled
-	controller.attempt = &settled
-	if err := controller.saveState(); err != nil {
-		controller.attempt = &previous
+	if err := controller.publishState(func(state *selfUpgradeStateFile) error {
+		for index := range state.Attempts {
+			if state.Attempts[index].Status == selfupgrade.AttemptStatusAttempt &&
+				state.Attempts[index].Matches(controller.incumbent) {
+				state.Attempts[index].Status = selfupgrade.AttemptStatusSettled
+			}
+		}
+		return nil
+	}); err != nil {
 		return fmt.Errorf("persist settled self-upgrade attempt: %w", err)
 	}
 	return nil
 }
 
 func (controller *selfUpgradeController) refuse(candidate selfupgrade.ImageEvidence, cause error) error {
-	controller.refused = selfupgrade.RememberRefusal(controller.refused, candidate)
 	controller.lastObservation = &selfUpgradeObservation{evidence: candidate, action: selfUpgradeActionRefused}
-	if err := controller.saveState(); err != nil {
+	if err := controller.publishState(func(state *selfUpgradeStateFile) error {
+		state.RefusedCandidates = selfupgrade.RememberRefusal(state.RefusedCandidates, candidate)
+		return nil
+	}); err != nil {
 		return errors.Join(cause, fmt.Errorf("persist self-upgrade refusal: %w", err))
 	}
 	return cause

--- a/internal/keepalive/app/selfupgrade.go
+++ b/internal/keepalive/app/selfupgrade.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
 )
@@ -38,19 +39,22 @@ var (
 	selfUpgradeStateRemove      = os.Remove
 	selfUpgradeStateWrite       = io.WriteString
 	selfUpgradeSyncDir          = syncSelfUpgradeDir
+	selfUpgradeNow              = time.Now
 )
 
 type selfUpgradeController struct {
-	enabled         bool
-	eligible        bool
-	reason          string
-	locator         string
-	incumbent       selfupgrade.ImageEvidence
-	generation      string
-	statePath       string
-	refused         []selfupgrade.RefusedCandidate
-	statePublished  bool
-	lastObservation *selfUpgradeObservation
+	enabled              bool
+	eligible             bool
+	reason               string
+	locator              string
+	incumbent            selfupgrade.ImageEvidence
+	generation           string
+	statePath            string
+	refused              []selfupgrade.RefusedCandidate
+	attempt              *selfupgrade.Attempt
+	startupRefusalReason string
+	statePublished       bool
+	lastObservation      *selfUpgradeObservation
 }
 
 type selfUpgradeObservation struct {
@@ -64,6 +68,7 @@ type selfUpgradeStateFile struct {
 	IncumbentVersion  string                         `json:"incumbent_version"`
 	IncumbentSHA256   string                         `json:"incumbent_sha256"`
 	RefusedCandidates []selfupgrade.RefusedCandidate `json:"refused_candidates,omitempty"`
+	Attempt           *selfupgrade.Attempt           `json:"attempt,omitempty"`
 }
 
 func newSelfUpgradeController(registryPath, locator, version string, enabled bool) *selfUpgradeController {
@@ -214,8 +219,22 @@ func loadSelfUpgradeState(controller *selfUpgradeController) error {
 	if err := validateSelfUpgradeRefusals(state.RefusedCandidates); err != nil {
 		return err
 	}
+	if state.Attempt != nil {
+		if err := selfupgrade.ValidateAttempt(*state.Attempt); err != nil {
+			return err
+		}
+		attempt := *state.Attempt
+		controller.attempt = &attempt
+	}
 	if state.Generation == controller.generation {
 		controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
+	}
+	if controller.attempt != nil && controller.attempt.Status == selfupgrade.AttemptStatusAttempt &&
+		controller.attempt.IsFresh(selfUpgradeNow()) && controller.attempt.Matches(controller.incumbent) {
+		controller.startupRefusalReason = fmt.Sprintf(
+			"refused unsettled self-upgrade image for 24h after a replacement attempt (candidate=%s)",
+			selfUpgradeEvidenceIdentityString(controller.incumbent),
+		)
 	}
 	return nil
 }
@@ -265,6 +284,7 @@ func (controller *selfUpgradeController) saveState() error {
 		IncumbentVersion:  controller.incumbent.EmbeddedVersion,
 		IncumbentSHA256:   controller.incumbent.SHA256,
 		RefusedCandidates: append([]selfupgrade.RefusedCandidate(nil), controller.refused...),
+		Attempt:           controller.attempt,
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -347,6 +367,10 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 		controller.lastObservation.action = selfUpgradeActionUnchanged
 		return nil
 	}
+	if controller.attempt != nil && controller.attempt.Status == selfupgrade.AttemptStatusAttempt &&
+		controller.attempt.IsFresh(selfUpgradeNow()) && controller.attempt.Matches(candidate) {
+		return controller.refuse(candidate, errors.New(controller.attempt.RefusalReason()))
+	}
 	if selfupgrade.RefusedCandidatesContain(controller.refused, candidate) {
 		controller.lastObservation.action = selfUpgradeActionRefused
 		return nil
@@ -360,10 +384,46 @@ func (controller *selfUpgradeController) maintain(ctx context.Context) error {
 	}
 	argv := append([]string(nil), os.Args...)
 	env := append([]string(nil), os.Environ()...)
+	if err := controller.recordAttempt(candidate); err != nil {
+		return fmt.Errorf("self-upgrade deferred: persist replacement attempt: %w", err)
+	}
 	if err := selfUpgradeExecImage(candidate, argv, env); err != nil {
+		controller.attempt = nil
 		return controller.refuse(candidate, fmt.Errorf("exec newer self-upgrade image: %w", err))
 	}
 	controller.lastObservation.action = selfUpgradeActionExec
+	return nil
+}
+
+func (controller *selfUpgradeController) recordAttempt(candidate selfupgrade.ImageEvidence) error {
+	attempt := selfupgrade.NewAttempt(candidate, selfUpgradeNow())
+	if err := selfupgrade.ValidateAttempt(attempt); err != nil {
+		return err
+	}
+	controller.attempt = &attempt
+	if err := controller.saveState(); err != nil {
+		controller.attempt = nil
+		return err
+	}
+	return nil
+}
+
+func (controller *selfUpgradeController) markSettled() error {
+	if controller == nil || controller.attempt == nil ||
+		controller.attempt.Status != selfupgrade.AttemptStatusAttempt {
+		return nil
+	}
+	if !controller.attempt.Matches(controller.incumbent) {
+		return nil
+	}
+	previous := *controller.attempt
+	settled := previous
+	settled.Status = selfupgrade.AttemptStatusSettled
+	controller.attempt = &settled
+	if err := controller.saveState(); err != nil {
+		controller.attempt = &previous
+		return fmt.Errorf("persist settled self-upgrade attempt: %w", err)
+	}
 	return nil
 }
 
@@ -385,4 +445,16 @@ func sameSelfUpgradeContent(first, second selfupgrade.ImageEvidence) bool {
 func sameSelfUpgradeFileIdentity(first, second selfupgrade.ImageEvidence) bool {
 	return sameSelfUpgradeContent(first, second) &&
 		first.Device == second.Device && first.Inode == second.Inode
+}
+
+func selfUpgradeEvidenceIdentityString(evidence selfupgrade.ImageEvidence) string {
+	return fmt.Sprintf(
+		"platform=%s,dev=%d,ino=%d,size=%d,sha256=%s,version=%s",
+		evidence.Platform,
+		evidence.Device,
+		evidence.Inode,
+		evidence.Size,
+		evidence.SHA256,
+		evidence.EmbeddedVersion,
+	)
 }

--- a/internal/keepalive/app/selfupgrade_lock_other.go
+++ b/internal/keepalive/app/selfupgrade_lock_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package app
+
+func acquireSelfUpgradeStateLock(string) (func() error, error) {
+	return func() error { return nil }, nil
+}

--- a/internal/keepalive/app/selfupgrade_lock_unix.go
+++ b/internal/keepalive/app/selfupgrade_lock_unix.go
@@ -1,0 +1,71 @@
+//go:build darwin || linux
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func acquireSelfUpgradeStateLock(statePath string) (func() error, error) {
+	if statePath == "" {
+		return nil, errors.New("self-upgrade state path is empty")
+	}
+	lockPath := filepath.Join(filepath.Dir(statePath), selfUpgradeStateLockName)
+	fd, err := unix.Open(
+		lockPath,
+		unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0o600,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open self-upgrade state lock: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), lockPath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, errors.New("open self-upgrade state lock file descriptor")
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = file.Close()
+		}
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat self-upgrade state lock: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return nil, errors.New("self-upgrade state lock is not a private regular file")
+	}
+	if err := unix.Flock(fd, unix.LOCK_EX); err != nil {
+		return nil, fmt.Errorf("lock self-upgrade state: %w", err)
+	}
+	closeOnError = false
+	released := false
+	return func() error {
+		if released {
+			return nil
+		}
+		released = true
+		unlockErr := unix.Flock(fd, unix.LOCK_UN)
+		closeErr := file.Close()
+		if unlockErr != nil && closeErr != nil {
+			return errors.Join(
+				fmt.Errorf("unlock self-upgrade state: %w", unlockErr),
+				fmt.Errorf("close self-upgrade state lock: %w", closeErr),
+			)
+		}
+		if unlockErr != nil {
+			return fmt.Errorf("unlock self-upgrade state: %w", unlockErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close self-upgrade state lock: %w", closeErr)
+		}
+		return nil
+	}, nil
+}

--- a/internal/keepalive/app/selfupgrade_test.go
+++ b/internal/keepalive/app/selfupgrade_test.go
@@ -287,6 +287,148 @@ func TestSelfUpgradePublicationMergesConcurrentAttemptAndRefusalLedgers(t *testi
 	}
 }
 
+func TestSelfUpgradeRecordAttemptRefusesFreshCandidateUnderLock(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	first := testSelfUpgradeController(dir, candidatePath, incumbent)
+	second := testSelfUpgradeController(dir, candidatePath, incumbent)
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+
+	release, err := first.recordAttempt(candidate)
+	if err != nil {
+		t.Fatalf("record first attempt: %v", err)
+	}
+	result := make(chan error, 1)
+	go func() {
+		secondRelease, secondErr := second.recordAttempt(candidate)
+		if secondRelease != nil {
+			secondErr = errors.Join(secondErr, secondRelease())
+		}
+		result <- secondErr
+	}()
+	select {
+	case secondErr := <-result:
+		t.Fatalf("second recordAttempt completed while first held the lock: %v", secondErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := release(); err != nil {
+		t.Fatalf("release first attempt lock: %v", err)
+	}
+	select {
+	case secondErr := <-result:
+		var refusal selfUpgradeAttemptRefusalError
+		if !errors.As(secondErr, &refusal) {
+			t.Fatalf("second recordAttempt error = %v, want authoritative refusal", secondErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second recordAttempt did not finish after lock release")
+	}
+	state := readSelfUpgradeStateForTest(t, first.statePath)
+	if len(state.Attempts) != 1 || state.Attempts[0].UnixTime != 1_700_000_000 {
+		t.Fatalf("attempt ledger = %#v, want one original attempt", state.Attempts)
+	}
+}
+
+func TestSelfUpgradeAttemptSidecarSurvivesLegacyStateWriter(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	writer := testSelfUpgradeController(dir, candidatePath, incumbent)
+	release, err := writer.recordAttempt(candidate)
+	if err != nil {
+		t.Fatalf("record attempt: %v", err)
+	}
+	if err := release(); err != nil {
+		t.Fatalf("release attempt lock: %v", err)
+	}
+
+	legacy := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchemaV1,
+		Generation:       "legacy-generation",
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+	}
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(writer.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := testSelfUpgradeController(dir, candidatePath, incumbent)
+	if err := loadSelfUpgradeState(reader); err != nil {
+		t.Fatalf("load state after legacy writer: %v", err)
+	}
+	if len(reader.attempts) != 1 || !reader.attempts[0].Matches(candidate) {
+		t.Fatalf("attempts after legacy writer = %#v, want preserved candidate", reader.attempts)
+	}
+	if err := reader.ensureStatePublished(); err != nil {
+		t.Fatalf("republish migrated state: %v", err)
+	}
+	state := readSelfUpgradeStateForTest(t, reader.statePath)
+	if state.Schema != selfUpgradeStateSchema || len(state.Attempts) != 1 || !state.Attempts[0].Matches(candidate) {
+		t.Fatalf("republished state = %#v, want preserved attempt", state)
+	}
+	info, err := os.Stat(selfUpgradeAttemptsPath(reader.statePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("attempt sidecar mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestSelfUpgradeExistingSchema2StateGetsAttemptSidecar(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	state := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchema,
+		Generation:       controller.generation,
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controller.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadSelfUpgradeState(controller); err != nil {
+		t.Fatalf("load schema 2 state without sidecar: %v", err)
+	}
+	if controller.statePublished {
+		t.Fatal("schema 2 state without an attempt sidecar was treated as fully published")
+	}
+	if err := controller.ensureStatePublished(); err != nil {
+		t.Fatalf("publish missing attempt sidecar: %v", err)
+	}
+	info, err := os.Stat(selfUpgradeAttemptsPath(controller.statePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("attempt sidecar mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
 func TestSelfUpgradeFutureAttemptTimestampDisablesEligibility(t *testing.T) {
 	dir := t.TempDir()
 	incumbentPath := filepath.Join(dir, "incumbent")
@@ -323,6 +465,148 @@ func TestSelfUpgradeFutureAttemptTimestampDisablesEligibility(t *testing.T) {
 	}
 	if len(controller.attempts) != 1 || controller.attempts[0] != future {
 		t.Fatalf("future attempt ledger = %#v, want preserved record", controller.attempts)
+	}
+}
+
+func TestSelfUpgradeFutureAttemptAfterMatchingAttemptDisablesEligibility(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	state := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchema,
+		Generation:       controller.generation,
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+		Attempts: []selfupgrade.Attempt{
+			selfupgrade.NewAttempt(incumbent, now.Add(-time.Minute)),
+			selfupgrade.NewAttempt(candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second)),
+		},
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controller.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return now }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+
+	if err := loadSelfUpgradeState(controller); err != nil {
+		t.Fatalf("load ordered attempts: %v", err)
+	}
+	if controller.eligible || !strings.Contains(controller.reason, "timestamp is uncertain") {
+		t.Fatalf("ordered future attempt controller = %#v, want unavailable", controller)
+	}
+	if len(controller.attempts) != 2 {
+		t.Fatalf("ordered attempt ledger = %#v, want both attempts preserved", controller.attempts)
+	}
+}
+
+func TestSelfUpgradeRefreshRejectsFutureAttemptAddedAfterStartup(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	future := selfupgrade.NewAttempt(candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second))
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return now }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+	state := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchema,
+		Generation:       controller.generation,
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+		Attempts:         []selfupgrade.Attempt{future},
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controller.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousCandidate := selfUpgradeCaptureCandidate
+	selfUpgradeCaptureCandidate = func(string) (selfupgrade.ImageEvidence, error) {
+		t.Fatal("future attempt should stop maintenance before candidate capture")
+		return selfupgrade.ImageEvidence{}, nil
+	}
+	t.Cleanup(func() { selfUpgradeCaptureCandidate = previousCandidate })
+	previousExec := selfUpgradeExecImage
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		t.Fatal("future attempt must not execute a candidate")
+		return nil
+	}
+	t.Cleanup(func() { selfUpgradeExecImage = previousExec })
+
+	if err := controller.maintain(context.Background()); err != nil {
+		t.Fatalf("maintain() with future attempt: %v", err)
+	}
+	if controller.eligible || !strings.Contains(controller.reason, "timestamp is uncertain") {
+		t.Fatalf("refreshed future attempt controller = %#v, want unavailable", controller)
+	}
+}
+
+func TestSelfUpgradeFutureSidecarCannotBeHiddenByPrimaryAttempt(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	current := selfupgrade.NewAttempt(candidate, now)
+	future := selfupgrade.NewAttempt(candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second))
+	state := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchema,
+		Generation:       controller.generation,
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+		Attempts:         []selfupgrade.Attempt{current},
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controller.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	attemptsRaw, err := json.Marshal(selfUpgradeAttemptsFile{
+		Schema:   selfUpgradeAttemptsSchema,
+		Attempts: []selfupgrade.Attempt{future},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(selfUpgradeAttemptsPath(controller.statePath), append(attemptsRaw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return now }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+
+	if err := loadSelfUpgradeState(controller); err != nil {
+		t.Fatalf("load future sidecar: %v", err)
+	}
+	if controller.eligible || !strings.Contains(controller.reason, "timestamp is uncertain") {
+		t.Fatalf("future sidecar controller = %#v, want unavailable", controller)
+	}
+	if len(controller.attempts) != 1 || controller.attempts[0] != future {
+		t.Fatalf("future sidecar attempts = %#v, want future entry preserved", controller.attempts)
 	}
 }
 
@@ -428,6 +712,109 @@ func TestSelfUpgradeRecordsAttemptBeforeExecAndSettles(t *testing.T) {
 	state = readSelfUpgradeStateForTest(t, controller.statePath)
 	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusSettled {
 		t.Fatalf("settled state = %#v, want settled attempt", state)
+	}
+}
+
+func TestSelfUpgradeMarkSettledReadsAuthoritativeState(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	writer := testSelfUpgradeController(dir, candidatePath, incumbent)
+	reader := testSelfUpgradeController(dir, candidatePath, incumbent)
+	previousNow := selfUpgradeNow
+	now := time.Unix(1_700_000_001, 0).UTC()
+	selfUpgradeNow = func() time.Time { return now }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+	writer.attempts = []selfupgrade.Attempt{selfupgrade.NewAttempt(incumbent, now.Add(-time.Second))}
+	if err := writer.saveState(); err != nil {
+		t.Fatalf("publish attempt: %v", err)
+	}
+	if len(reader.attempts) != 0 {
+		t.Fatalf("reader local attempts = %#v, want stale empty view", reader.attempts)
+	}
+	if err := reader.markSettled(); err != nil {
+		t.Fatalf("markSettled() = %v", err)
+	}
+	state := readSelfUpgradeStateForTest(t, reader.statePath)
+	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("settled state = %#v, want authoritative attempt settled", state)
+	}
+}
+
+func TestSelfUpgradeRecordAttemptHonorsAuthoritativeRefusal(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	writer := testSelfUpgradeController(dir, candidatePath, incumbent)
+	writer.refused = []selfupgrade.RefusedCandidate{selfupgrade.RefusedCandidateFromEvidence(candidate)}
+	if err := writer.saveState(); err != nil {
+		t.Fatalf("publish refusal: %v", err)
+	}
+	reader := testSelfUpgradeController(dir, candidatePath, incumbent)
+	if _, err := reader.recordAttempt(candidate); !errors.Is(err, errSelfUpgradeCandidateRefused) {
+		t.Fatalf("recordAttempt() error = %v, want authoritative refusal", err)
+	}
+	state := readSelfUpgradeStateForTest(t, reader.statePath)
+	if len(state.Attempts) != 0 {
+		t.Fatalf("attempts after authoritative refusal = %#v, want none", state.Attempts)
+	}
+}
+
+func TestSelfUpgradeRetriesAfterTransientAttemptPublicationFailure(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	if err := controller.saveState(); err != nil {
+		t.Fatalf("publish initial state: %v", err)
+	}
+	previousLock := selfUpgradeAcquireLock
+	previousCandidate := selfUpgradeCaptureCandidate
+	previousExec := selfUpgradeExecImage
+	lockCalls := 0
+	selfUpgradeAcquireLock = func(path string) (func() error, error) {
+		lockCalls++
+		if lockCalls == 2 {
+			return nil, errors.New("temporary self-upgrade lock failure")
+		}
+		return previousLock(path)
+	}
+	selfUpgradeCaptureCandidate = func(path string) (selfupgrade.ImageEvidence, error) {
+		return captureSelfUpgradeTestImage(t, path, "1.1.0"), nil
+	}
+	execCalls := 0
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		execCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		selfUpgradeAcquireLock = previousLock
+		selfUpgradeCaptureCandidate = previousCandidate
+		selfUpgradeExecImage = previousExec
+	})
+
+	if err := controller.maintain(context.Background()); err == nil || !strings.Contains(err.Error(), "temporary self-upgrade lock failure") {
+		t.Fatalf("first maintain() error = %v, want transient publication failure", err)
+	}
+	if controller.lastObservation != nil {
+		t.Fatalf("last observation = %#v, want deferred publication not cached", controller.lastObservation)
+	}
+	selfUpgradeAcquireLock = previousLock
+	if err := controller.maintain(context.Background()); err != nil {
+		t.Fatalf("second maintain() error = %v, want retry", err)
+	}
+	if execCalls != 1 {
+		t.Fatalf("exec calls = %d, want retry after transient failure", execCalls)
 	}
 }
 

--- a/internal/keepalive/app/selfupgrade_test.go
+++ b/internal/keepalive/app/selfupgrade_test.go
@@ -194,6 +194,187 @@ func TestSelfUpgradeExecFailureIsRememberedOnce(t *testing.T) {
 	if execCalls != 1 || len(controller.refused) != 1 {
 		t.Fatalf("exec calls=%d refusal memory=%d, want 1 and 1", execCalls, len(controller.refused))
 	}
+	state := readSelfUpgradeStateForTest(t, controller.statePath)
+	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("persisted attempts = %#v, want failed replacement attempt preserved", state.Attempts)
+	}
+}
+
+func TestSelfUpgradeSchema1MigratesBeforeProtectedExec(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	attempt := selfupgrade.NewAttempt(candidate, time.Now())
+	legacy := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchemaV1,
+		Generation:       "legacy-generation",
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+		Attempt:          &attempt,
+	}
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controller.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadSelfUpgradeState(controller); err != nil {
+		t.Fatalf("load schema 1 state: %v", err)
+	}
+	if len(controller.attempts) != 1 || controller.attempts[0] != attempt {
+		t.Fatalf("migrated attempts = %#v, want %#v", controller.attempts, attempt)
+	}
+	if controller.statePublished {
+		t.Fatal("schema 1 state was treated as schema 2 before publication")
+	}
+	if err := controller.ensureStatePublished(); err != nil {
+		t.Fatalf("publish migrated state: %v", err)
+	}
+	state := readSelfUpgradeStateForTest(t, controller.statePath)
+	if state.Schema != selfUpgradeStateSchema || len(state.Attempts) != 1 || state.Attempt != nil {
+		t.Fatalf("published migrated state = %#v, want schema 2 ledger", state)
+	}
+}
+
+func TestSelfUpgradePublicationMergesConcurrentAttemptAndRefusalLedgers(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidateBPath := filepath.Join(dir, "candidate-b")
+	candidateCPath := filepath.Join(dir, "candidate-c")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidateBPath, "candidate b")
+	writeExecutableForSelfUpgradeTest(t, candidateCPath, "candidate c")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidateB := captureSelfUpgradeTestImage(t, candidateBPath, "1.1.0")
+	candidateC := captureSelfUpgradeTestImage(t, candidateCPath, "1.2.0")
+	first := testSelfUpgradeController(dir, candidateBPath, incumbent)
+	second := testSelfUpgradeController(dir, candidateCPath, incumbent)
+	first.generation = "shared-generation"
+	second.generation = first.generation
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return time.Unix(1_700_000_001, 0) }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+
+	release, err := first.recordAttempt(candidateB)
+	if err != nil {
+		t.Fatalf("record first attempt: %v", err)
+	}
+	if err := release(); err != nil {
+		t.Fatalf("release first attempt lock: %v", err)
+	}
+	if err := second.refuse(candidateC, errors.New("test refusal")); !strings.Contains(err.Error(), "test refusal") {
+		t.Fatalf("refuse second candidate error = %v, want cause", err)
+	}
+	state := readSelfUpgradeStateForTest(t, first.statePath)
+	if len(state.Attempts) != 1 || !state.Attempts[0].Matches(candidateB) {
+		t.Fatalf("merged attempts = %#v, want candidate B preserved", state.Attempts)
+	}
+	if !selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidateC) {
+		t.Fatalf("merged refusals = %#v, want candidate C", state.RefusedCandidates)
+	}
+	info, err := os.Stat(filepath.Join(dir, selfUpgradeStateLockName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("state lock mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestSelfUpgradeFutureAttemptTimestampDisablesEligibility(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	future := selfupgrade.NewAttempt(candidate, now.Add(selfupgrade.AttemptFutureSkew+time.Second))
+	state := selfUpgradeStateFile{
+		Schema:           selfUpgradeStateSchema,
+		Generation:       controller.generation,
+		Attempts:         []selfupgrade.Attempt{future},
+		IncumbentVersion: incumbent.EmbeddedVersion,
+		IncumbentSHA256:  incumbent.SHA256,
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controller.statePath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return now }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+	if err := loadSelfUpgradeState(controller); err != nil {
+		t.Fatalf("load future attempt: %v", err)
+	}
+	if controller.eligible || !strings.Contains(controller.reason, "timestamp is uncertain") {
+		t.Fatalf("future attempt controller = %#v, want unavailable", controller)
+	}
+	if len(controller.attempts) != 1 || controller.attempts[0] != future {
+		t.Fatalf("future attempt ledger = %#v, want preserved record", controller.attempts)
+	}
+}
+
+func TestSelfUpgradeLedgerRefusesRolledBackFreshCandidate(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidateBPath := filepath.Join(dir, "candidate-b")
+	candidateCPath := filepath.Join(dir, "candidate-c")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidateBPath, "candidate b")
+	writeExecutableForSelfUpgradeTest(t, candidateCPath, "candidate c")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidateB := captureSelfUpgradeTestImage(t, candidateBPath, "1.1.0")
+	candidateC := captureSelfUpgradeTestImage(t, candidateCPath, "1.2.0")
+	controller := testSelfUpgradeController(dir, candidateBPath, incumbent)
+	now := time.Unix(1_700_000_001, 0)
+	controller.attempts = []selfupgrade.Attempt{
+		selfupgrade.NewAttempt(candidateB, now.Add(-time.Second)),
+		selfupgrade.NewAttempt(candidateC, now.Add(-time.Second)),
+	}
+	previousNow := selfUpgradeNow
+	previousCandidate := selfUpgradeCaptureCandidate
+	previousExec := selfUpgradeExecImage
+	selfUpgradeNow = func() time.Time { return now }
+	selfUpgradeCaptureCandidate = func(string) (selfupgrade.ImageEvidence, error) {
+		return candidateB, nil
+	}
+	execCalls := 0
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		execCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		selfUpgradeNow = previousNow
+		selfUpgradeCaptureCandidate = previousCandidate
+		selfUpgradeExecImage = previousExec
+	})
+	if err := controller.saveState(); err != nil {
+		t.Fatalf("save attempt ledger: %v", err)
+	}
+	err := controller.maintain(context.Background())
+	if err == nil || !strings.Contains(err.Error(), controller.attempts[0].RefusalReason()) {
+		t.Fatalf("rollback maintain error = %v, want B refusal", err)
+	}
+	if execCalls != 0 {
+		t.Fatalf("rollback exec calls = %d, want no retry", execCalls)
+	}
+	state := readSelfUpgradeStateForTest(t, controller.statePath)
+	if len(state.Attempts) != 2 || state.Attempts[0].Status != selfupgrade.AttemptStatusAttempt ||
+		state.Attempts[1].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("rollback attempt ledger = %#v, want both fresh attempts preserved", state.Attempts)
+	}
 }
 
 func TestSelfUpgradeRecordsAttemptBeforeExecAndSettles(t *testing.T) {
@@ -216,7 +397,7 @@ func TestSelfUpgradeRecordsAttemptBeforeExecAndSettles(t *testing.T) {
 	selfUpgradeExecImage = func(candidate selfupgrade.ImageEvidence, _ []string, _ []string) error {
 		attempted = candidate
 		state := readSelfUpgradeStateForTest(t, controller.statePath)
-		if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusAttempt {
+		if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusAttempt {
 			t.Fatalf("state at exec = %#v, want unsettled attempt", state)
 		}
 		return nil
@@ -230,14 +411,14 @@ func TestSelfUpgradeRecordsAttemptBeforeExecAndSettles(t *testing.T) {
 	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("maintain() error = %v", err)
 	}
-	if controller.attempt == nil || controller.attempt.Status != selfupgrade.AttemptStatusAttempt {
-		t.Fatalf("controller attempt = %#v, want unsettled attempt", controller.attempt)
+	if len(controller.attempts) != 1 || controller.attempts[0].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("controller attempts = %#v, want one unsettled attempt", controller.attempts)
 	}
 	if err := controller.markSettled(); err != nil {
 		t.Fatalf("markSettled() with old incumbent error = %v", err)
 	}
 	state := readSelfUpgradeStateForTest(t, controller.statePath)
-	if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusAttempt {
+	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusAttempt {
 		t.Fatalf("old-incumbent state = %#v, want unsettled attempt", state)
 	}
 	controller.incumbent = attempted
@@ -245,7 +426,7 @@ func TestSelfUpgradeRecordsAttemptBeforeExecAndSettles(t *testing.T) {
 		t.Fatalf("markSettled() with attempted incumbent error = %v", err)
 	}
 	state = readSelfUpgradeStateForTest(t, controller.statePath)
-	if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusSettled {
+	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusSettled {
 		t.Fatalf("settled state = %#v, want settled attempt", state)
 	}
 }
@@ -260,7 +441,7 @@ func TestSelfUpgradeUnsettledAttemptMatchingCandidateRefusesAndStaysPending(t *t
 	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
 	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
 	attempt := selfupgrade.NewAttempt(candidate, time.Unix(1_700_000_000, 0))
-	controller.attempt = &attempt
+	controller.attempts = []selfupgrade.Attempt{attempt}
 	if err := controller.saveState(); err != nil {
 		t.Fatalf("save attempt state: %v", err)
 	}
@@ -284,7 +465,7 @@ func TestSelfUpgradeUnsettledAttemptMatchingCandidateRefusesAndStaysPending(t *t
 	})
 
 	err := controller.maintain(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "candidate was exec'd at 2023-11-14T22:13:20Z") {
+	if err == nil || !strings.Contains(err.Error(), "replacement attempt was armed at 2023-11-14T22:13:20Z") {
 		t.Fatalf("maintain() error = %v, want unsettled-attempt refusal", err)
 	}
 	if execCalls != 0 {
@@ -293,14 +474,14 @@ func TestSelfUpgradeUnsettledAttemptMatchingCandidateRefusesAndStaysPending(t *t
 	if controller.lastObservation == nil || controller.lastObservation.action != selfUpgradeActionRefused {
 		t.Fatalf("last observation = %#v, want refusal", controller.lastObservation)
 	}
-	if controller.attempt == nil || controller.attempt.Status != selfupgrade.AttemptStatusAttempt {
-		t.Fatalf("controller attempt = %#v, want unsettled attempt", controller.attempt)
+	if len(controller.attempts) != 1 || controller.attempts[0].Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("controller attempts = %#v, want one unsettled attempt", controller.attempts)
 	}
 	if err := controller.markSettled(); err != nil {
 		t.Fatalf("markSettled() with old incumbent error = %v", err)
 	}
 	state := readSelfUpgradeStateForTest(t, controller.statePath)
-	if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusAttempt {
+	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusAttempt {
 		t.Fatalf("persisted attempt = %#v, want unsettled attempt", state)
 	}
 	if !selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidate) {
@@ -318,7 +499,7 @@ func TestSelfUpgradeExpiredAttemptMatchingCandidateExecs(t *testing.T) {
 	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
 	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
 	attempt := selfupgrade.NewAttempt(candidate, time.Unix(1_700_000_000, 0).Add(-selfupgrade.AttemptMaxAge-time.Second))
-	controller.attempt = &attempt
+	controller.attempts = []selfupgrade.Attempt{attempt}
 	if err := controller.saveState(); err != nil {
 		t.Fatalf("save attempt state: %v", err)
 	}
@@ -347,9 +528,9 @@ func TestSelfUpgradeExpiredAttemptMatchingCandidateExecs(t *testing.T) {
 	if execCalls != 1 {
 		t.Fatalf("exec calls = %d, want one expired-attempt replacement", execCalls)
 	}
-	if controller.attempt == nil || controller.attempt.Status != selfupgrade.AttemptStatusAttempt ||
-		!controller.attempt.Matches(candidate) {
-		t.Fatalf("refreshed attempt = %#v, want current candidate", controller.attempt)
+	if len(controller.attempts) != 1 || controller.attempts[0].Status != selfupgrade.AttemptStatusAttempt ||
+		!controller.attempts[0].Matches(candidate) {
+		t.Fatalf("refreshed attempts = %#v, want current candidate", controller.attempts)
 	}
 }
 
@@ -370,7 +551,7 @@ func testSelfUpgradeStartupAttempt(t *testing.T, status string, wantRefusal bool
 	writer := testSelfUpgradeController(dir, filepath.Join(dir, "candidate"), incumbent)
 	attempt := selfupgrade.NewAttempt(incumbent, time.Unix(1_700_000_000, 0))
 	attempt.Status = status
-	writer.attempt = &attempt
+	writer.attempts = []selfupgrade.Attempt{attempt}
 	writer.generation = "old-generation"
 	if err := writer.saveState(); err != nil {
 		t.Fatalf("save startup state: %v", err)

--- a/internal/keepalive/app/selfupgrade_test.go
+++ b/internal/keepalive/app/selfupgrade_test.go
@@ -767,6 +767,60 @@ func TestSelfUpgradeRecordAttemptHonorsAuthoritativeRefusal(t *testing.T) {
 	}
 }
 
+func TestSelfUpgradeSettledCandidateExecsWithoutRearmingAttempt(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	settled := selfupgrade.NewAttempt(candidate, time.Now().Add(-time.Minute))
+	settled.Status = selfupgrade.AttemptStatusSettled
+	controller.attempts = []selfupgrade.Attempt{settled}
+	if err := controller.saveState(); err != nil {
+		t.Fatalf("save settled attempt: %v", err)
+	}
+	before, err := os.ReadFile(controller.statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	previousCandidate := selfUpgradeCaptureCandidate
+	previousExec := selfUpgradeExecImage
+	selfUpgradeCaptureCandidate = func(string) (selfupgrade.ImageEvidence, error) {
+		return candidate, nil
+	}
+	execCalls := 0
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		execCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		selfUpgradeCaptureCandidate = previousCandidate
+		selfUpgradeExecImage = previousExec
+	})
+
+	if err := controller.maintain(context.Background()); err != nil {
+		t.Fatalf("maintain() error = %v", err)
+	}
+	if execCalls != 1 {
+		t.Fatalf("exec calls = %d, want one settled-candidate exec", execCalls)
+	}
+	after, err := os.ReadFile(controller.statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("settled state changed during exec:\nbefore=%safter=%s", before, after)
+	}
+	state := readSelfUpgradeStateForTest(t, controller.statePath)
+	if len(state.Attempts) != 1 || state.Attempts[0].Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("settled state = %#v, want unchanged settled entry", state)
+	}
+}
+
 func TestSelfUpgradeRetriesAfterTransientAttemptPublicationFailure(t *testing.T) {
 	dir := t.TempDir()
 	incumbentPath := filepath.Join(dir, "incumbent")
@@ -873,6 +927,23 @@ func TestSelfUpgradeUnsettledAttemptMatchingCandidateRefusesAndStaysPending(t *t
 	}
 	if !selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidate) {
 		t.Fatalf("persisted refusals = %#v, want candidate", state.RefusedCandidates)
+	}
+}
+
+func TestSelfUpgradeMarkSettledNoOpsWhenUnavailable(t *testing.T) {
+	controllers := []*selfUpgradeController{
+		{enabled: false, eligible: true, statePath: filepath.Join(t.TempDir(), selfUpgradeStateFileName)},
+		{enabled: true, eligible: false, statePath: filepath.Join(t.TempDir(), selfUpgradeStateFileName)},
+		{enabled: true, eligible: true},
+	}
+	for index, controller := range controllers {
+		if err := controller.markSettled(); err != nil {
+			t.Fatalf("controller %d markSettled() error = %v, want no-op", index, err)
+		}
+	}
+	var nilController *selfUpgradeController
+	if err := nilController.markSettled(); err != nil {
+		t.Fatalf("nil markSettled() error = %v, want no-op", err)
 	}
 }
 

--- a/internal/keepalive/app/selfupgrade_test.go
+++ b/internal/keepalive/app/selfupgrade_test.go
@@ -2,11 +2,13 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
 )
@@ -194,6 +196,205 @@ func TestSelfUpgradeExecFailureIsRememberedOnce(t *testing.T) {
 	}
 }
 
+func TestSelfUpgradeRecordsAttemptBeforeExecAndSettles(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousNow := selfUpgradeNow
+	previousCandidate := selfUpgradeCaptureCandidate
+	previousExec := selfUpgradeExecImage
+	selfUpgradeNow = func() time.Time { return time.Unix(1_700_000_000, 0) }
+	selfUpgradeCaptureCandidate = func(path string) (selfupgrade.ImageEvidence, error) {
+		return captureSelfUpgradeTestImage(t, path, "1.1.0"), nil
+	}
+	var attempted selfupgrade.ImageEvidence
+	selfUpgradeExecImage = func(candidate selfupgrade.ImageEvidence, _ []string, _ []string) error {
+		attempted = candidate
+		state := readSelfUpgradeStateForTest(t, controller.statePath)
+		if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusAttempt {
+			t.Fatalf("state at exec = %#v, want unsettled attempt", state)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		selfUpgradeNow = previousNow
+		selfUpgradeCaptureCandidate = previousCandidate
+		selfUpgradeExecImage = previousExec
+	})
+
+	if err := controller.maintain(context.Background()); err != nil {
+		t.Fatalf("maintain() error = %v", err)
+	}
+	if controller.attempt == nil || controller.attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("controller attempt = %#v, want unsettled attempt", controller.attempt)
+	}
+	if err := controller.markSettled(); err != nil {
+		t.Fatalf("markSettled() with old incumbent error = %v", err)
+	}
+	state := readSelfUpgradeStateForTest(t, controller.statePath)
+	if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("old-incumbent state = %#v, want unsettled attempt", state)
+	}
+	controller.incumbent = attempted
+	if err := controller.markSettled(); err != nil {
+		t.Fatalf("markSettled() with attempted incumbent error = %v", err)
+	}
+	state = readSelfUpgradeStateForTest(t, controller.statePath)
+	if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusSettled {
+		t.Fatalf("settled state = %#v, want settled attempt", state)
+	}
+}
+
+func TestSelfUpgradeUnsettledAttemptMatchingCandidateRefusesAndStaysPending(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	attempt := selfupgrade.NewAttempt(candidate, time.Unix(1_700_000_000, 0))
+	controller.attempt = &attempt
+	if err := controller.saveState(); err != nil {
+		t.Fatalf("save attempt state: %v", err)
+	}
+
+	previousNow := selfUpgradeNow
+	previousCandidate := selfUpgradeCaptureCandidate
+	previousExec := selfUpgradeExecImage
+	selfUpgradeNow = func() time.Time { return time.Unix(1_700_000_001, 0) }
+	selfUpgradeCaptureCandidate = func(path string) (selfupgrade.ImageEvidence, error) {
+		return captureSelfUpgradeTestImage(t, path, "1.1.0"), nil
+	}
+	execCalls := 0
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		execCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		selfUpgradeNow = previousNow
+		selfUpgradeCaptureCandidate = previousCandidate
+		selfUpgradeExecImage = previousExec
+	})
+
+	err := controller.maintain(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "candidate was exec'd at 2023-11-14T22:13:20Z") {
+		t.Fatalf("maintain() error = %v, want unsettled-attempt refusal", err)
+	}
+	if execCalls != 0 {
+		t.Fatalf("exec calls = %d, want no retry", execCalls)
+	}
+	if controller.lastObservation == nil || controller.lastObservation.action != selfUpgradeActionRefused {
+		t.Fatalf("last observation = %#v, want refusal", controller.lastObservation)
+	}
+	if controller.attempt == nil || controller.attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("controller attempt = %#v, want unsettled attempt", controller.attempt)
+	}
+	if err := controller.markSettled(); err != nil {
+		t.Fatalf("markSettled() with old incumbent error = %v", err)
+	}
+	state := readSelfUpgradeStateForTest(t, controller.statePath)
+	if state.Attempt == nil || state.Attempt.Status != selfupgrade.AttemptStatusAttempt {
+		t.Fatalf("persisted attempt = %#v, want unsettled attempt", state)
+	}
+	if !selfupgrade.RefusedCandidatesContain(state.RefusedCandidates, candidate) {
+		t.Fatalf("persisted refusals = %#v, want candidate", state.RefusedCandidates)
+	}
+}
+
+func TestSelfUpgradeExpiredAttemptMatchingCandidateExecs(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	candidate := captureSelfUpgradeTestImage(t, candidatePath, "1.1.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+	attempt := selfupgrade.NewAttempt(candidate, time.Unix(1_700_000_000, 0).Add(-selfupgrade.AttemptMaxAge-time.Second))
+	controller.attempt = &attempt
+	if err := controller.saveState(); err != nil {
+		t.Fatalf("save attempt state: %v", err)
+	}
+
+	previousNow := selfUpgradeNow
+	previousCandidate := selfUpgradeCaptureCandidate
+	previousExec := selfUpgradeExecImage
+	selfUpgradeNow = func() time.Time { return time.Unix(1_700_000_001, 0) }
+	selfUpgradeCaptureCandidate = func(path string) (selfupgrade.ImageEvidence, error) {
+		return captureSelfUpgradeTestImage(t, path, "1.1.0"), nil
+	}
+	execCalls := 0
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		execCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		selfUpgradeNow = previousNow
+		selfUpgradeCaptureCandidate = previousCandidate
+		selfUpgradeExecImage = previousExec
+	})
+
+	if err := controller.maintain(context.Background()); err != nil {
+		t.Fatalf("maintain() error = %v", err)
+	}
+	if execCalls != 1 {
+		t.Fatalf("exec calls = %d, want one expired-attempt replacement", execCalls)
+	}
+	if controller.attempt == nil || controller.attempt.Status != selfupgrade.AttemptStatusAttempt ||
+		!controller.attempt.Matches(candidate) {
+		t.Fatalf("refreshed attempt = %#v, want current candidate", controller.attempt)
+	}
+}
+
+func TestSelfUpgradeUnsettledAttemptRefusesMatchingImageAtStartup(t *testing.T) {
+	testSelfUpgradeStartupAttempt(t, selfupgrade.AttemptStatusAttempt, true)
+}
+
+func TestSelfUpgradeSettledAttemptDoesNotRefuseMatchingImageAtStartup(t *testing.T) {
+	testSelfUpgradeStartupAttempt(t, selfupgrade.AttemptStatusSettled, false)
+}
+
+func testSelfUpgradeStartupAttempt(t *testing.T, status string, wantRefusal bool) {
+	t.Helper()
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "running image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	writer := testSelfUpgradeController(dir, filepath.Join(dir, "candidate"), incumbent)
+	attempt := selfupgrade.NewAttempt(incumbent, time.Unix(1_700_000_000, 0))
+	attempt.Status = status
+	writer.attempt = &attempt
+	writer.generation = "old-generation"
+	if err := writer.saveState(); err != nil {
+		t.Fatalf("save startup state: %v", err)
+	}
+
+	reader := testSelfUpgradeController(dir, writer.locator, incumbent)
+	reader.generation = "new-generation"
+	previousNow := selfUpgradeNow
+	selfUpgradeNow = func() time.Time { return time.Unix(1_700_000_001, 0) }
+	t.Cleanup(func() { selfUpgradeNow = previousNow })
+	if err := loadSelfUpgradeState(reader); err != nil {
+		t.Fatalf("load startup state: %v", err)
+	}
+	if got := reader.startupRefusalReason != ""; got != wantRefusal {
+		t.Fatalf("startup diagnostic=%t, want %t; controller=%#v", got, wantRefusal, reader)
+	}
+	if wantRefusal && reader.startupRefusalReason == "" {
+		t.Fatal("startup refusal reason is empty")
+	}
+	if !wantRefusal && reader.startupRefusalReason != "" {
+		t.Fatalf("settled startup refusal reason = %q, want empty", reader.startupRefusalReason)
+	}
+}
+
 func TestSelfUpgradeOptOutDoesNotPublishOrProbe(t *testing.T) {
 	dir := t.TempDir()
 	controller := &selfUpgradeController{
@@ -280,4 +481,17 @@ func assertSelfUpgradeStateMode(t *testing.T, path string) {
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("state mode = %o, want 600", info.Mode().Perm())
 	}
+}
+
+func readSelfUpgradeStateForTest(t *testing.T, path string) selfUpgradeStateFile {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state selfUpgradeStateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatal(err)
+	}
+	return state
 }

--- a/internal/selfupgrade/attempt.go
+++ b/internal/selfupgrade/attempt.go
@@ -80,7 +80,7 @@ func (attempt Attempt) Matches(evidence ImageEvidence) bool {
 
 func (attempt Attempt) RefusalReason() string {
 	return fmt.Sprintf(
-		"replacement attempt was armed at %s and did not settle; refusing for 24h",
+		"replacement attempt was armed at %s and did not settle; refusing while the attempt is fresh relative to the recorded timestamp",
 		time.Unix(attempt.UnixTime, 0).UTC().Format(time.RFC3339),
 	)
 }
@@ -135,6 +135,9 @@ func AddAttempt(attempts []Attempt, addition Attempt, now time.Time) ([]Attempt,
 	current := PruneExpiredAttempts(attempts, now)
 	for index, attempt := range current {
 		if attempt.Candidate == addition.Candidate {
+			if attempt.IsFutureUncertain(now) {
+				return nil, fmt.Errorf("self-upgrade attempt timestamp is uncertain")
+			}
 			current = append(current[:index], current[index+1:]...)
 			break
 		}

--- a/internal/selfupgrade/attempt.go
+++ b/internal/selfupgrade/attempt.go
@@ -1,0 +1,73 @@
+package selfupgrade
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	AttemptStatusAttempt = "attempt"
+	AttemptStatusSettled = "settled"
+	AttemptMaxAge        = 24 * time.Hour
+)
+
+// Attempt records the stable identity of an image that was about to replace
+// the current process. It deliberately excludes paths and observation methods.
+type Attempt struct {
+	Status    string           `json:"status"`
+	Candidate RefusedCandidate `json:"candidate"`
+	UnixTime  int64            `json:"unix_time"`
+}
+
+func NewAttempt(evidence ImageEvidence, now time.Time) Attempt {
+	return Attempt{
+		Status:    AttemptStatusAttempt,
+		Candidate: RefusedCandidateFromEvidence(evidence),
+		UnixTime:  now.UTC().Unix(),
+	}
+}
+
+func ValidateAttempt(attempt Attempt) error {
+	return ValidateAttemptForPlatform(attempt, runtime.GOOS)
+}
+
+func ValidateAttemptForPlatform(attempt Attempt, platform string) error {
+	if attempt.Status != AttemptStatusAttempt && attempt.Status != AttemptStatusSettled {
+		return fmt.Errorf("self-upgrade attempt status %q is invalid", attempt.Status)
+	}
+	candidate := attempt.Candidate
+	if candidate.Platform != platform || candidate.Device == 0 || candidate.Inode == 0 ||
+		candidate.Size <= 0 || !ValidSHA256(candidate.SHA256) {
+		return fmt.Errorf("self-upgrade attempt identity is invalid")
+	}
+	version := strings.TrimSpace(candidate.EmbeddedVersion)
+	if version == "" || version != candidate.EmbeddedVersion || strings.ContainsRune(version, 0) {
+		return fmt.Errorf("self-upgrade attempt version is invalid")
+	}
+	if attempt.UnixTime <= 0 {
+		return fmt.Errorf("self-upgrade attempt time is invalid")
+	}
+	return nil
+}
+
+func (attempt Attempt) Matches(evidence ImageEvidence) bool {
+	return attempt.Candidate == RefusedCandidateFromEvidence(evidence)
+}
+
+func (attempt Attempt) RefusalReason() string {
+	return fmt.Sprintf(
+		"candidate was exec'd at %s and did not settle; refusing for 24h",
+		time.Unix(attempt.UnixTime, 0).UTC().Format(time.RFC3339),
+	)
+}
+
+func (attempt Attempt) IsFresh(now time.Time) bool {
+	if attempt.UnixTime <= 0 {
+		return false
+	}
+	recordedAt := time.Unix(attempt.UnixTime, 0)
+	age := now.UTC().Sub(recordedAt)
+	return age > -AttemptMaxAge && age < AttemptMaxAge
+}

--- a/internal/selfupgrade/attempt.go
+++ b/internal/selfupgrade/attempt.go
@@ -151,7 +151,7 @@ func AddAttempt(attempts []Attempt, addition Attempt, now time.Time) ([]Attempt,
 		}
 		if evict == -1 {
 			for index, attempt := range current {
-				if attempt.Status != AttemptStatusAttempt || attempt.IsFresh(now) {
+				if attempt.Status != AttemptStatusAttempt || attempt.IsFresh(now) || attempt.IsFutureUncertain(now) {
 					continue
 				}
 				if evict == -1 || attempt.UnixTime < current[evict].UnixTime {
@@ -183,9 +183,17 @@ func MergeAttempts(current, desired []Attempt, now time.Time) ([]Attempt, error)
 		mergedExisting := false
 		for index, existing := range merged {
 			if existing.Candidate == attempt.Candidate {
-				if existing.Status == AttemptStatusSettled {
+				switch {
+				case existing.IsFutureUncertain(now):
+					if !attempt.IsFutureUncertain(now) || attempt.UnixTime <= existing.UnixTime {
+						attempt = existing
+					}
+				case attempt.IsFutureUncertain(now):
+					// Preserve an uncertain timestamp so the caller can fail closed.
+				case existing.Status == AttemptStatusSettled ||
+					(attempt.Status == AttemptStatusSettled && attempt.UnixTime < existing.UnixTime):
 					attempt = existing
-				} else if attempt.Status != AttemptStatusSettled {
+				case attempt.Status != AttemptStatusSettled && attempt.UnixTime <= existing.UnixTime:
 					attempt = existing
 				}
 				merged[index] = attempt

--- a/internal/selfupgrade/attempt.go
+++ b/internal/selfupgrade/attempt.go
@@ -11,6 +11,8 @@ const (
 	AttemptStatusAttempt = "attempt"
 	AttemptStatusSettled = "settled"
 	AttemptMaxAge        = 24 * time.Hour
+	AttemptFutureSkew    = time.Hour
+	AttemptLimit         = 8
 )
 
 // Attempt records the stable identity of an image that was about to replace
@@ -52,13 +54,33 @@ func ValidateAttemptForPlatform(attempt Attempt, platform string) error {
 	return nil
 }
 
+// ValidateAttempts validates the bounded ledger and rejects duplicate image
+// identities. A duplicate would make settlement and refusal ownership
+// ambiguous after a concurrent publication.
+func ValidateAttempts(attempts []Attempt) error {
+	if len(attempts) > AttemptLimit {
+		return fmt.Errorf("self-upgrade attempt ledger exceeds the limit of %d", AttemptLimit)
+	}
+	seen := make(map[RefusedCandidate]struct{}, len(attempts))
+	for _, attempt := range attempts {
+		if err := ValidateAttempt(attempt); err != nil {
+			return err
+		}
+		if _, exists := seen[attempt.Candidate]; exists {
+			return fmt.Errorf("self-upgrade attempt ledger contains a duplicate candidate")
+		}
+		seen[attempt.Candidate] = struct{}{}
+	}
+	return nil
+}
+
 func (attempt Attempt) Matches(evidence ImageEvidence) bool {
 	return attempt.Candidate == RefusedCandidateFromEvidence(evidence)
 }
 
 func (attempt Attempt) RefusalReason() string {
 	return fmt.Sprintf(
-		"candidate was exec'd at %s and did not settle; refusing for 24h",
+		"replacement attempt was armed at %s and did not settle; refusing for 24h",
 		time.Unix(attempt.UnixTime, 0).UTC().Format(time.RFC3339),
 	)
 }
@@ -69,5 +91,116 @@ func (attempt Attempt) IsFresh(now time.Time) bool {
 	}
 	recordedAt := time.Unix(attempt.UnixTime, 0)
 	age := now.UTC().Sub(recordedAt)
-	return age > -AttemptMaxAge && age < AttemptMaxAge
+	return age > -AttemptFutureSkew && age < AttemptMaxAge
+}
+
+func (attempt Attempt) IsExpired(now time.Time) bool {
+	if attempt.Status != AttemptStatusAttempt || attempt.UnixTime <= 0 {
+		return false
+	}
+	return now.UTC().Sub(time.Unix(attempt.UnixTime, 0)) >= AttemptMaxAge
+}
+
+func (attempt Attempt) IsFutureUncertain(now time.Time) bool {
+	if attempt.UnixTime <= 0 {
+		return false
+	}
+	return now.UTC().Sub(time.Unix(attempt.UnixTime, 0)) <= -AttemptFutureSkew
+}
+
+// PruneExpiredAttempts removes only unresolved attempts that are past the
+// refusal window. Settled entries remain available for bounded ledger merge
+// and audit until they are evicted by a newer attempt.
+func PruneExpiredAttempts(attempts []Attempt, now time.Time) []Attempt {
+	pruned := make([]Attempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		if attempt.IsExpired(now) {
+			continue
+		}
+		pruned = append(pruned, attempt)
+	}
+	return pruned
+}
+
+// AddAttempt appends a new attempt without evicting a fresh unresolved
+// attempt. It returns an error when the bounded ledger contains no safe entry
+// to evict.
+func AddAttempt(attempts []Attempt, addition Attempt, now time.Time) ([]Attempt, error) {
+	if err := ValidateAttempts(attempts); err != nil {
+		return nil, err
+	}
+	if err := ValidateAttempt(addition); err != nil {
+		return nil, err
+	}
+	current := PruneExpiredAttempts(attempts, now)
+	for index, attempt := range current {
+		if attempt.Candidate == addition.Candidate {
+			current = append(current[:index], current[index+1:]...)
+			break
+		}
+	}
+	if len(current) >= AttemptLimit {
+		evict := -1
+		for index, attempt := range current {
+			if attempt.Status != AttemptStatusSettled {
+				continue
+			}
+			if evict == -1 || attempt.UnixTime < current[evict].UnixTime {
+				evict = index
+			}
+		}
+		if evict == -1 {
+			for index, attempt := range current {
+				if attempt.Status != AttemptStatusAttempt || attempt.IsFresh(now) {
+					continue
+				}
+				if evict == -1 || attempt.UnixTime < current[evict].UnixTime {
+					evict = index
+				}
+			}
+		}
+		if evict == -1 {
+			return nil, fmt.Errorf("self-upgrade attempt ledger is full of fresh unresolved attempts")
+		}
+		current = append(current[:evict], current[evict+1:]...)
+	}
+	current = append(current, addition)
+	return current, ValidateAttempts(current)
+}
+
+// MergeAttempts unions two controller views while preserving the bounded
+// ledger invariant. Settled entries are terminal, so a stale unresolved view
+// cannot reopen an entry that another controller settled.
+func MergeAttempts(current, desired []Attempt, now time.Time) ([]Attempt, error) {
+	if err := ValidateAttempts(current); err != nil {
+		return nil, err
+	}
+	if err := ValidateAttempts(desired); err != nil {
+		return nil, err
+	}
+	merged := PruneExpiredAttempts(current, now)
+	for _, attempt := range desired {
+		mergedExisting := false
+		for index, existing := range merged {
+			if existing.Candidate == attempt.Candidate {
+				if existing.Status == AttemptStatusSettled {
+					attempt = existing
+				} else if attempt.Status != AttemptStatusSettled {
+					attempt = existing
+				}
+				merged[index] = attempt
+				mergedExisting = true
+				break
+			}
+		}
+		if mergedExisting {
+			continue
+		}
+		var err error
+		merged, err = AddAttempt(merged, attempt, now)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
 }

--- a/internal/selfupgrade/attempt_test.go
+++ b/internal/selfupgrade/attempt_test.go
@@ -1,0 +1,17 @@
+package selfupgrade
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAttemptIsFreshAllowsBoundedFutureClockSkew(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	attempt := Attempt{UnixTime: now.Add(time.Hour).Unix()}
+	if !attempt.IsFresh(now) {
+		t.Fatal("future-dated attempt within the skew bound is not fresh")
+	}
+	if attempt.IsFresh(now.Add(-26 * time.Hour)) {
+		t.Fatal("future-dated attempt beyond the skew bound is fresh")
+	}
+}

--- a/internal/selfupgrade/attempt_test.go
+++ b/internal/selfupgrade/attempt_test.go
@@ -1,17 +1,76 @@
 package selfupgrade
 
 import (
+	"runtime"
+	"strconv"
 	"testing"
 	"time"
 )
 
 func TestAttemptIsFreshAllowsBoundedFutureClockSkew(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0).UTC()
-	attempt := Attempt{UnixTime: now.Add(time.Hour).Unix()}
+	attempt := Attempt{UnixTime: now.Add(AttemptFutureSkew - time.Second).Unix()}
 	if !attempt.IsFresh(now) {
 		t.Fatal("future-dated attempt within the skew bound is not fresh")
 	}
-	if attempt.IsFresh(now.Add(-26 * time.Hour)) {
-		t.Fatal("future-dated attempt beyond the skew bound is fresh")
+	uncertain := Attempt{UnixTime: now.Add(AttemptFutureSkew).Unix()}
+	if uncertain.IsFresh(now) {
+		t.Fatal("future-dated attempt at the skew boundary is fresh")
+	}
+	if uncertain.IsExpired(now) {
+		t.Fatal("future-dated attempt is expired")
+	}
+	if !uncertain.IsFutureUncertain(now) {
+		t.Fatal("future-dated attempt is not marked uncertain")
+	}
+}
+
+func TestAddAttemptDoesNotEvictFreshUnresolvedEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	incumbent := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.0.0",
+	}
+	attempts := make([]Attempt, 0, AttemptLimit)
+	for index := 0; index < AttemptLimit; index++ {
+		candidate := incumbent
+		candidate.Inode = uint64(index + 1)
+		candidate.EmbeddedVersion = "1.0." + strconv.Itoa(index+1)
+		attempts = append(attempts, NewAttempt(candidate, now))
+	}
+	addition := incumbent
+	addition.Inode = AttemptLimit + 1
+	addition.EmbeddedVersion = "2.0.0"
+	if _, err := AddAttempt(attempts, NewAttempt(addition, now), now); err == nil {
+		t.Fatal("AddAttempt() succeeded with a full fresh unresolved ledger")
+	}
+	if len(attempts) != AttemptLimit {
+		t.Fatalf("input ledger length = %d, want %d", len(attempts), AttemptLimit)
+	}
+}
+
+func TestMergeAttemptsDoesNotReopenSettledEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	evidence := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.1.0",
+	}
+	settled := NewAttempt(evidence, now.Add(-time.Minute))
+	settled.Status = AttemptStatusSettled
+	stale := NewAttempt(evidence, now)
+	merged, err := MergeAttempts([]Attempt{settled}, []Attempt{stale}, now)
+	if err != nil {
+		t.Fatalf("MergeAttempts() error = %v", err)
+	}
+	if len(merged) != 1 || merged[0].Status != AttemptStatusSettled {
+		t.Fatalf("merged attempts = %#v, want one settled entry", merged)
 	}
 }

--- a/internal/selfupgrade/attempt_test.go
+++ b/internal/selfupgrade/attempt_test.go
@@ -53,6 +53,41 @@ func TestAddAttemptDoesNotEvictFreshUnresolvedEntry(t *testing.T) {
 	}
 }
 
+func TestAddAttemptDoesNotEvictFutureUncertainEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	incumbent := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.0.0",
+	}
+	attempts := make([]Attempt, 0, AttemptLimit)
+	for index := 0; index < AttemptLimit; index++ {
+		candidate := incumbent
+		candidate.Inode = uint64(index + 1)
+		candidate.EmbeddedVersion = "1.0." + strconv.Itoa(index+1)
+		when := now
+		if index == 0 {
+			when = now.Add(AttemptFutureSkew + time.Second)
+		}
+		attempts = append(attempts, NewAttempt(candidate, when))
+	}
+	addition := incumbent
+	addition.Inode = AttemptLimit + 1
+	addition.EmbeddedVersion = "2.0.0"
+	if _, err := AddAttempt(attempts, NewAttempt(addition, now), now); err == nil {
+		t.Fatal("AddAttempt() succeeded with a full ledger containing a future-uncertain entry")
+	}
+	if len(attempts) != AttemptLimit {
+		t.Fatalf("input ledger length = %d, want %d", len(attempts), AttemptLimit)
+	}
+	if !attempts[0].IsFutureUncertain(now) {
+		t.Fatalf("future-uncertain entry = %#v, want preserved", attempts[0])
+	}
+}
+
 func TestMergeAttemptsDoesNotReopenSettledEntry(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0).UTC()
 	evidence := ImageEvidence{
@@ -72,5 +107,69 @@ func TestMergeAttemptsDoesNotReopenSettledEntry(t *testing.T) {
 	}
 	if len(merged) != 1 || merged[0].Status != AttemptStatusSettled {
 		t.Fatalf("merged attempts = %#v, want one settled entry", merged)
+	}
+}
+
+func TestMergeAttemptsPreservesNewerUnresolvedEntryAgainstOlderSettledView(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	evidence := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.1.0",
+	}
+	current := NewAttempt(evidence, now)
+	olderSettled := NewAttempt(evidence, now.Add(-time.Minute))
+	olderSettled.Status = AttemptStatusSettled
+	merged, err := MergeAttempts([]Attempt{current}, []Attempt{olderSettled}, now)
+	if err != nil {
+		t.Fatalf("MergeAttempts() error = %v", err)
+	}
+	if len(merged) != 1 || merged[0] != current {
+		t.Fatalf("merged attempts = %#v, want newer unresolved entry", merged)
+	}
+}
+
+func TestMergeAttemptsKeepsNewestUnresolvedEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	evidence := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.1.0",
+	}
+	older := NewAttempt(evidence, now.Add(-time.Minute))
+	newer := NewAttempt(evidence, now)
+	merged, err := MergeAttempts([]Attempt{older}, []Attempt{newer}, now)
+	if err != nil {
+		t.Fatalf("MergeAttempts() error = %v", err)
+	}
+	if len(merged) != 1 || merged[0] != newer {
+		t.Fatalf("merged attempts = %#v, want newest unresolved entry", merged)
+	}
+}
+
+func TestMergeAttemptsPreservesFutureUncertainty(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	evidence := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.1.0",
+	}
+	current := NewAttempt(evidence, now)
+	future := NewAttempt(evidence, now.Add(AttemptFutureSkew+time.Second))
+	merged, err := MergeAttempts([]Attempt{current}, []Attempt{future}, now)
+	if err != nil {
+		t.Fatalf("MergeAttempts() error = %v", err)
+	}
+	if len(merged) != 1 || merged[0] != future || !merged[0].IsFutureUncertain(now) {
+		t.Fatalf("merged attempts = %#v, want future-uncertain entry preserved", merged)
 	}
 }

--- a/internal/selfupgrade/attempt_test.go
+++ b/internal/selfupgrade/attempt_test.go
@@ -88,6 +88,27 @@ func TestAddAttemptDoesNotEvictFutureUncertainEntry(t *testing.T) {
 	}
 }
 
+func TestAddAttemptDoesNotDeleteMatchingFutureUncertainEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	candidate := ImageEvidence{
+		Platform:        runtime.GOOS,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		SHA256:          "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		EmbeddedVersion: "1.0.0",
+	}
+	future := NewAttempt(candidate, now.Add(AttemptFutureSkew+time.Second))
+	addition := NewAttempt(candidate, now)
+	attempts := []Attempt{future}
+	if _, err := AddAttempt(attempts, addition, now); err == nil {
+		t.Fatal("AddAttempt() succeeded with a matching future-uncertain entry")
+	}
+	if len(attempts) != 1 || attempts[0] != future {
+		t.Fatalf("input ledger = %#v, want matching future entry preserved", attempts)
+	}
+}
+
 func TestMergeAttemptsDoesNotReopenSettledEntry(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0).UTC()
 	evidence := ImageEvidence{

--- a/internal/selfupgrade/bounded_probe.go
+++ b/internal/selfupgrade/bounded_probe.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -23,7 +23,7 @@ type BoundedProbeOptions struct {
 	ExtraFiles []*os.File
 }
 
-// RunBoundedProbe runs a short-lived probe with bounded stdout and process
+// RunBoundedProbe runs a short-lived probe with bounded stdout and stderr and process
 // cleanup. Callers must use it only after binding and verifying the image. A
 // wake uses this for the post-bind preflight of the exact image it already
 // verified; it is not a candidate-version discovery mechanism.
@@ -46,28 +46,47 @@ func RunBoundedProbe(
 		command.ExtraFiles = options.ExtraFiles
 	}
 	output := &boundedProbeOutput{remaining: boundedProbeMaxOutput}
+	stderr := &boundedProbeOutput{remaining: boundedProbeMaxOutput}
 	command.Stdout = output
-	command.Stderr = io.Discard
+	command.Stderr = stderr
 	if err := command.Start(); err != nil {
 		return nil, err
 	}
 	pid := command.Process.Pid
 	waitErr := command.Wait()
 	cleanupErr := cleanupBoundedProbeProcessGroup(pid)
-	if waitErr != nil {
-		if cleanupErr != nil {
-			return nil, errors.Join(
-				waitErr,
-				fmt.Errorf("bounded probe process-group cleanup: %w", cleanupErr),
+	wrapProbeError := func(probeErr error) error {
+		if probeErr == nil {
+			return nil
+		}
+		if stderr.overflow {
+			probeErr = errors.Join(
+				probeErr,
+				fmt.Errorf("bounded probe stderr exceeds %d bytes", boundedProbeMaxOutput),
 			)
 		}
-		return nil, waitErr
+		if diagnostic := strings.TrimSpace(stderr.buffer.String()); diagnostic != "" {
+			probeErr = fmt.Errorf("%w; stderr: %s", probeErr, diagnostic)
+		}
+		return probeErr
+	}
+	if waitErr != nil {
+		if cleanupErr != nil {
+			return nil, wrapProbeError(errors.Join(
+				waitErr,
+				fmt.Errorf("bounded probe process-group cleanup: %w", cleanupErr),
+			))
+		}
+		return nil, wrapProbeError(waitErr)
 	}
 	if cleanupErr != nil {
-		return nil, fmt.Errorf("bounded probe process-group cleanup: %w", cleanupErr)
+		return nil, wrapProbeError(fmt.Errorf("bounded probe process-group cleanup: %w", cleanupErr))
 	}
 	if output.overflow {
-		return nil, fmt.Errorf("bounded probe output exceeds %d bytes", boundedProbeMaxOutput)
+		return nil, wrapProbeError(fmt.Errorf("bounded probe output exceeds %d bytes", boundedProbeMaxOutput))
+	}
+	if stderr.overflow {
+		return nil, wrapProbeError(fmt.Errorf("bounded probe stderr exceeds %d bytes", boundedProbeMaxOutput))
 	}
 	return append([]byte(nil), output.buffer.Bytes()...), nil
 }

--- a/internal/selfupgrade/bounded_probe_unix_test.go
+++ b/internal/selfupgrade/bounded_probe_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -45,6 +46,19 @@ printf 'probe-ok\n'
 		t.Fatalf("RunBoundedProbe() took %v, want at most %v", elapsed, boundedProbeWaitDelay+2*time.Second)
 	}
 	waitForBoundedProbeChildExit(t, pid)
+}
+
+func TestRunBoundedProbeIncludesTrimmedStderrInError(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = RunBoundedProbe(ctx, shell, []string{"-c", "printf 'codesign: invalid signature  \\n' >&2; exit 1"}, BoundedProbeOptions{})
+	if err == nil || !strings.Contains(err.Error(), "stderr: codesign: invalid signature") {
+		t.Fatalf("RunBoundedProbe() error = %v, want trimmed stderr diagnostic", err)
+	}
 }
 
 func runBoundedProbeShellTest(t *testing.T, script string) (int, []byte, error) {

--- a/internal/selfupgrade/darwin_tools.go
+++ b/internal/selfupgrade/darwin_tools.go
@@ -21,7 +21,8 @@ func verifyDarwinSystemTool(path string) error {
 		return err
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 || stat.Uid != 0 {
+	if !ok || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 ||
+		info.Mode().Perm()&0o022 != 0 || stat.Uid != 0 {
 		return fmt.Errorf("darwin system tool %s is not a root-owned executable regular file", path)
 	}
 	return nil

--- a/internal/selfupgrade/darwin_tools.go
+++ b/internal/selfupgrade/darwin_tools.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package selfupgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+var selfUpgradeDarwinToolLstat = os.Lstat
+
+func verifyDarwinSystemTool(path string) error {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return errors.New("darwin system tool path is not absolute and canonical")
+	}
+	info, err := selfUpgradeDarwinToolLstat(path)
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 || stat.Uid != 0 {
+		return fmt.Errorf("darwin system tool %s is not a root-owned executable regular file", path)
+	}
+	return nil
+}

--- a/internal/selfupgrade/darwin_tools_test.go
+++ b/internal/selfupgrade/darwin_tools_test.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package selfupgrade
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type darwinToolTestFileInfo struct {
+	mode os.FileMode
+	sys  *syscall.Stat_t
+}
+
+func (info darwinToolTestFileInfo) Name() string       { return "tool" }
+func (info darwinToolTestFileInfo) Size() int64        { return 1 }
+func (info darwinToolTestFileInfo) Mode() os.FileMode  { return info.mode }
+func (info darwinToolTestFileInfo) ModTime() time.Time { return time.Time{} }
+func (info darwinToolTestFileInfo) IsDir() bool        { return false }
+func (info darwinToolTestFileInfo) Sys() any           { return info.sys }
+
+func TestVerifyDarwinSystemToolRejectsGroupAndWorldWritableModes(t *testing.T) {
+	previous := selfUpgradeDarwinToolLstat
+	t.Cleanup(func() { selfUpgradeDarwinToolLstat = previous })
+	for _, path := range []string{"/usr/bin/codesign", "/bin/ps"} {
+		for _, test := range []struct {
+			name string
+			mode os.FileMode
+			want bool
+		}{
+			{name: "private executable", mode: 0o755},
+			{name: "group writable", mode: 0o775, want: true},
+			{name: "world writable", mode: 0o757, want: true},
+		} {
+			t.Run(filepath.Base(path)+"/"+test.name, func(t *testing.T) {
+				selfUpgradeDarwinToolLstat = func(got string) (os.FileInfo, error) {
+					if got != path {
+						t.Fatalf("lstat path = %q, want %q", got, path)
+					}
+					return darwinToolTestFileInfo{
+						mode: test.mode,
+						sys:  &syscall.Stat_t{Uid: 0},
+					}, nil
+				}
+				err := verifyDarwinSystemTool(path)
+				if (err != nil) != test.want {
+					t.Fatalf("verifyDarwinSystemTool() error = %v, wantErr=%t", err, test.want)
+				}
+			})
+		}
+	}
+}

--- a/internal/selfupgrade/exec_darwin.go
+++ b/internal/selfupgrade/exec_darwin.go
@@ -3,17 +3,51 @@
 package selfupgrade
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
+const darwinCodeSignProbeTimeout = 5 * time.Second
+
+var (
+	selfUpgradeCodesignLookPath = exec.LookPath
+	selfUpgradeDarwinExec       = syscall.Exec
+)
+
 func execSupportedPlatform() bool { return true }
+
+func verifyDarwinCodeSignature(stagePath string) error {
+	codesignPath, err := selfUpgradeCodesignLookPath("codesign")
+	if err != nil {
+		return fmt.Errorf(
+			"verify Darwin code signature: codesign is unavailable; install Xcode Command Line Tools with xcode-select --install: %w",
+			err,
+		)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), darwinCodeSignProbeTimeout)
+	defer cancel()
+	if _, err := RunBoundedProbe(
+		ctx,
+		codesignPath,
+		[]string{"--verify", "--strict", stagePath},
+		BoundedProbeOptions{Env: os.Environ()},
+	); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("verify Darwin code signature: codesign probe timed out: %w", ctx.Err())
+		}
+		return fmt.Errorf("verify Darwin code signature for %s: %w", stagePath, err)
+	}
+	return nil
+}
 
 func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
 	if candidate.ExecutionPath == "" {
@@ -96,9 +130,12 @@ func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
 	if !SameDarwinStagedImageEvidence(staged, candidate) {
 		return errors.New("self-upgrade stage changed while binding")
 	}
+	if err := verifyDarwinCodeSignature(stagePath); err != nil {
+		return err
+	}
 	// Darwin cannot exec an open file descriptor. The private 0700 stage
 	// directory named with our PID is re-verified immediately before exec;
 	// same-UID races in that window are outside AMQ's threat model, as for wake
 	// self-upgrade.
-	return syscall.Exec(stagePath, argv, env)
+	return selfUpgradeDarwinExec(stagePath, argv, env)
 }

--- a/internal/selfupgrade/exec_darwin.go
+++ b/internal/selfupgrade/exec_darwin.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,15 +19,18 @@ import (
 const darwinCodeSignProbeTimeout = 5 * time.Second
 
 var (
-	selfUpgradeCodesignLookPath = exec.LookPath
-	selfUpgradeDarwinExec       = syscall.Exec
+	selfUpgradeCodesignPath  = "/usr/bin/codesign"
+	selfUpgradeCodesignProbe = RunBoundedProbe
+	selfUpgradeDarwinExec    = syscall.Exec
 )
 
 func execSupportedPlatform() bool { return true }
 
 func verifyDarwinCodeSignature(stagePath string) error {
-	codesignPath, err := selfUpgradeCodesignLookPath("codesign")
-	if err != nil {
+	if err := verifyDarwinSystemTool(selfUpgradeCodesignPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("verify Darwin code signature tool: %w", err)
+		}
 		return fmt.Errorf(
 			"verify Darwin code signature: codesign is unavailable; install Xcode Command Line Tools with xcode-select --install: %w",
 			err,
@@ -35,18 +38,29 @@ func verifyDarwinCodeSignature(stagePath string) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), darwinCodeSignProbeTimeout)
 	defer cancel()
-	if _, err := RunBoundedProbe(
+	out, err := selfUpgradeCodesignProbe(
 		ctx,
-		codesignPath,
+		selfUpgradeCodesignPath,
 		[]string{"--verify", "--strict", stagePath},
 		BoundedProbeOptions{Env: os.Environ()},
-	); err != nil {
+	)
+	if err != nil {
 		if ctx.Err() != nil {
-			return fmt.Errorf("verify Darwin code signature: codesign probe timed out: %w", ctx.Err())
+			return fmt.Errorf(
+				"verify Darwin code signature: codesign probe timed out: %w",
+				errors.Join(ctx.Err(), err),
+			)
 		}
 		return fmt.Errorf("verify Darwin code signature for %s: %w", stagePath, err)
 	}
+	if diagnostic := strings.TrimSpace(string(out)); diagnostic != "" {
+		return fmt.Errorf("verify Darwin code signature for %s: ambiguous codesign output %q", stagePath, diagnostic)
+	}
 	return nil
+}
+
+func VerifyDarwinCodeSignature(stagePath string) error {
+	return verifyDarwinCodeSignature(stagePath)
 }
 
 func execImagePlatform(candidate ImageEvidence, argv, env []string) error {

--- a/internal/selfupgrade/exec_darwin.go
+++ b/internal/selfupgrade/exec_darwin.go
@@ -32,7 +32,7 @@ func verifyDarwinCodeSignature(stagePath string) error {
 			return fmt.Errorf("verify Darwin code signature tool: %w", err)
 		}
 		return fmt.Errorf(
-			"verify Darwin code signature: codesign is unavailable; install Xcode Command Line Tools with xcode-select --install: %w",
+			"verify Darwin code signature: /usr/bin/codesign must exist and pass validation; otherwise replacement is refused: %w",
 			err,
 		)
 	}
@@ -148,8 +148,8 @@ func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
 		return err
 	}
 	// Darwin cannot exec an open file descriptor. The private 0700 stage
-	// directory named with our PID is re-verified immediately before exec;
-	// same-UID races in that window are outside AMQ's threat model, as for wake
-	// self-upgrade.
+	// directory named with our PID is signature-verified before pathname exec;
+	// same-UID races after that validation are outside AMQ's threat model, as for
+	// wake self-upgrade.
 	return selfUpgradeDarwinExec(stagePath, argv, env)
 }

--- a/internal/selfupgrade/exec_darwin_test.go
+++ b/internal/selfupgrade/exec_darwin_test.go
@@ -18,22 +18,12 @@ func TestExecImagePlatformRejectsModifiedDarwinCodeSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	codesignPath, err := exec.LookPath("codesign")
-	if err != nil {
-		t.Fatal(err)
-	}
-	previousLookPath := selfUpgradeCodesignLookPath
+	previousPath := selfUpgradeCodesignPath
 	previousExec := selfUpgradeDarwinExec
 	t.Cleanup(func() {
-		selfUpgradeCodesignLookPath = previousLookPath
+		selfUpgradeCodesignPath = previousPath
 		selfUpgradeDarwinExec = previousExec
 	})
-	selfUpgradeCodesignLookPath = func(name string) (string, error) {
-		if name != "codesign" {
-			t.Fatalf("looked up %q, want codesign", name)
-		}
-		return codesignPath, nil
-	}
 	execCalls := 0
 	selfUpgradeDarwinExec = func(string, []string, []string) error {
 		execCalls++
@@ -55,22 +45,12 @@ func TestExecImagePlatformAcceptsIntactDarwinCodeSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	codesignPath, err := exec.LookPath("codesign")
-	if err != nil {
-		t.Fatal(err)
-	}
-	previousLookPath := selfUpgradeCodesignLookPath
+	previousPath := selfUpgradeCodesignPath
 	previousExec := selfUpgradeDarwinExec
 	t.Cleanup(func() {
-		selfUpgradeCodesignLookPath = previousLookPath
+		selfUpgradeCodesignPath = previousPath
 		selfUpgradeDarwinExec = previousExec
 	})
-	selfUpgradeCodesignLookPath = func(name string) (string, error) {
-		if name != "codesign" {
-			t.Fatalf("looked up %q, want codesign", name)
-		}
-		return codesignPath, nil
-	}
 	wantExecErr := errors.New("stop before replacement")
 	execCalls := 0
 	selfUpgradeDarwinExec = func(string, []string, []string) error {
@@ -97,13 +77,13 @@ func TestExecImagePlatformReportsMissingDarwinCodeSignatureTool(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	previousLookPath := selfUpgradeCodesignLookPath
+	previousPath := selfUpgradeCodesignPath
 	previousExec := selfUpgradeDarwinExec
 	t.Cleanup(func() {
-		selfUpgradeCodesignLookPath = previousLookPath
+		selfUpgradeCodesignPath = previousPath
 		selfUpgradeDarwinExec = previousExec
 	})
-	selfUpgradeCodesignLookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	selfUpgradeCodesignPath = filepath.Join(dir, "missing-codesign")
 	execCalls := 0
 	selfUpgradeDarwinExec = func(string, []string, []string) error {
 		execCalls++
@@ -133,10 +113,7 @@ func signedDarwinCandidate(t *testing.T) string {
 	if err := os.WriteFile(candidatePath, data, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	codesignPath, err := exec.LookPath("codesign")
-	if err != nil {
-		t.Fatalf("look up codesign for signed fixture: %v", err)
-	}
+	codesignPath := "/usr/bin/codesign"
 	output, err := exec.Command(
 		codesignPath,
 		"--force",

--- a/internal/selfupgrade/exec_darwin_test.go
+++ b/internal/selfupgrade/exec_darwin_test.go
@@ -1,0 +1,180 @@
+//go:build darwin
+
+package selfupgrade
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecImagePlatformRejectsModifiedDarwinCodeSignature(t *testing.T) {
+	candidatePath := signedDarwinCandidate(t)
+	corruptDarwinCandidate(t, candidatePath)
+	candidate, err := CaptureImageEvidence(candidatePath, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	codesignPath, err := exec.LookPath("codesign")
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousLookPath := selfUpgradeCodesignLookPath
+	previousExec := selfUpgradeDarwinExec
+	t.Cleanup(func() {
+		selfUpgradeCodesignLookPath = previousLookPath
+		selfUpgradeDarwinExec = previousExec
+	})
+	selfUpgradeCodesignLookPath = func(name string) (string, error) {
+		if name != "codesign" {
+			t.Fatalf("looked up %q, want codesign", name)
+		}
+		return codesignPath, nil
+	}
+	execCalls := 0
+	selfUpgradeDarwinExec = func(string, []string, []string) error {
+		execCalls++
+		return errors.New("unexpected exec")
+	}
+
+	err = execImagePlatform(candidate, []string{candidatePath}, os.Environ())
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "modified") {
+		t.Fatalf("execImagePlatform() error = %v, want signature refusal", err)
+	}
+	if execCalls != 0 {
+		t.Fatalf("exec calls = %d, want zero after signature refusal", execCalls)
+	}
+}
+
+func TestExecImagePlatformAcceptsIntactDarwinCodeSignature(t *testing.T) {
+	candidatePath := signedDarwinCandidate(t)
+	candidate, err := CaptureImageEvidence(candidatePath, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	codesignPath, err := exec.LookPath("codesign")
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousLookPath := selfUpgradeCodesignLookPath
+	previousExec := selfUpgradeDarwinExec
+	t.Cleanup(func() {
+		selfUpgradeCodesignLookPath = previousLookPath
+		selfUpgradeDarwinExec = previousExec
+	})
+	selfUpgradeCodesignLookPath = func(name string) (string, error) {
+		if name != "codesign" {
+			t.Fatalf("looked up %q, want codesign", name)
+		}
+		return codesignPath, nil
+	}
+	wantExecErr := errors.New("stop before replacement")
+	execCalls := 0
+	selfUpgradeDarwinExec = func(string, []string, []string) error {
+		execCalls++
+		return wantExecErr
+	}
+
+	err = execImagePlatform(candidate, []string{candidatePath}, os.Environ())
+	if !errors.Is(err, wantExecErr) {
+		t.Fatalf("execImagePlatform() error = %v, want injected exec error", err)
+	}
+	if execCalls != 1 {
+		t.Fatalf("exec calls = %d, want one after signature verification", execCalls)
+	}
+}
+
+func TestExecImagePlatformReportsMissingDarwinCodeSignatureTool(t *testing.T) {
+	dir := t.TempDir()
+	candidatePath := filepath.Join(dir, "amq-keepalive")
+	if err := os.WriteFile(candidatePath, []byte("candidate"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := CaptureImageEvidence(candidatePath, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousLookPath := selfUpgradeCodesignLookPath
+	previousExec := selfUpgradeDarwinExec
+	t.Cleanup(func() {
+		selfUpgradeCodesignLookPath = previousLookPath
+		selfUpgradeDarwinExec = previousExec
+	})
+	selfUpgradeCodesignLookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	execCalls := 0
+	selfUpgradeDarwinExec = func(string, []string, []string) error {
+		execCalls++
+		return nil
+	}
+
+	err = execImagePlatform(candidate, []string{candidatePath}, os.Environ())
+	if err == nil || !strings.Contains(err.Error(), "xcode-select --install") {
+		t.Fatalf("execImagePlatform() error = %v, want installation remedy", err)
+	}
+	if execCalls != 0 {
+		t.Fatalf("exec calls = %d, want zero when codesign is missing", execCalls)
+	}
+}
+
+func signedDarwinCandidate(t *testing.T) string {
+	t.Helper()
+	sourcePath, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePath := filepath.Join(t.TempDir(), "amq-keepalive")
+	if err := os.WriteFile(candidatePath, data, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	codesignPath, err := exec.LookPath("codesign")
+	if err != nil {
+		t.Fatalf("look up codesign for signed fixture: %v", err)
+	}
+	output, err := exec.Command(
+		codesignPath,
+		"--force",
+		"--sign",
+		"-",
+		"--timestamp=none",
+		candidatePath,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("codesign signed fixture: %v\n%s", err, output)
+	}
+	return candidatePath
+}
+
+func corruptDarwinCandidate(t *testing.T, candidatePath string) {
+	t.Helper()
+	file, err := os.OpenFile(candidatePath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() < 2 {
+		t.Fatalf("signed fixture size = %d, want at least two bytes", info.Size())
+	}
+	offset := info.Size() / 2
+	var byteAtOffset [1]byte
+	if _, err := file.ReadAt(byteAtOffset[:], offset); err != nil {
+		t.Fatal(err)
+	}
+	byteAtOffset[0] ^= 0xff
+	if _, err := file.WriteAt(byteAtOffset[:], offset); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Sync(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/selfupgrade/exec_darwin_test.go
+++ b/internal/selfupgrade/exec_darwin_test.go
@@ -91,7 +91,7 @@ func TestExecImagePlatformReportsMissingDarwinCodeSignatureTool(t *testing.T) {
 	}
 
 	err = execImagePlatform(candidate, []string{candidatePath}, os.Environ())
-	if err == nil || !strings.Contains(err.Error(), "xcode-select --install") {
+	if err == nil || !strings.Contains(err.Error(), "/usr/bin/codesign must exist and pass validation") {
 		t.Fatalf("execImagePlatform() error = %v, want installation remedy", err)
 	}
 	if execCalls != 0 {

--- a/internal/selfupgrade/stages_darwin.go
+++ b/internal/selfupgrade/stages_darwin.go
@@ -3,13 +3,24 @@
 package selfupgrade
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
+)
+
+const selfUpgradeStagePIDProbeTimeout = 5 * time.Second
+
+var (
+	selfUpgradeStagePIDKill         = syscall.Kill
+	selfUpgradeStagePSLookPath      = exec.LookPath
+	selfUpgradeStageRunBoundedProbe = RunBoundedProbe
 )
 
 func selfUpgradeStagePrefix(locator string) string {
@@ -84,6 +95,50 @@ func selfUpgradeStagePIDLive(pid int) bool {
 	if pid == os.Getpid() {
 		return false
 	}
-	err := syscall.Kill(pid, 0)
-	return err == nil || !errors.Is(err, syscall.ESRCH)
+	err := selfUpgradeStagePIDKill(pid, 0)
+	switch {
+	case errors.Is(err, syscall.ESRCH):
+		return false
+	case errors.Is(err, syscall.EPERM):
+		return true
+	case err != nil:
+		return true
+	}
+
+	comm, err := selfUpgradeStagePIDComm(pid)
+	if err != nil {
+		return true
+	}
+	return comm == "amq" || comm == "amq-keepalive"
+}
+
+func selfUpgradeStagePIDComm(pid int) (string, error) {
+	psPath, err := selfUpgradeStagePSLookPath("ps")
+	if err != nil {
+		return "", fmt.Errorf("find ps for self-upgrade stage PID %d: %w", pid, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeStagePIDProbeTimeout)
+	defer cancel()
+	out, err := selfUpgradeStageRunBoundedProbe(
+		ctx,
+		psPath,
+		[]string{"-o", "comm=", "-p", strconv.Itoa(pid)},
+		BoundedProbeOptions{Env: os.Environ()},
+	)
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("inspect self-upgrade stage PID %d timed out: %w", pid, ctx.Err())
+		}
+		return "", fmt.Errorf("inspect self-upgrade stage PID %d: %w", pid, err)
+	}
+	trimmed := strings.TrimSpace(string(out))
+	lines := strings.Split(trimmed, "\n")
+	if trimmed == "" || len(lines) != 1 {
+		return "", fmt.Errorf("inspect self-upgrade stage PID %d: ps returned ambiguous command %q", pid, string(out))
+	}
+	comm := strings.TrimSpace(lines[0])
+	if comm == "" || strings.ContainsRune(comm, '\r') {
+		return "", fmt.Errorf("inspect self-upgrade stage PID %d: ps returned invalid command %q", pid, string(out))
+	}
+	return filepath.Base(comm), nil
 }

--- a/internal/selfupgrade/stages_darwin.go
+++ b/internal/selfupgrade/stages_darwin.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -19,7 +18,7 @@ const selfUpgradeStagePIDProbeTimeout = 5 * time.Second
 
 var (
 	selfUpgradeStagePIDKill         = syscall.Kill
-	selfUpgradeStagePSLookPath      = exec.LookPath
+	selfUpgradeStagePSPath          = "/bin/ps"
 	selfUpgradeStageRunBoundedProbe = RunBoundedProbe
 )
 
@@ -113,15 +112,14 @@ func selfUpgradeStagePIDLive(pid int) bool {
 }
 
 func selfUpgradeStagePIDComm(pid int) (string, error) {
-	psPath, err := selfUpgradeStagePSLookPath("ps")
-	if err != nil {
-		return "", fmt.Errorf("find ps for self-upgrade stage PID %d: %w", pid, err)
+	if err := verifyDarwinSystemTool(selfUpgradeStagePSPath); err != nil {
+		return "", fmt.Errorf("verify ps for self-upgrade stage PID %d: %w", pid, err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeStagePIDProbeTimeout)
 	defer cancel()
 	out, err := selfUpgradeStageRunBoundedProbe(
 		ctx,
-		psPath,
+		selfUpgradeStagePSPath,
 		[]string{"-o", "comm=", "-p", strconv.Itoa(pid)},
 		BoundedProbeOptions{Env: os.Environ()},
 	)

--- a/internal/selfupgrade/stages_darwin_test.go
+++ b/internal/selfupgrade/stages_darwin_test.go
@@ -3,29 +3,154 @@
 package selfupgrade
 
 import (
+	"context"
+	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"syscall"
 	"testing"
 )
 
-func TestCleanupStagesLeavesLiveProcessStages(t *testing.T) {
+func TestSelfUpgradeStagePIDLiveClassifiesProcess(t *testing.T) {
+	tests := []struct {
+		name        string
+		killErr     error
+		lookPathErr error
+		probeOutput string
+		probeErr    error
+		wantLive    bool
+		wantPS      bool
+	}{
+		{
+			name:     "eperm keeps stage",
+			killErr:  syscall.EPERM,
+			wantLive: true,
+		},
+		{
+			name:        "foreign command is stale",
+			probeOutput: "sleep\n",
+			wantLive:    false,
+			wantPS:      true,
+		},
+		{
+			name:        "amq command keeps stage",
+			probeOutput: "amq\n",
+			wantLive:    true,
+			wantPS:      true,
+		},
+		{
+			name:        "keepalive command keeps stage",
+			probeOutput: "amq-keepalive\n",
+			wantLive:    true,
+			wantPS:      true,
+		},
+		{
+			name:     "esrch removes stage",
+			killErr:  syscall.ESRCH,
+			wantLive: false,
+		},
+		{
+			name:        "missing ps keeps stage",
+			lookPathErr: errors.New("ps unavailable"),
+			wantLive:    true,
+			wantPS:      true,
+		},
+		{
+			name:     "probe error keeps stage",
+			probeErr: errors.New("ps failed"),
+			wantLive: true,
+			wantPS:   true,
+		},
+		{
+			name:        "ambiguous command keeps stage",
+			probeOutput: "amq\nsleep\n",
+			wantLive:    true,
+			wantPS:      true,
+		},
+	}
+
+	previousKill := selfUpgradeStagePIDKill
+	previousLookPath := selfUpgradeStagePSLookPath
+	previousProbe := selfUpgradeStageRunBoundedProbe
+	t.Cleanup(func() {
+		selfUpgradeStagePIDKill = previousKill
+		selfUpgradeStagePSLookPath = previousLookPath
+		selfUpgradeStageRunBoundedProbe = previousProbe
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const pid = 12345
+			probeCalls := 0
+			lookPathCalls := 0
+			selfUpgradeStagePIDKill = func(gotPID int, signal syscall.Signal) error {
+				if gotPID != pid || signal != 0 {
+					t.Fatalf("Kill(%d, %d), want Kill(%d, 0)", gotPID, signal, pid)
+				}
+				return tt.killErr
+			}
+			selfUpgradeStagePSLookPath = func(name string) (string, error) {
+				lookPathCalls++
+				if name != "ps" {
+					t.Fatalf("LookPath(%q), want ps", name)
+				}
+				if tt.lookPathErr != nil {
+					return "", tt.lookPathErr
+				}
+				return "/bin/ps", nil
+			}
+			selfUpgradeStageRunBoundedProbe = func(
+				ctx context.Context,
+				path string,
+				args []string,
+				_ BoundedProbeOptions,
+			) ([]byte, error) {
+				probeCalls++
+				if path != "/bin/ps" {
+					t.Fatalf("probe path = %q, want /bin/ps", path)
+				}
+				wantArgs := []string{"-o", "comm=", "-p", strconv.Itoa(pid)}
+				if !slices.Equal(args, wantArgs) {
+					t.Fatalf("probe args = %#v, want %#v", args, wantArgs)
+				}
+				if ctx == nil {
+					t.Fatal("probe context is nil")
+				}
+				return []byte(tt.probeOutput), tt.probeErr
+			}
+
+			got := selfUpgradeStagePIDLive(pid)
+			if got != tt.wantLive {
+				t.Fatalf("selfUpgradeStagePIDLive(%d) = %t, want %t", pid, got, tt.wantLive)
+			}
+			if got := lookPathCalls > 0; got != tt.wantPS {
+				t.Fatalf("ps lookup called = %t, want %t", got, tt.wantPS)
+			}
+			wantProbeCalls := 0
+			if tt.wantPS && tt.lookPathErr == nil {
+				wantProbeCalls = 1
+			}
+			if probeCalls != wantProbeCalls {
+				t.Fatalf("probe calls = %d, want %d", probeCalls, wantProbeCalls)
+			}
+		})
+	}
+}
+
+func TestCleanupStagesRemovesDeadAndForeignStages(t *testing.T) {
 	dir := t.TempDir()
 	locator := filepath.Join(dir, "amq-keepalive")
-	liveProcess := exec.Command("sleep", "30")
-	if err := liveProcess.Start(); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = liveProcess.Process.Kill()
-		_ = liveProcess.Wait()
-	})
-	liveDir := filepath.Join(dir, selfUpgradeStagePrefix(locator)+strconv.Itoa(liveProcess.Process.Pid)+"-live")
-	deadPID := deadSelfUpgradeStagePID(t)
-	deadDir := filepath.Join(dir, selfUpgradeStagePrefix(locator)+strconv.Itoa(deadPID)+"-dead")
-	for _, stageDir := range []string{liveDir, deadDir} {
+	const (
+		foreignPID = 1001
+		amqPID     = 1002
+		deadPID    = 1003
+	)
+	stageDirs := map[int]string{}
+	for _, pid := range []int{foreignPID, amqPID, deadPID} {
+		stageDir := filepath.Join(dir, selfUpgradeStagePrefix(locator)+strconv.Itoa(pid)+"-stage")
+		stageDirs[pid] = stageDir
 		if err := os.Mkdir(stageDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
@@ -34,24 +159,64 @@ func TestCleanupStagesLeavesLiveProcessStages(t *testing.T) {
 		}
 	}
 
+	previousKill := selfUpgradeStagePIDKill
+	previousLookPath := selfUpgradeStagePSLookPath
+	previousProbe := selfUpgradeStageRunBoundedProbe
+	t.Cleanup(func() {
+		selfUpgradeStagePIDKill = previousKill
+		selfUpgradeStagePSLookPath = previousLookPath
+		selfUpgradeStageRunBoundedProbe = previousProbe
+	})
+	selfUpgradeStagePIDKill = func(pid int, _ syscall.Signal) error {
+		switch pid {
+		case foreignPID, amqPID:
+			return nil
+		case deadPID:
+			return syscall.ESRCH
+		default:
+			t.Fatalf("unexpected PID %d", pid)
+			return syscall.ESRCH
+		}
+	}
+	selfUpgradeStagePSLookPath = func(name string) (string, error) {
+		if name != "ps" {
+			t.Fatalf("LookPath(%q), want ps", name)
+		}
+		return "/bin/ps", nil
+	}
+	selfUpgradeStageRunBoundedProbe = func(
+		_ context.Context,
+		path string,
+		args []string,
+		_ BoundedProbeOptions,
+	) ([]byte, error) {
+		if path != "/bin/ps" {
+			t.Fatalf("probe path = %q, want /bin/ps", path)
+		}
+		if len(args) != 4 || args[0] != "-o" || args[1] != "comm=" || args[2] != "-p" {
+			t.Fatalf("probe args = %#v, want ps -o comm= -p <pid>", args)
+		}
+		switch args[3] {
+		case strconv.Itoa(foreignPID):
+			return []byte("sleep\n"), nil
+		case strconv.Itoa(amqPID):
+			return []byte("amq-keepalive\n"), nil
+		default:
+			t.Fatalf("unexpected probe PID %q", args[3])
+			return nil, errors.New("unexpected probe PID")
+		}
+	}
+
 	if err := CleanupStages(locator); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(liveDir); err != nil {
-		t.Fatalf("live stage = %v, want preserved", err)
+	if _, err := os.Stat(stageDirs[foreignPID]); !os.IsNotExist(err) {
+		t.Fatalf("foreign stage = %v, want removed", err)
 	}
-	if _, err := os.Stat(deadDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(stageDirs[deadPID]); !os.IsNotExist(err) {
 		t.Fatalf("dead stage = %v, want removed", err)
 	}
-}
-
-func deadSelfUpgradeStagePID(t *testing.T) int {
-	t.Helper()
-	for pid := os.Getpid() + 1; pid < os.Getpid()+10000; pid++ {
-		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
-			return pid
-		}
+	if _, err := os.Stat(stageDirs[amqPID]); err != nil {
+		t.Fatalf("AMQ stage = %v, want preserved", err)
 	}
-	t.Fatal("could not find a dead process id")
-	return 0
 }

--- a/internal/selfupgrade/stages_darwin_test.go
+++ b/internal/selfupgrade/stages_darwin_test.go
@@ -72,11 +72,11 @@ func TestSelfUpgradeStagePIDLiveClassifiesProcess(t *testing.T) {
 	}
 
 	previousKill := selfUpgradeStagePIDKill
-	previousLookPath := selfUpgradeStagePSLookPath
+	previousToolLstat := selfUpgradeDarwinToolLstat
 	previousProbe := selfUpgradeStageRunBoundedProbe
 	t.Cleanup(func() {
 		selfUpgradeStagePIDKill = previousKill
-		selfUpgradeStagePSLookPath = previousLookPath
+		selfUpgradeDarwinToolLstat = previousToolLstat
 		selfUpgradeStageRunBoundedProbe = previousProbe
 	})
 
@@ -84,22 +84,22 @@ func TestSelfUpgradeStagePIDLiveClassifiesProcess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			const pid = 12345
 			probeCalls := 0
-			lookPathCalls := 0
+			toolLstatCalls := 0
 			selfUpgradeStagePIDKill = func(gotPID int, signal syscall.Signal) error {
 				if gotPID != pid || signal != 0 {
 					t.Fatalf("Kill(%d, %d), want Kill(%d, 0)", gotPID, signal, pid)
 				}
 				return tt.killErr
 			}
-			selfUpgradeStagePSLookPath = func(name string) (string, error) {
-				lookPathCalls++
-				if name != "ps" {
-					t.Fatalf("LookPath(%q), want ps", name)
+			selfUpgradeDarwinToolLstat = func(path string) (os.FileInfo, error) {
+				toolLstatCalls++
+				if path != "/bin/ps" {
+					t.Fatalf("Lstat(%q), want /bin/ps", path)
 				}
 				if tt.lookPathErr != nil {
-					return "", tt.lookPathErr
+					return nil, tt.lookPathErr
 				}
-				return "/bin/ps", nil
+				return os.Lstat("/bin/ps")
 			}
 			selfUpgradeStageRunBoundedProbe = func(
 				ctx context.Context,
@@ -125,8 +125,8 @@ func TestSelfUpgradeStagePIDLiveClassifiesProcess(t *testing.T) {
 			if got != tt.wantLive {
 				t.Fatalf("selfUpgradeStagePIDLive(%d) = %t, want %t", pid, got, tt.wantLive)
 			}
-			if got := lookPathCalls > 0; got != tt.wantPS {
-				t.Fatalf("ps lookup called = %t, want %t", got, tt.wantPS)
+			if got := toolLstatCalls > 0; got != tt.wantPS {
+				t.Fatalf("ps validation called = %t, want %t", got, tt.wantPS)
 			}
 			wantProbeCalls := 0
 			if tt.wantPS && tt.lookPathErr == nil {
@@ -160,11 +160,11 @@ func TestCleanupStagesRemovesDeadAndForeignStages(t *testing.T) {
 	}
 
 	previousKill := selfUpgradeStagePIDKill
-	previousLookPath := selfUpgradeStagePSLookPath
+	previousToolLstat := selfUpgradeDarwinToolLstat
 	previousProbe := selfUpgradeStageRunBoundedProbe
 	t.Cleanup(func() {
 		selfUpgradeStagePIDKill = previousKill
-		selfUpgradeStagePSLookPath = previousLookPath
+		selfUpgradeDarwinToolLstat = previousToolLstat
 		selfUpgradeStageRunBoundedProbe = previousProbe
 	})
 	selfUpgradeStagePIDKill = func(pid int, _ syscall.Signal) error {
@@ -178,11 +178,11 @@ func TestCleanupStagesRemovesDeadAndForeignStages(t *testing.T) {
 			return syscall.ESRCH
 		}
 	}
-	selfUpgradeStagePSLookPath = func(name string) (string, error) {
-		if name != "ps" {
-			t.Fatalf("LookPath(%q), want ps", name)
+	selfUpgradeDarwinToolLstat = func(path string) (os.FileInfo, error) {
+		if path != "/bin/ps" {
+			t.Fatalf("Lstat(%q), want /bin/ps", path)
 		}
-		return "/bin/ps", nil
+		return os.Lstat(path)
 	}
 	selfUpgradeStageRunBoundedProbe = func(
 		_ context.Context,


### PR DESCRIPTION
Hardening for the in-place self-upgrade of `amq wake` and `amq-keepalive` (follow-up to #672/#675; refs bead agent-message-queue-1ed).

**A2a — Darwin pre-exec signature check.** After the private stage is re-verified and before `execve`, `codesign --verify --strict <stage>` runs through the shared bounded probe. A failure (or a missing `codesign`) is a refusal for that candidate and generation; it catches the invalid-signature case *before* the point of no return, where macOS would otherwise SIGKILL the new image after the old process is already gone.

**A2b — crash-loop guard.** Before `execve`, an `attempt` record (candidate dev/ino/size/sha256/version + time) is persisted (`.selfupgrade.json` sidecar for keepalive; `.wake.selfupgrade.attempt` for wake). A candidate matching a fresh (<24h, bounded clock skew) unsettled attempt is refused before exec — this is what breaks the launchd `KeepAlive` loop when a replaced image dies after a successful `execve`. The attempt settles only when the *running* image matches it: keepalive after its first fully healthy supervise pass, wake at its first quiescent maintenance boundary. Sidecars are removed with lock cleanup.

**A3 — Darwin stage cleanup liveness.** pid-named stage dirs: `ESRCH` → remove; `EPERM`, missing `ps`, probe error, or ambiguous output → keep (bounded garbage over deleting a live stage); a verified `amq`/`amq-keepalive` comm → keep; a verified foreign comm → PID reuse → remove.

**Limits (documented in `docs/amq-keepalive.md` and `docs/wake-lifecycle.md`):** the guard cannot help when the new image dies before reaching the maintenance code; the 24h memory is per install path (keepalive) / per wake agent dir; there is no rollback of the installed executable — that stays with the package manager.

Tests include the negative cases a naive implementation fails: codesign failure → refused once with zero exec; unsettled attempt matching the *candidate* (not the incumbent) → refused and stays unsettled after a healthy pass; incumbent≠attempt → not settled; expired attempt → exec proceeds; EPERM/foreign-comm/ambiguous-ps stage classification.
