### PR TITLE
fix(wake): retry restart readiness when the record changes while opening

### DIFF
--- a/internal/cli/wake_restart_retry_unix_test.go
+++ b/internal/cli/wake_restart_retry_unix_test.go
@@ -1,0 +1,217 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWakeRestartRetriesReadinessWhenRecordChangesWhileOpening proves the
+// requestWakeRestart poll loop treats wakeSnapshotReadChangedError as transient:
+// the first readiness observation fails with the typed error (the owner rewrote
+// the record by atomic rename between the reader's two opens), and the second
+// observation sees the stable restarted readiness. Before the fix, the first
+// error aborted the whole restart with status=refused.
+func TestWakeRestartRetriesReadinessWhenRecordChangesWhileOpening(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	prepareWakeRestartRecordForBoundResumeTest(t, &fixture, &bound)
+	cleanup, err := acquireWakeLockAfterResumeInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:            wakeInjectModeNone,
+			requestedOwner:      &fixture.owner,
+			resumeEligible:      true,
+			resumeImageEvidence: &bound,
+		},
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+			BoundImage: &bound,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	current := inspectWakeLock(fixture.root, fixture.agent)
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	oldSleep := wakeRestartSleep
+	oldObserve := wakeRestartObserveReadiness
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+		wakeRestartSleep = oldSleep
+		wakeRestartObserveReadiness = oldObserve
+	})
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error { return nil }
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error { return nil }
+
+	// On the first sleep, complete the owner-side restart: write the prepared
+	// proof and consume the restart record so the next readiness observation is
+	// stable and ready. The transient error is injected by observeCalls below.
+	sleepCalls := 0
+	wakeRestartSleep = func(time.Duration) {
+		sleepCalls++
+		if sleepCalls != 1 {
+			return
+		}
+		if err := writeWakePreparedFileInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if err := consumeWakeRestartAfterPrepared(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+			wakeResumeBootstrap{
+				Schema:     wakeRestartSchemaV1,
+				RequestID:  fixture.record.RequestID,
+				Generation: fixture.record.Generation,
+			},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	observeCalls := 0
+	sawTransient := false
+	wakeRestartObserveReadiness = func(
+		agentDir *wakeAgentDir,
+		root, me string,
+		expected wakeLockInspection,
+	) (wakeRestartReadiness, error) {
+		observeCalls++
+		if observeCalls == 1 {
+			sawTransient = true
+			// The exact error the producer returns when the record's inode/ctime
+			// changes between the reader's two opens (see readWakeQuarantineSnapshotAt).
+			return wakeRestartReadiness{}, newWakeSnapshotReadChangedError(
+				errors.New("wake restart request changed while opening"),
+			)
+		}
+		return oldObserve(agentDir, root, me, expected)
+	}
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err != nil {
+		t.Fatalf("transient readiness error should retry to success: result=%#v err=%v", result, err)
+	}
+	if result.Status != "restarted" || result.PreviousGeneration != fixture.record.Generation ||
+		result.Generation != current.Lock.Generation {
+		t.Fatalf("restarted result after transient retry = %#v", result)
+	}
+	if !sawTransient {
+		t.Fatalf("transient readiness error was never injected; test does not exercise the retry path (observeCalls=%d)", observeCalls)
+	}
+	if observeCalls < 2 {
+		t.Fatalf("readiness observer was not retried after the transient error (observeCalls=%d)", observeCalls)
+	}
+}
+
+// TestWakeRestartStillRefusesWhenRecordStaysRefused is the negative guard: a
+// record that stays status=refused must still terminate as refused. A naive
+// "swallow all read errors" implementation would loop to the restart timeout
+// instead; this test pins that only wakeSnapshotReadChangedError is retried.
+func TestWakeRestartStillRefusesWhenRecordStaysRefused(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	prepareWakeRestartRecordForBoundResumeTest(t, &fixture, &bound)
+	cleanup, err := acquireWakeLockAfterResumeInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:            wakeInjectModeNone,
+			requestedOwner:      &fixture.owner,
+			resumeEligible:      true,
+			resumeImageEvidence: &bound,
+		},
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+			BoundImage: &bound,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	oldSleep := wakeRestartSleep
+	oldObserve := wakeRestartObserveReadiness
+	oldReadRecord := wakeRestartReadRecord
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+		wakeRestartSleep = oldSleep
+		wakeRestartObserveReadiness = oldObserve
+		wakeRestartReadRecord = oldReadRecord
+	})
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error { return nil }
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error { return nil }
+
+	// Bypass the real sleep so the loop spins fast; the refused record must
+	// terminate it well before any real wall-clock timeout.
+	wakeRestartSleep = func(time.Duration) {}
+
+	// Simulate a generation change so the poll loop reaches the refused-record
+	// check. The readiness observer reports prepared=false with the refused
+	// record present, then the explicit record read returns the refused record.
+	refusedRecord := fixture.record
+	refusedRecord.Status = wakeRestartRefused
+	refusedRecord.Reason = "owner refused restart for test"
+	wakeRestartObserveReadiness = func(
+		*wakeAgentDir,
+		string,
+		string,
+		wakeLockInspection,
+	) (wakeRestartReadiness, error) {
+		return wakeRestartReadiness{
+			Prepared:     false,
+			Record:       refusedRecord,
+			RecordExists: true,
+		}, nil
+	}
+	readCalls := 0
+	wakeRestartReadRecord = func(int, *wakeAgentDir) (wakeRestartRecord, bool, error) {
+		readCalls++
+		return refusedRecord, true, nil
+	}
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err == nil {
+		t.Fatalf("refused record must terminate with an error; got result=%#v", result)
+	}
+	if result.Status != "refused" {
+		t.Fatalf("result.Status = %q, want %q (refused must not be swallowed into a timeout)", result.Status, "refused")
+	}
+	if !strings.Contains(result.Reason, refusedRecord.Reason) {
+		t.Fatalf("result.Reason = %q, want it to contain the refused record reason %q", result.Reason, refusedRecord.Reason)
+	}
+	if readCalls == 0 {
+		t.Fatalf("refused record reader was never called; the negative path was not exercised")
+	}
+	// Guard against a swallow-all implementation: the loop must NOT spin to the
+	// timeout when the record is stably refused. readCalls stays small because
+	// the first refused read terminates the loop.
+	if readCalls > 4 {
+		t.Fatalf("readiness loop spun %d times on a stably-refused record; refused should terminate immediately", readCalls)
+	}
+}

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -97,6 +97,11 @@ var (
 	wakeRestartBoundPreflight = preflightBoundWakeRestartCandidate
 	wakeRestartIgnore         = signal.Ignore
 	wakeRestartSignalNotify   = signal.Notify
+	// Test seams for the readiness/record readers in the requestWakeRestart
+	// poll loop. Production wires them to the real readers; tests swap them to
+	// inject transient wakeSnapshotReadChangedError and refused records.
+	wakeRestartObserveReadiness = observeWakeRestartReadinessInDir
+	wakeRestartReadRecord       = readWakeRestartRecordAt
 )
 
 func runWakeRestart(args []string) error {
@@ -272,13 +277,25 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 				result.Reason = err.Error()
 				return result, err
 			}
-			readiness, readinessErr := observeWakeRestartReadinessInDir(
+			readiness, readinessErr := wakeRestartObserveReadiness(
 				agentDir,
 				root,
 				me,
 				current,
 			)
 			if readinessErr != nil {
+				// The owner rewrites the restart record by atomic rename during
+				// handoff, so the snapshot identity check (Dev+Ino+Ctimespec on
+				// Darwin) can transiently observe a different inode between the
+				// reader's two opens. That is a retryable race in the read path,
+				// not corruption: keep polling until the owner publishes a stable
+				// restarted generation. The snapshot check itself stays strict.
+				var changed *wakeSnapshotReadChangedError
+				if errors.As(readinessErr, &changed) {
+					result.Reason = readinessErr.Error()
+					wakeRestartSleep(25 * time.Millisecond)
+					continue
+				}
 				result.Reason = readinessErr.Error()
 				return result, readinessErr
 			}
@@ -293,10 +310,20 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 		var exists bool
 		readErr := agentDir.withFD(func(dirfd int) error {
 			var err error
-			observed, exists, err = readWakeRestartRecordAt(dirfd, agentDir)
+			observed, exists, err = wakeRestartReadRecord(dirfd, agentDir)
 			return err
 		})
 		if readErr != nil {
+			// Same transient race as the readiness read above: the record file
+			// is rewritten by rename during handoff and the double-open identity
+			// check can observe a changed inode. Retry; refused and vanished
+			// records still terminate below.
+			var changed *wakeSnapshotReadChangedError
+			if errors.As(readErr, &changed) {
+				result.Reason = readErr.Error()
+				wakeRestartSleep(25 * time.Millisecond)
+				continue
+			}
 			result.Reason = readErr.Error()
 			return result, readErr
 		}


### PR DESCRIPTION
`amq wake restart` polls readiness every 25ms but treated `wakeSnapshotReadChangedError` as fatal, so a restart could return `status=refused` (~5% of runs) whenever the owner rewrote the restart record by atomic rename between the reader's two opens — the snapshot identity check (Dev+Ino+Ctimespec on Darwin) legitimately sees a different inode. The typed error documents itself as retryable when the caller can restart the read-only decision; the poll loop is that caller (refs bead agent-message-queue-b9n).

- Both poll-loop read sites now `continue` on that error; refused and vanished records still terminate; `wakeRestartWaitTimeout` still bounds the loop. The snapshot check stays strict.
- Tests: transient error once then ready → `restarted`; a record that stays refused → still `refused` within ≤4 reads (a swallow-all-errors implementation would loop to timeout).

Symptom was `TestDarwinWakeRestartRealPTYPreservesPIDAndUnreadWork` flaking with "wake restart request changed while opening". Investigated and implemented by amit-pi.
