### PR TITLE
test(wake): reap spawned wake PTY child before TempDir cleanup

### DIFF
--- a/internal/cli/wake_self_upgrade_e2e_darwin_test.go
+++ b/internal/cli/wake_self_upgrade_e2e_darwin_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -23,6 +25,17 @@ func TestDarwinWakeSelfUpgradeRealPTYStableSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 	ptyLog := filepath.Join(t.TempDir(), "pty.log")
+	// Register the spawned-wake reap BEFORE the test runs so that, under LIFO
+	// cleanup ordering, it executes after the assertions but BEFORE the
+	// TempDir RemoveAll cleanups. Without this the real-PTY wake daemon (a
+	// detached child of `script`/`coop exec`) keeps writing to
+	// root/agents/codex after the test returns and TempDir cleanup fails with
+	// "directory not empty" (bead agent-message-queue-sqx). The PID is captured
+	// from the helper's AMQ_SELF_UPGRADE_HELPER_OK line after CombinedOutput.
+	var spawnedWakePID int
+	t.Cleanup(func() {
+		reapSpawnedWakeSelfUpgradePID(t, spawnedWakePID)
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(
@@ -55,4 +68,66 @@ func TestDarwinWakeSelfUpgradeRealPTYStableSymlink(t *testing.T) {
 	if !strings.Contains(string(output), "AMQ_SELF_UPGRADE_HELPER_OK") {
 		t.Fatalf("Darwin self-upgrade helper proof missing:\n%s", output)
 	}
+	spawnedWakePID = parseSpawnedWakePIDFromHelperOutput(t, string(output))
+}
+
+// parseSpawnedWakePIDFromHelperOutput extracts the wake daemon PID the helper
+// prints as "AMQ_SELF_UPGRADE_HELPER_OK pid=<n> ...". Returns 0 if absent
+// (reapSpawnedWakeSelfUpgradePID treats 0 as nothing-to-reap).
+func parseSpawnedWakePIDFromHelperOutput(t *testing.T, output string) int {
+	t.Helper()
+	marker := "AMQ_SELF_UPGRADE_HELPER_OK pid="
+	idx := strings.Index(output, marker)
+	if idx < 0 {
+		return 0
+	}
+	rest := output[idx+len(marker):]
+	end := strings.IndexAny(rest, " \n")
+	if end < 0 {
+		end = len(rest)
+	}
+	pidStr := strings.TrimSpace(rest[:end])
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		t.Fatalf("could not parse spawned wake pid from helper output: %q", output)
+	}
+	return pid
+}
+
+// reapSpawnedWakeSelfUpgradePID waits for the real-PTY wake daemon to exit
+// after the test's assertions, using reap observation (not a fixed sleep) so
+// TempDir cleanup runs against a quiescent root. If the PID is 0 (helper never
+// printed proof) there is nothing to reap. If the child fails to exit within
+// the bound the test fails explicitly, naming the pid — instead of surfacing as
+// a TempDir "directory not empty" cleanup error.
+func reapSpawnedWakeSelfUpgradePID(t *testing.T, pid int) {
+	t.Helper()
+	if pid <= 0 {
+		return
+	}
+	// The wake daemon is detached; it will not exit on its own in the E2E
+	// window. Signal it to stop, then observe actual exit via processAlive.
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		t.Errorf("spawned wake pid %d: os.FindProcess: %v", pid, err)
+		return
+	}
+	_ = proc.Signal(syscall.SIGTERM)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// SIGTERM did not settle it within the bound; escalate.
+	_ = proc.Signal(syscall.SIGKILL)
+	killDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(killDeadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("spawned wake pid %d did not exit within reap bound", pid)
 }


### PR DESCRIPTION
`TestDarwinWakeSelfUpgradeRealPTYStableSymlink` spawned a detached real-PTY wake that kept writing under the test root after the assertions finished, so `t.TempDir` cleanup failed with "directory not empty" (seen on the new macOS CI job and locally; refs bead agent-message-queue-sqx).

The test now registers a reap step before its TempDir cleanups: it parses the wake PID the helper prints (`AMQ_SELF_UPGRADE_HELPER_OK pid=<n>`), sends SIGTERM, observes exit via liveness polling (escalating to SIGKILL), and fails explicitly naming the pid if the child does not exit within the bound. No fixed sleeps. 10/10 green on macOS locally.

Implemented by amit-pi.
