### PR TITLE
fix(doctor): find the codex skill where npx skills add installs it

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -877,10 +877,10 @@ func checkSkill(agent string) doctorCheck {
 	// ~/.<agent>/skills paths remain for installs created before the shared dir.
 	agentDir := "." + agent
 	candidates := []string{
-		filepath.Join(agentDir, "skills", "amq-cli"),                 // project-local, agent-specific
-		filepath.Join(".agents", "skills", "amq-cli"),                // project-local, shared
-		filepath.Join(home, agentDir, "skills", "amq-cli"),          // user-level, agent-specific
-		filepath.Join(home, ".agents", "skills", "amq-cli"),         // user-level, shared (npx skills add -g)
+		filepath.Join(agentDir, "skills", "amq-cli"),        // project-local, agent-specific
+		filepath.Join(".agents", "skills", "amq-cli"),       // project-local, shared
+		filepath.Join(home, agentDir, "skills", "amq-cli"),  // user-level, agent-specific
+		filepath.Join(home, ".agents", "skills", "amq-cli"), // user-level, shared (npx skills add -g)
 	}
 
 	// Check project-local candidates first, then user-level, in order.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -870,27 +870,43 @@ func checkSkill(agent string) doctorCheck {
 	}
 
 	home, _ := os.UserHomeDir()
-	skillDir := filepath.Join(home, "."+agent, "skills", "amq-cli")
-	localSkillDir := filepath.Join("."+agent, "skills", "amq-cli")
 
-	// Check project-local skills first, then user-level
-	switch {
-	case fileExists(filepath.Join(localSkillDir, "SKILL.md")):
-		check.Status = "ok"
-		check.Message = "installed (project-local)"
-
-	case fileExists(filepath.Join(skillDir, "SKILL.md")):
-		check.Status = "ok"
-		check.Message = "installed"
-
-	case dirExists(skillDir):
-		check.Status = "warn"
-		check.Message = "skill directory exists but SKILL.md missing"
-
-	default:
-		check.Status = "warn"
-		check.Message = "not installed (run: npx skills add avivsinai/agent-message-queue -g -y)"
+	// Candidate skill directories, in priority order. The shared ~/.agents/skills
+	// (and project-local .agents/skills) is where `npx skills add -g` installs,
+	// so every agent checks it in addition to its agent-specific dir. The legacy
+	// ~/.<agent>/skills paths remain for installs created before the shared dir.
+	agentDir := "." + agent
+	candidates := []string{
+		filepath.Join(agentDir, "skills", "amq-cli"),                 // project-local, agent-specific
+		filepath.Join(".agents", "skills", "amq-cli"),                // project-local, shared
+		filepath.Join(home, agentDir, "skills", "amq-cli"),          // user-level, agent-specific
+		filepath.Join(home, ".agents", "skills", "amq-cli"),         // user-level, shared (npx skills add -g)
 	}
 
+	// Check project-local candidates first, then user-level, in order.
+	for _, dir := range candidates {
+		if fileExists(filepath.Join(dir, "SKILL.md")) {
+			check.Status = "ok"
+			if strings.HasPrefix(dir, ".") {
+				check.Message = "installed (project-local)"
+			} else {
+				check.Message = "installed"
+			}
+			return check
+		}
+	}
+
+	// No SKILL.md in any candidate. Warn if a skill directory exists but is
+	// missing SKILL.md (partial install); otherwise recommend the remedy.
+	for _, dir := range candidates {
+		if dirExists(dir) {
+			check.Status = "warn"
+			check.Message = "skill directory exists but SKILL.md missing"
+			return check
+		}
+	}
+
+	check.Status = "warn"
+	check.Message = "not installed (run: npx skills add avivsinai/agent-message-queue -g -y)"
 	return check
 }

--- a/internal/cli/doctor_skill_test.go
+++ b/internal/cli/doctor_skill_test.go
@@ -49,6 +49,56 @@ func TestCheckSkillGrokDoesNotInheritClaudePath(t *testing.T) {
 	}
 }
 
+// TestCheckSkillCodexFoundUnderSharedAgentsDir is the qtv regression: the
+// remedy (`npx skills add avivsinai/agent-message-queue -g -y`) installs to
+// ~/.agents/skills/amq-cli, but the old check only looked in ~/.codex/skills,
+// so doctor always warned right after running its own remedy. The shared
+// ~/.agents/skills candidate must satisfy the codex check.
+func TestCheckSkillCodexFoundUnderSharedAgentsDir(t *testing.T) {
+	home := t.TempDir()
+	// CWD is a separate clean dir with no project-local skills, so only the
+	// user-level ~/.agents/skills candidate can satisfy the check.
+	t.Chdir(t.TempDir())
+	t.Setenv("HOME", home)
+	writeSkillFile(t, filepath.Join(home, ".agents", "skills", "amq-cli", "SKILL.md"))
+
+	got := checkSkill("codex")
+	if got.Name != "codex skill" || got.Status != "ok" || got.Message != "installed" {
+		t.Fatalf("codex skill under ~/.agents/skills = %#v; want status=ok message=installed", got)
+	}
+}
+
+// TestCheckSkillCodexAbsentEverywhereWarns is the negative: with no skill
+// anywhere, doctor must warn and keep the remedy text.
+func TestCheckSkillCodexAbsentEverywhereWarns(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(t.TempDir())
+	t.Setenv("HOME", home)
+
+	got := checkSkill("codex")
+	if got.Status != "warn" || !strings.Contains(got.Message, "not installed") ||
+		!strings.Contains(got.Message, "npx skills add") {
+		t.Fatalf("absent codex skill = %#v; want warn with remedy", got)
+	}
+}
+
+// TestCheckSkillCodexDirWithoutSkillMdWarns guards the partial-install case:
+// a skill directory exists but SKILL.md is missing. Must warn, not report ok.
+func TestCheckSkillCodexDirWithoutSkillMdWarns(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(t.TempDir())
+	t.Setenv("HOME", home)
+	// Directory present under the shared user-level path, but no SKILL.md inside.
+	if err := os.MkdirAll(filepath.Join(home, ".agents", "skills", "amq-cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkSkill("codex")
+	if got.Status != "warn" || !strings.Contains(got.Message, "SKILL.md missing") {
+		t.Fatalf("codex skill dir without SKILL.md = %#v; want warn about missing SKILL.md", got)
+	}
+}
+
 func TestDoctorJSONIncludesGrokSkillCheck(t *testing.T) {
 	root := healthyDoctorMailboxRoot(t, "claude")
 	findDoctorCheck(t, runDoctorMailboxJSON(t, root).Checks, "grok skill")


### PR DESCRIPTION
`amq doctor` checked the codex skill only under `~/.codex/skills`, but its own remedy (`npx skills add avivsinai/agent-message-queue -g -y`) installs to `~/.agents/skills` — so the warning could never clear (refs bead agent-message-queue-qtv).

`checkSkill` now checks an ordered candidate list per agent: project-local `.<agent>/skills` and `.agents/skills`, then user-level `~/.<agent>/skills` (legacy) and `~/.agents/skills`. Remedy text unchanged. Tests isolate HOME and CWD; the negative cases (absent everywhere → warn; dir without SKILL.md → warn) are included.

Implemented by amit-pi.
