### PR TITLE
test(launch): skip tmux socket test when tmux is absent

### DIFF
--- a/internal/launch/tmux_test.go
+++ b/internal/launch/tmux_test.go
@@ -138,6 +138,9 @@ func TestTmuxTargetMissingClassifiesExitedServer(t *testing.T) {
 }
 
 func TestTmuxCloseUsesPinnedSocketAfterEnvironmentCleanup(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
 	backend := NewTmuxBackend("tmux")
 	backend.socketName = ""
 	active := true


### PR DESCRIPTION
Adds the same `exec.LookPath("tmux")` skip guard its five siblings use to `TestTmuxCloseUsesPinnedSocketAfterEnvironmentCleanup` (refs bead agent-message-queue-xy2). It was the only tmux test constructing `NewTmuxBackend("tmux")` unguarded, and it fails on the macos-latest runner surfaced by #680.

Implemented by amit-pi.
