### PR TITLE
fix(bridge): prefer GNU stat for enqueue config mode

### DIFF
--- a/scripts/amq-bridge-bot-enqueue.sh
+++ b/scripts/amq-bridge-bot-enqueue.sh
@@ -41,7 +41,9 @@ config=${AMQ_BRIDGE_ENQUEUE_CONFIG:-}
 [[ -e "$config" ]] || refuse "AMQ_BRIDGE_ENQUEUE_CONFIG not found: $config"
 [[ -f "$config" ]] || refuse "AMQ_BRIDGE_ENQUEUE_CONFIG must be a regular file: $config"
 
-config_mode=$(stat -f '%OLp' "$config" 2>/dev/null || stat -c '%a' "$config")
+# Prefer GNU `stat -c '%a'`. BSD-first `stat -f` is `--file-system` on GNU
+# coreutils and dumps filesystem info into the compared mode string.
+config_mode=$(stat -c '%a' "$config" 2>/dev/null || stat -f '%OLp' "$config")
 [[ "$config_mode" == "600" ]] \
   || refuse "AMQ_BRIDGE_ENQUEUE_CONFIG mode is $config_mode, want 600"
 

--- a/scripts/amq-bridge-bot-enqueue_test.sh
+++ b/scripts/amq-bridge-bot-enqueue_test.sh
@@ -101,7 +101,16 @@ ENQUEUE_CONFIG="$symlink_config" run_refused "symlink config" --dest-alias grok/
 loose_config="$tmp_dir/loose-config.json"
 cp "$config" "$loose_config"
 chmod 0644 "$loose_config"
-ENQUEUE_CONFIG="$loose_config" run_refused "mode-0644 config" --dest-alias grok/claude
+loose_out=$(AMQ_BRIDGE_ENQUEUE_CONFIG="$loose_config" PATH="$tmp_dir:$PATH" \
+  "$wrapper" --dest-alias grok/claude <<<"$(make_message)" 2>&1) && status=0 || status=$?
+[[ "$status" -ne 0 ]] || fail "mode-0644 config: expected refusal"
+if [[ "$loose_out" == *"$body_marker"* ]]; then
+  fail "mode-0644 config: refusal printed the message body"
+fi
+# Named check: reject with a numeric mode, not a GNU `stat -f` filesystem dump.
+printf '%s\n' "$loose_out" | grep -Fq 'AMQ_BRIDGE_ENQUEUE_CONFIG mode is 644, want 600' \
+  || fail "mode-0644 config: expected numeric mode error, got: $loose_out"
+printf 'ok: mode-0644 config rejected\n'
 
 run_refused "extra positional argument" --dest-alias grok/claude extra
 run_refused "wrong flag name" --to grok/claude
@@ -121,12 +130,17 @@ if [[ "$(count_spool)" -ne "$before_count" ]]; then
   fail "a refused call wrote a spool file"
 fi
 
-# PATH resolution: amq-bridge found via PATH.
+# Named check: a real mode-600 config must pass (GNU `stat -c '%a'`, not a
+# BSD-first `stat -f` filesystem dump). PATH resolution: amq-bridge via PATH.
 out=$(AMQ_BRIDGE_ENQUEUE_CONFIG="$config" PATH="$tmp_dir:$PATH" \
-  "$wrapper" --dest-alias grok/claude <<<"$(make_message)")
+  "$wrapper" --dest-alias grok/claude <<<"$(make_message)" 2>&1) && status=0 || status=$?
+if [[ "$status" -ne 0 ]]; then
+  fail "mode-600 config: expected accept, got exit $status (output: $out)"
+fi
 [[ "$out" == "$spool_dir"/*.md ]] || fail "PATH resolution: unexpected output: $out"
 [[ -f "$out" ]] || fail "PATH resolution: spool file missing: $out"
 grep -Fq "$body_marker" "$out" || fail "PATH resolution: spool file missing body"
+printf 'ok: mode-600 config accepted\n'
 dest_sidecar="${out%.md}.dest"
 [[ -f "$dest_sidecar" ]] || fail "PATH resolution: missing .dest sidecar"
 [[ "$(cat "$dest_sidecar")" == "grok/claude" ]] || fail "PATH resolution: wrong .dest sidecar content"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`scripts/amq-bridge-bot-enqueue.sh` tried BSD `stat -f '%OLp'` first. On GNU/Linux that flag is `--file-system`, so the command dumps filesystem info into the compared mode string. A real mode-600 enqueue config then failed with `mode is <stat dump>, want 600`.

Prefer GNU `stat -c '%a'` first and keep BSD `stat -f` for macOS.

## Changes

- Prefer `stat -c '%a'` on GNU coreutils; fall back to BSD `stat -f '%OLp'`.
- Named checks in `scripts/amq-bridge-bot-enqueue_test.sh`: a 0600 config is accepted and a 0644 config is rejected with a numeric mode error (not a filesystem dump).

## Testing

- [x] GitHub CI green on `6867809` (`ci / build`, `windows-claim-test`, `macos-test`)
- [x] New tests added
- [x] Named Linux check on this Cloud VM: `bash scripts/amq-bridge-bot-enqueue_test.sh`

### Named Linux mode-check log

Host: Linux GNU coreutils 9.4 (`stat -c '%a'` first path).

```
Linux cursor 6.12.94+ #1 SMP PREEMPT_DYNAMIC Thu Aug 27 17:56:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
---
stat (GNU coreutils) 9.4
---
go: downloading go1.26.6 (linux/amd64)
go: downloading golang.org/x/sys v0.47.0
ok: mode-0644 config rejected
ok: mode-600 config accepted
amq-bridge-bot-enqueue regression tests passed
TEST_EXIT=0
```

Artifact: `/opt/cursor/artifacts/amq-bridge-bot-enqueue-linux-mode.log`

## Related Issues

N/A — leaf fix from current `main`, not stacked on release-please.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7dc67e-e2bf-4ce0-8973-f6e30a950dd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7dc67e-e2bf-4ce0-8973-f6e30a950dd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

