### PR TITLE
fix(update): reject unpublished sentinel latest versions

### DIFF
--- a/internal/cli/update_check_test.go
+++ b/internal/cli/update_check_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/update"
+)
+
+func TestDrainJSONStdoutStaysParseableWithUpdateHint(t *testing.T) {
+	root, _ := seedDrainMailbox(t)
+	seedUpdateCache(t, "v0.73.0")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return Run([]string{"drain", "--root", root, "--me", "alice", "--json", "--include-body"}, "v0.70.0")
+	})
+	if err != nil {
+		t.Fatalf("drain: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(stdout, "update available") || strings.Contains(stdout, "9.9.9") {
+		t.Fatalf("update hint leaked onto drain stdout:\n%s", stdout)
+	}
+	var result drainResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("drain stdout must stay machine-parseable: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if result.Count != 1 || len(result.Drained) != 1 || result.Drained[0].ID != "hint-msg" {
+		t.Fatalf("drain payload = %#v, want the seeded message", result)
+	}
+	if !strings.Contains(stderr, "amq: update available (v0.70.0 -> v0.73.0)") {
+		t.Fatalf("stderr missing update hint:\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+}
+
+func TestDrainJSONDoesNotAdvertiseSentinelLatest(t *testing.T) {
+	root, _ := seedDrainMailbox(t)
+	seedUpdateCache(t, "v9.9.9")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return Run([]string{"drain", "--root", root, "--me", "alice", "--json", "--include-body"}, "v0.70.0")
+	})
+	if err != nil {
+		t.Fatalf("drain: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(stdout, "9.9.9") || strings.Contains(stderr, "9.9.9") {
+		t.Fatalf("sentinel leaked into drain streams:\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+	var result drainResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("drain stdout must stay machine-parseable: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if result.Count != 1 {
+		t.Fatalf("drain payload = %#v, want the seeded message", result)
+	}
+}
+
+func seedDrainMailbox(t *testing.T) (root, agent string) {
+	t.Helper()
+	root = t.TempDir()
+	agent = "alice"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "hint-msg",
+			From:    "bob",
+			To:      []string{agent},
+			Thread:  "p2p/alice__bob",
+			Subject: "hint",
+			Created: "2026-08-27T10:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, agent, "hint-msg.md", data); err != nil {
+		t.Fatal(err)
+	}
+	return root, agent
+}
+
+func seedUpdateCache(t *testing.T, latest string) {
+	t.Helper()
+	cacheDir := t.TempDir()
+	t.Setenv(update.EnvCacheDir, cacheDir)
+	path, err := update.DefaultCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := update.SaveCache(path, &update.Cache{
+		CheckedAt:     time.Now().UTC(),
+		LatestVersion: latest,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -74,6 +74,9 @@ type preparedCompanionUpgrade struct {
 // (not companions). It is best-effort: a cache write failure does not fail
 // the upgrade.
 func saveUpgradeCache(latest string) {
+	if update.IsUnpublishedTestVersion(latest) {
+		return
+	}
 	cachePath, err := update.DefaultCachePath()
 	if err != nil {
 		return

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -788,12 +788,12 @@ func stubUpgradeNetwork(t *testing.T) (replaced *[]string) {
 	}
 	t.Cleanup(func() { downloadReleaseAssetForUpgrade = oldDownload })
 	oldChecksums := fetchChecksumsForUpgrade
-	fetchChecksumsForUpgrade = func(context.Context, *http.Client, string) (map[string]string, error) {
+	fetchChecksumsForUpgrade = func(_ context.Context, _ *http.Client, tag string) (map[string]string, error) {
 		// Return a checksum for every asset name the upgrade loop can request
 		// (amq + each companion) so the lookup always hits regardless of OS.
 		m := map[string]string{}
 		for _, name := range append([]string{update.BinaryName}, update.CompanionBinaries...) {
-			if asset, err := update.AssetNameFor(name, "v0.0.0-test", runtime.GOOS, runtime.GOARCH); err == nil {
+			if asset, err := update.AssetNameFor(name, tag, runtime.GOOS, runtime.GOARCH); err == nil {
 				m[asset] = "checksum"
 			}
 		}
@@ -879,6 +879,25 @@ func TestRunUpgradeDirectInstallReplacesBinary(t *testing.T) {
 	}
 }
 
+func TestSaveUpgradeCacheSkipsUnpublishedTestVersion(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv(update.EnvCacheDir, cacheDir)
+	path, err := update.DefaultCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, latest := range []string{"v9.9.9", "9.9.9", "v0.0.0-test"} {
+		saveUpgradeCache(latest)
+		cache, err := update.LoadCache(path)
+		if err != nil {
+			t.Fatalf("LoadCache after %q: %v", latest, err)
+		}
+		if cache != nil {
+			t.Fatalf("saveUpgradeCache(%q) wrote %#v", latest, cache)
+		}
+	}
+}
+
 func TestRunUpgradeWritesCacheToOverride(t *testing.T) {
 	cacheDir := t.TempDir()
 	t.Setenv(update.EnvCacheDir, cacheDir)
@@ -893,7 +912,7 @@ func TestRunUpgradeWritesCacheToOverride(t *testing.T) {
 	detectHomebrewPrefixForUpgrade = func() string { return "" }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 	oldFetch := fetchLatestTagForUpgrade
-	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.73.0", nil }
 	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
 	stubUpgradeNetwork(t)
 	oldSave := saveUpgradeCacheForUpgrade
@@ -911,8 +930,8 @@ func TestRunUpgradeWritesCacheToOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCache: %v", err)
 	}
-	if cache == nil || cache.LatestVersion != "v0.0.0-test" {
-		t.Fatalf("cache = %#v, want latest v0.0.0-test under %s", cache, cacheDir)
+	if cache == nil || cache.LatestVersion != "v0.73.0" {
+		t.Fatalf("cache = %#v, want latest v0.73.0 under %s", cache, cacheDir)
 	}
 }
 
@@ -976,7 +995,7 @@ func TestRunUpgradeScheduledCacheRepairsOnNextRun(t *testing.T) {
 	detectHomebrewPrefixForUpgrade = func() string { return "" }
 	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 	oldFetch := fetchLatestTagForUpgrade
-	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.0.0-test", nil }
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) { return "v0.73.0", nil }
 	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetch })
 	stubUpgradeNetwork(t)
 	oldReplace := replaceBinaryForUpgrade
@@ -1001,14 +1020,14 @@ func TestRunUpgradeScheduledCacheRepairsOnNextRun(t *testing.T) {
 		t.Fatalf("cache after scheduled replacement = %#v, want stale value preserved", first)
 	}
 
-	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "v0.0.0-test") }); err != nil {
+	if _, _, err := captureEnvOutput(t, func() error { return runUpgrade(nil, "v0.73.0") }); err != nil {
 		t.Fatalf("already-current runUpgrade: %v", err)
 	}
 	second, err := update.LoadCache(cachePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second == nil || second.LatestVersion != "v0.0.0-test" {
+	if second == nil || second.LatestVersion != "v0.73.0" {
 		t.Fatalf("cache after next run = %#v, want repaired latest version", second)
 	}
 	if replaceCalls != 1 {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -117,6 +117,9 @@ type Notifier struct {
 	Client         *http.Client
 	CachePath      string
 	CheckInterval  time.Duration
+	// FetchLatest overrides FetchLatestTag. Tests inject it so a sentinel
+	// GitHub payload can be exercised without a network round trip.
+	FetchLatest func(context.Context, *http.Client) (string, error)
 }
 
 func (n Notifier) Start(ctx context.Context) {
@@ -145,34 +148,79 @@ func (n Notifier) Start(ctx context.Context) {
 	}
 
 	if cache == nil || n.now().Sub(cache.CheckedAt) >= n.interval() {
-		go func(alreadyHinted bool) {
-			refreshCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-			latest, err := FetchLatestTag(refreshCtx, n.client())
-			if err != nil {
-				return
-			}
-			latest = normalizeVersion(latest)
-			if latest == "" {
-				return
-			}
-			if !alreadyHinted && IsUpdateAvailable(current, latest) {
-				_ = writeUpdateHint(n.stderr(), current, latest)
-			}
-			_ = SaveCache(cachePath, &Cache{
-				CheckedAt:     n.now().UTC(),
-				LatestVersion: latest,
-			})
-		}(hinted)
+		go n.refreshLatest(ctx, cachePath, current, hinted)
 	}
 }
 
+func (n Notifier) refreshLatest(ctx context.Context, cachePath, current string, alreadyHinted bool) {
+	refreshCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	latest, err := n.fetchLatest(refreshCtx)
+	if err != nil {
+		return
+	}
+	latest = normalizeVersion(latest)
+	if latest == "" || isUnpublishedTestVersion(latest) {
+		return
+	}
+	if !alreadyHinted && IsUpdateAvailable(current, latest) {
+		_ = writeUpdateHint(n.stderr(), current, latest)
+	}
+	_ = SaveCache(cachePath, &Cache{
+		CheckedAt:     n.now().UTC(),
+		LatestVersion: latest,
+	})
+}
+
+func (n Notifier) fetchLatest(ctx context.Context) (string, error) {
+	if n.FetchLatest != nil {
+		return n.FetchLatest(ctx, n.client())
+	}
+	return FetchLatestTag(ctx, n.client())
+}
+
 func IsUpdateAvailable(current, latest string) bool {
+	if isUnpublishedTestVersion(latest) {
+		return false
+	}
 	cmp, ok := CompareVersions(current, latest)
 	if !ok {
 		return false
 	}
 	return cmp < 0
+}
+
+// unpublishedTestCores are fixture versions used by scripts and tests.
+// Production latest-version paths must never advertise or persist them.
+var unpublishedTestCores = map[string]struct{}{
+	"9.9.9": {},
+}
+
+var unpublishedTestExact = map[string]struct{}{
+	"0.0.0-test": {},
+}
+
+func isUnpublishedTestVersion(version string) bool {
+	version = strings.ToLower(strings.TrimSpace(version))
+	version = strings.TrimPrefix(version, "v")
+	if version == "" {
+		return false
+	}
+	if _, ok := unpublishedTestExact[version]; ok {
+		return true
+	}
+	core := version
+	if cut := strings.IndexAny(core, "+-"); cut >= 0 {
+		core = core[:cut]
+	}
+	_, ok := unpublishedTestCores[core]
+	return ok
+}
+
+// IsUnpublishedTestVersion reports whether version is a documented test
+// sentinel (9.9.9 or 0.0.0-test) rather than a publishable latest.
+func IsUnpublishedTestVersion(version string) bool {
+	return isUnpublishedTestVersion(version)
 }
 
 func CompareVersions(current, latest string) (int, bool) {
@@ -631,8 +679,14 @@ func ParseChecksums(data []byte) (map[string]string, error) {
 	return checksums, nil
 }
 
+var latestReleaseAPIURL = defaultLatestReleaseAPIURL
+
+func defaultLatestReleaseAPIURL() string {
+	return fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", RepoSlug)
+}
+
 func FetchLatestTag(ctx context.Context, client *http.Client) (string, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", RepoSlug)
+	url := latestReleaseAPIURL()
 	var release struct {
 		TagName string `json:"tag_name"`
 	}
@@ -641,6 +695,9 @@ func FetchLatestTag(ctx context.Context, client *http.Client) (string, error) {
 	}
 	if strings.TrimSpace(release.TagName) == "" {
 		return "", errors.New("latest release missing tag_name")
+	}
+	if isUnpublishedTestVersion(release.TagName) {
+		return "", fmt.Errorf("latest release tag %q is an unpublished test version", release.TagName)
 	}
 	return release.TagName, nil
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,7 +1,12 @@
 package update
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +14,208 @@ import (
 	"testing"
 	"time"
 )
+
+func TestIsUnpublishedTestVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"9.9.9", true},
+		{"v9.9.9", true},
+		{"V9.9.9", true},
+		{" 9.9.9 ", true},
+		{"v9.9.9-rc.1", true},
+		{"9.9.9+build", true},
+		{"0.0.0-test", true},
+		{"v0.0.0-test", true},
+		{"V0.0.0-TEST", true},
+		{"0.73.0", false},
+		{"v0.73.0", false},
+		{"v0.70.0", false},
+		{"9.9.8", false},
+		{"9.9.90", false},
+		{"19.9.9", false},
+		{"0.0.0", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsUnpublishedTestVersion(tc.version); got != tc.want {
+			t.Fatalf("IsUnpublishedTestVersion(%q)=%v want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestIsUpdateAvailableRejectsUnpublishedLatest(t *testing.T) {
+	if !IsUpdateAvailable("v0.70.0", "v0.73.0") {
+		t.Fatal("published newer latest must still be advertised")
+	}
+	if IsUpdateAvailable("v0.70.0", "v9.9.9") {
+		t.Fatal("sentinel 9.9.9 must not be advertised; CompareVersions would treat it as newer")
+	}
+	if IsUpdateAvailable("v0.70.0", "9.9.9") {
+		t.Fatal("bare sentinel 9.9.9 must not be advertised")
+	}
+	if IsUpdateAvailable("v0.70.0", "v0.0.0-test") {
+		t.Fatal("documented test latest 0.0.0-test must not be advertised")
+	}
+}
+
+func TestFetchLatestTagRejectsUnpublishedTestVersion(t *testing.T) {
+	for _, tag := range []string{"v9.9.9", "9.9.9", "v0.0.0-test"} {
+		t.Run(tag, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]string{"tag_name": tag}); err != nil {
+					t.Errorf("encode: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+			oldURL := latestReleaseAPIURL
+			latestReleaseAPIURL = func() string { return server.URL }
+			t.Cleanup(func() { latestReleaseAPIURL = oldURL })
+
+			got, err := FetchLatestTag(context.Background(), server.Client())
+			if err == nil || !strings.Contains(err.Error(), "unpublished test version") {
+				t.Fatalf("FetchLatestTag(%q) err=%v got=%q, want unpublished test version error", tag, err, got)
+			}
+			if got != "" {
+				t.Fatalf("FetchLatestTag(%q) returned %q, want empty", tag, got)
+			}
+		})
+	}
+}
+
+func TestFetchLatestTagAcceptsPublishedVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.73.0"}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	oldURL := latestReleaseAPIURL
+	latestReleaseAPIURL = func() string { return server.URL }
+	t.Cleanup(func() { latestReleaseAPIURL = oldURL })
+
+	got, err := FetchLatestTag(context.Background(), server.Client())
+	if err != nil {
+		t.Fatalf("FetchLatestTag: %v", err)
+	}
+	if got != "v0.73.0" {
+		t.Fatalf("FetchLatestTag=%q want v0.73.0", got)
+	}
+}
+
+func TestNotifierStartDoesNotAdvertiseCachedSentinel(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "update.json")
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	if err := SaveCache(cachePath, &Cache{CheckedAt: now, LatestVersion: "v9.9.9"}); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	n := Notifier{
+		CurrentVersion: "v0.70.0",
+		CachePath:      cachePath,
+		CheckInterval:  24 * time.Hour,
+		Now:            func() time.Time { return now },
+		Stderr:         &stderr,
+		FetchLatest: func(context.Context, *http.Client) (string, error) {
+			t.Fatal("fresh sentinel cache must not refresh")
+			return "", nil
+		},
+	}
+	n.Start(context.Background())
+	if strings.Contains(stderr.String(), "9.9.9") || strings.Contains(stderr.String(), "update available") {
+		t.Fatalf("advertised sentinel from cache:\n%s", stderr.String())
+	}
+}
+
+func TestNotifierStartAdvertisesPublishedCachedLatestOnStderr(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "update.json")
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	if err := SaveCache(cachePath, &Cache{CheckedAt: now, LatestVersion: "v0.73.0"}); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	n := Notifier{
+		CurrentVersion: "v0.70.0",
+		CachePath:      cachePath,
+		CheckInterval:  24 * time.Hour,
+		Now:            func() time.Time { return now },
+		Stderr:         &stderr,
+		FetchLatest: func(context.Context, *http.Client) (string, error) {
+			t.Fatal("fresh published cache must not refresh")
+			return "", nil
+		},
+	}
+	n.Start(context.Background())
+	want := "amq: update available (v0.70.0 -> v0.73.0). Run 'amq upgrade' to install.\n"
+	if stderr.String() != want {
+		t.Fatalf("stderr=%q want %q", stderr.String(), want)
+	}
+}
+
+func TestNotifierRefreshLatestDoesNotPersistOrAdvertiseSentinel(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "update.json")
+	var stderr bytes.Buffer
+	n := Notifier{
+		CurrentVersion: "v0.70.0",
+		Stderr:         &stderr,
+		Now:            func() time.Time { return time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC) },
+		FetchLatest: func(context.Context, *http.Client) (string, error) {
+			return "v9.9.9", nil
+		},
+	}
+	n.refreshLatest(context.Background(), cachePath, "v0.70.0", false)
+	cache, err := LoadCache(cachePath)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if cache != nil {
+		t.Fatalf("cache = %#v, want sentinel omitted from latest", cache)
+	}
+	if strings.Contains(stderr.String(), "9.9.9") || strings.Contains(stderr.String(), "update available") {
+		t.Fatalf("advertised fetched sentinel:\n%s", stderr.String())
+	}
+}
+
+func TestNotifierRefreshLatestPersistsPublishedVersion(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "update.json")
+	var stderr bytes.Buffer
+	now := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	n := Notifier{
+		CurrentVersion: "v0.70.0",
+		Stderr:         &stderr,
+		Now:            func() time.Time { return now },
+		FetchLatest: func(context.Context, *http.Client) (string, error) {
+			return "v0.73.0", nil
+		},
+	}
+	n.refreshLatest(context.Background(), cachePath, "v0.70.0", false)
+	cache, err := LoadCache(cachePath)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if cache == nil || cache.LatestVersion != "v0.73.0" || !cache.CheckedAt.Equal(now) {
+		t.Fatalf("cache = %#v, want latest v0.73.0", cache)
+	}
+	if !strings.Contains(stderr.String(), "v0.70.0 -> v0.73.0") {
+		t.Fatalf("stderr missing published update hint:\n%s", stderr.String())
+	}
+}
+
+func TestWriteUpdateHintWritesToProvidedWriter(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeUpdateHint(&buf, "v0.70.0", "v0.73.0"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Fatalf("hint missing trailing newline: %q", buf.String())
+	}
+	if err := writeUpdateHint(io.Discard, "v0.70.0", "v0.73.0"); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestCompareVersions(t *testing.T) {
 	cases := []struct {
@@ -18,6 +225,7 @@ func TestCompareVersions(t *testing.T) {
 		ok      bool
 	}{
 		{"v1.2.3", "v1.2.3", 0, true},
+		{"v0.70.0", "v9.9.9", -1, true},
 		{"v1.2.3", "v1.2.4", -1, true},
 		{"1.2.3", "v1.2.4", -1, true},
 		{"v2.0.0", "v1.9.9", 1, true},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production update check no longer treats documented test sentinels as a published latest. `9.9.9` / `v9.9.9` and `0.0.0-test` / `v0.0.0-test` are rejected: they are never advertised, never written to the update cache as `latest_version`, and never returned from `FetchLatestTag`. Tests keep using `9.9.9` as a fixture.

Fixes #670.

## Investigation

The Amit fleet notice `amq: update available (v0.70.0 -> v9.9.9)` is explained by the existing check path, not by a real release:

- Live GitHub latest release is **v0.73.0**. There is no tag or release named `v9.9.9` (this PR does not invent one).
- Homebrew tap `Formula/amq.rb` is **0.73.0**. Code search of `avivsinai/homebrew-tap` found no `9.9.9`.
- Plugin metadata in this repo does not publish `9.9.9`.
- `9.9.9` is a test/sentinel in `scripts/test_version_embed.sh`, `scripts/test_release_metadata.sh`, `internal/selfupgrade/*_test.go`, and `internal/cli/upgrade_test.go` (`LatestVersion: "v9.9.9"`).
- `CompareVersions` is a pure semver compare, so `9.9.9 > 0.70.0` and a poisoned cache or a leaked fetch always wins the hint.

No published artifact, release, or formula contained `9.9.9`. Nothing to yank. The leak is the latest-version path accepting a test sentinel from cache or GitHub JSON.

## Changes

- Reject unpublished test versions in `IsUpdateAvailable`, `FetchLatestTag`, notifier cache writes, and `saveUpgradeCache`.
- Keep `9.9.9` as a cache fixture for scheduled-upgrade repair tests.
- Confirm `writeUpdateHint` stays on stderr; `amq drain --json` stdout remains machine-parseable when a real update hint is present.

## Testing

Named tests on this Cloud VM (`79440dd`, 2026-08-28T18:38:44Z) all passed. Full log: `/opt/cursor/artifacts/issue-670-named-tests.log`

```
=== RUN   TestIsUnpublishedTestVersion
--- PASS: TestIsUnpublishedTestVersion
=== RUN   TestIsUpdateAvailableRejectsUnpublishedLatest
--- PASS: TestIsUpdateAvailableRejectsUnpublishedLatest
=== RUN   TestFetchLatestTagRejectsUnpublishedTestVersion
--- PASS: TestFetchLatestTagRejectsUnpublishedTestVersion/v9.9.9
--- PASS: TestFetchLatestTagRejectsUnpublishedTestVersion/9.9.9
--- PASS: TestFetchLatestTagRejectsUnpublishedTestVersion/v0.0.0-test
=== RUN   TestFetchLatestTagAcceptsPublishedVersion
--- PASS: TestFetchLatestTagAcceptsPublishedVersion
=== RUN   TestNotifierStartDoesNotAdvertiseCachedSentinel
--- PASS: TestNotifierStartDoesNotAdvertiseCachedSentinel
=== RUN   TestNotifierStartAdvertisesPublishedCachedLatestOnStderr
--- PASS: TestNotifierStartAdvertisesPublishedCachedLatestOnStderr
=== RUN   TestNotifierRefreshLatestDoesNotPersistOrAdvertiseSentinel
--- PASS: TestNotifierRefreshLatestDoesNotPersistOrAdvertiseSentinel
=== RUN   TestNotifierRefreshLatestPersistsPublishedVersion
--- PASS: TestNotifierRefreshLatestPersistsPublishedVersion
=== RUN   TestDrainJSONStdoutStaysParseableWithUpdateHint
--- PASS: TestDrainJSONStdoutStaysParseableWithUpdateHint
=== RUN   TestDrainJSONDoesNotAdvertiseSentinelLatest
--- PASS: TestDrainJSONDoesNotAdvertiseSentinelLatest
=== RUN   TestSaveUpgradeCacheSkipsUnpublishedTestVersion
--- PASS: TestSaveUpgradeCacheSkipsUnpublishedTestVersion
ok  github.com/avivsinai/agent-message-queue/internal/update
ok  github.com/avivsinai/agent-message-queue/internal/cli
```

GitHub CI for `79440dd` completed with no failures (`ci / build`, `ci / macos-test`, `ci / windows-claim-test`, Gitleaks, GitGuardian). Local `make ci` lint/vet/skills passed on this VM; full `go test ./...` also hit two host-only failures outside this change (`TestProcLocksSeesFlockWithoutAcquiring`, `TestCaptureImageEvidenceRejectsHashTimeMutation`).

- [x] Named tests on this Cloud VM
- [x] `make ci` lint/vet/skills on this Cloud VM
- [x] GitHub CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-409ad61b-68ee-4fa6-8994-e0881283290c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-409ad61b-68ee-4fa6-8994-e0881283290c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

