### PR TITLE
fix(cli): assert physical canonical roots in env test

### DIFF
--- a/docs/session-routing.md
+++ b/docs/session-routing.md
@@ -74,6 +74,10 @@ rejected unless a non-empty `--root` or `--session` explicitly repins it.
 `amq env --session` routes from a valid pinned base before it checks project
 configuration.
 
+Exported and persisted roots are physical canonical paths with symlinks
+resolved; for example, macOS `/var` becomes `/private/var`. Complete pins from
+`amq env` remain valid across this change.
+
 ## Creation and backlog discovery
 
 Create named sessions explicitly with `amq session create <name>`. `coop exec`

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -783,7 +783,7 @@ func TestRelativeHighPrecedenceRootsCanonicalizeBeforeEnvSendAndDoctor(t *testin
 			targetRoot := filepath.Join(repo, defaultCoopRoot)
 			configureSendTestRoot(t, targetRoot, "alice", "bob")
 			t.Setenv("HOME", fakeHome)
-			test.setup(t, targetRoot)
+			test.setup(t, canonicalTestPath(t, targetRoot))
 			t.Chdir(nested)
 			resetAmqrcCache()
 
@@ -811,7 +811,7 @@ func TestRelativeHighPrecedenceRootsCanonicalizeBeforeEnvSendAndDoctor(t *testin
 			if err != nil {
 				t.Fatalf("env shell: %v", err)
 			}
-			if want := "export AM_ROOT=" + shellQuotePosix(targetRoot) + "\n"; !strings.Contains(stdout, want) {
+			if want := "export AM_ROOT=" + shellQuotePosix(canonicalTestPath(t, targetRoot)) + "\n"; !strings.Contains(stdout, want) {
 				t.Fatalf("env shell omitted canonical root %q:\n%s", want, stdout)
 			}
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -195,7 +195,7 @@ func runEnv(args []string) error {
 		if checkErr != nil {
 			return checkErr
 		} else if decision.Verdict != sessionguard.Allow && mismatch != nil {
-			return ContextMismatchError("refusing env: %s. Use explicit --session <name> or --root <path> to repin", mismatch.Error())
+			return ContextMismatchError("refusing env: %s. Run 'amq env --session <name>' or 'amq env --root <path>' to repin", mismatch.Error())
 		}
 	}
 

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -1000,6 +1000,46 @@ func TestRunEnvSessionRejectsAMRootOutsideLegacyPin(t *testing.T) {
 	}
 }
 
+func TestRunEnvIncompleteLegacyPinNamesRepinRemedy(t *testing.T) {
+	repo := t.TempDir()
+	nested := filepath.Join(repo, "nested")
+	baseRoot := filepath.Join(repo, defaultCoopRoot)
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir git marker: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(baseRoot, "current"), 0o700); err != nil {
+		t.Fatalf("mkdir session root: %v", err)
+	}
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatalf("mkdir nested cwd: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".amqrc"), []byte(`{"root": ".agent-mail"}`), 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+
+	t.Chdir(nested)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(envRoot, "")
+	t.Setenv(envBaseRoot, baseRoot)
+	t.Setenv(envSession, "current")
+	t.Setenv(envGlobalRoot, "")
+	setOptionalEnv(t, envRootID, "", false)
+	setOptionalEnv(t, envBaseRootID, "", false)
+	resetAmqrcCache()
+	t.Cleanup(resetAmqrcCache)
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--me", "codex", "--json"})
+	})
+	if err == nil || GetExitCode(err) != ExitContextMismatch ||
+		!strings.Contains(err.Error(), "amq env --session <name>") {
+		t.Fatalf("runEnv error = %v, want exit-5 repin remedy", err)
+	}
+	if stdout != "" {
+		t.Fatalf("runEnv emitted a replacement context after mismatch: %q", stdout)
+	}
+}
+
 func TestRunEnvNonExportSessionEmitsFullContext(t *testing.T) {
 	root := t.TempDir()
 	rcContent := `{"root": ".agent-mail"}`


### PR DESCRIPTION
#676 made root discovery resolve symlinks (required for the nested-worktree ceiling). On macOS that turns `/var/...` into `/private/var/...`, and `TestRelativeHighPrecedenceRootsCanonicalizeBeforeEnvSendAndDoctor` string-matched the unresolved path — Darwin-only red that Linux CI never saw (refs bead agent-message-queue-xvh).

- `common_test.go`: the shell-export assertion now expects the physical canonical root (still an exact match, so a non-canonical export fails the test).
- `env.go`: the context-mismatch refusal names runnable remedies (`amq env --session <name>` / `amq env --root <path>`), with a test.
- `docs/session-routing.md`: states that exported and persisted roots are physical canonical paths.

No change to the discovery walk.
