### PR TITLE
fix(wake): self-upgrade after the running image path is unlinked

### DIFF
--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -614,9 +614,12 @@ image is bound and verified; neither discovers a version from an untrusted
 candidate. A descendant that leaves the process group (setsid or setpgid) can
 escape it, which remains an explicit limitation of bounded probe cleanup.
 
-Darwin treats a still-running, identity-confirmed wake whose recorded path is
-gone (`proc_pidpath` ENOENT or ESRCH after an installer unlink) as a
-conclusive deleted image, so Homebrew Cellar replacement can exec in place.
+Darwin treats a still-running, identity-confirmed wake whose live mapped
+executable has the recorded device and inode as the same image even when the
+recorded pathname is gone, so Homebrew Cellar replacement can exec in place.
+Homebrew cleanup removes the previous Cellar; a wake still running that image upgrades normally because identity is compared by dev/ino, not pathname.
+An unreadable live identity or a present pathname that resolves to a different
+image remains inconclusive.
 A failed upgrade candidate is attempted at most
 once per candidate within one wake generation, bounded to the 8 most recent
 distinct candidates; a new generation resets that refusal memory. A refused

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -617,7 +617,6 @@ escape it, which remains an explicit limitation of bounded probe cleanup.
 Darwin treats a still-running, identity-confirmed wake whose live mapped
 executable has the recorded device and inode as the same image even when the
 recorded pathname is gone, so Homebrew Cellar replacement can exec in place.
-Homebrew cleanup removes the previous Cellar; a wake still running that image upgrades normally because identity is compared by dev/ino, not pathname.
 An unreadable live identity or a present pathname that resolves to a different
 image remains inconclusive.
 A failed upgrade candidate is attempted at most

--- a/internal/cli/doctor_stale_wake_binary_darwin.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin.go
@@ -9,21 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 const wakeStartedTimestampUncertainty = time.Second
 
 const deletedWakeImageReason = "wake is running a deleted image; restart it"
-
-// darwinWakeMappedImageGone reports whether Darwin could not name the live
-// process image because the vnode is already gone. Homebrew Cellar unlinks
-// produce ESRCH from proc_pidpath while the wake is still running; ENOENT is
-// the same class. Other inspection failures stay unknown.
-func darwinWakeMappedImageGone(err error) bool {
-	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, unix.ESRCH)
-}
 
 func inspectWakeBinaryStalenessPlatform(
 	inspection wakeLockInspection,
@@ -69,27 +59,25 @@ func inspectWakeBinaryStalenessPlatform(
 
 	running, err := inspectDarwinWakeProcessImage(inspection.PID)
 	if err != nil {
-		if darwinWakeMappedImageGone(err) && inspection.IdentityConfirmed && inspection.Process.Running {
-			imagePath := running.Path
-			if imagePath == "" {
-				imagePath = recorded.ExecutionPath
-			}
-			if imagePath == recorded.ExecutionPath {
-				if _, pathErr := os.Lstat(imagePath); errors.Is(pathErr, fs.ErrNotExist) {
-					return wakeBinaryStaleness{
-						Stale:    true,
-						Method:   wakeBinaryComparisonDarwinDeletedImage,
-						Evidence: comparisonEvidence,
-						Reason:   deletedWakeImageReason,
-					}, nil
-				}
-			}
-		}
 		return wakeBinaryStaleness{}, err
 	}
+	if running.Identity.Device != recorded.Device || running.Identity.Inode != recorded.Inode {
+		return wakeBinaryStaleness{}, fmt.Errorf("live wake image identity disagrees with recorded image evidence")
+	}
 	restartStageAlias := sameDarwinWakeRestartStageAlias(recorded, running)
+	deletedImage := false
 	if !sameDarwinWakeImagePath(recorded.ExecutionPath, running.Path) && !restartStageAlias {
-		return wakeBinaryStaleness{}, fmt.Errorf("live wake image path disagrees with recorded image evidence")
+		if _, pathErr := os.Lstat(recorded.ExecutionPath); errors.Is(pathErr, fs.ErrNotExist) {
+			deletedImage = true
+		} else {
+			return wakeBinaryStaleness{}, fmt.Errorf("live wake image path disagrees with recorded image evidence")
+		}
+	}
+	method := wakeBinaryComparisonDarwinProcessImage
+	reason := ""
+	if deletedImage {
+		method = wakeBinaryComparisonDarwinDeletedImage
+		reason = deletedWakeImageReason
 	}
 	comparisonEvidence.Running = wakeBinaryFileEvidenceFromIdentity(running.Identity)
 	if err := confirmResolvedDarwinWakeBinary(current, currentIdentity); err != nil {
@@ -99,8 +87,9 @@ func inspectWakeBinaryStalenessPlatform(
 	if running.Identity.Device != currentIdentity.Device || running.Identity.Inode != currentIdentity.Inode {
 		return wakeBinaryStaleness{
 			Stale:    true,
-			Method:   wakeBinaryComparisonDarwinProcessImage,
+			Method:   method,
 			Evidence: comparisonEvidence,
+			Reason:   reason,
 		}, nil
 	}
 	// The restart-stage hardlink changes the shared inode's ctime, while
@@ -125,8 +114,9 @@ func inspectWakeBinaryStalenessPlatform(
 		}, nil
 	}
 	return wakeBinaryStaleness{
-		Method:   wakeBinaryComparisonDarwinProcessImage,
+		Method:   method,
 		Evidence: comparisonEvidence,
+		Reason:   reason,
 	}, nil
 }
 

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -84,6 +84,7 @@ func TestDarwinSameVersionPathReplacementCannotReportCurrent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	runningEvidence := darwinWakeImageEvidenceForTest(t, executionPath, loadedInfo)
 	readyPath := filepath.Join(dir, "ready")
 	captureGatePath := filepath.Join(dir, "capture")
 	resultPath := filepath.Join(dir, "result.json")
@@ -153,9 +154,9 @@ func TestDarwinSameVersionPathReplacementCannotReportCurrent(t *testing.T) {
 		PID: cmd.Process.Pid,
 		Lock: wakeLock{
 			Started:              captured.Started,
-			ImagePath:            captured.Evidence.ExecutionPath,
-			ImageVersion:         captured.Evidence.EmbeddedVersion,
-			RunningImageEvidence: &captured.Evidence,
+			ImagePath:            runningEvidence.ExecutionPath,
+			ImageVersion:         runningEvidence.EmbeddedVersion,
+			RunningImageEvidence: &runningEvidence,
 		},
 	}
 	comparison, err := inspectWakeBinaryStalenessPlatform(
@@ -450,7 +451,11 @@ func TestDarwinWakeBinaryComparisonReportsDeletedLiveImageStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
-	stubDarwinProcessImage(t, darwinWakeProcessImage{Path: runningPath}, os.ErrNotExist)
+	mappedPath := filepath.Join(dir, "mapped-amq")
+	if err := os.Link(runningPath, mappedPath); err != nil {
+		t.Fatal(err)
+	}
+	stubDarwinProcessImage(t, darwinMappedImageForTest(t, mappedPath, runningInfo), nil)
 	if err := os.Remove(runningPath); err != nil {
 		t.Fatal(err)
 	}
@@ -480,17 +485,63 @@ func TestDarwinWakeBinaryComparisonReportsDeletedLiveImageStale(t *testing.T) {
 	}
 }
 
-func TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathReturnsENOENT(t *testing.T) {
+func TestMaintainWakeSelfUpgradeRequestsRestartAfterRecordedImagePathUnlinked(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runningPath := filepath.Join(t.TempDir(), "Cellar", "amq", "0.73.0", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(runningPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(executable, runningPath); err != nil {
+		t.Fatal(err)
+	}
+	runningInfo, err := os.Stat(runningPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorded, err := captureWakeImageEvidence(runningPath, fixture.lock.Lock.ImageVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.lock.Lock.ImagePath = recorded.ExecutionPath
+	fixture.lock.Lock.RunningImageEvidence = &recorded
+	if err := os.Remove(runningPath); err != nil {
+		t.Fatal(err)
+	}
+	stubDarwinProcessImage(t, darwinMappedImageForTest(t, executable, runningInfo), nil)
+
+	candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
+	state := selfUpgradeStateForCandidate(t, candidate)
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+	decision, err := maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
+	if err != nil || decision.Action != wakeSelfUpgradeActionPending {
+		t.Fatalf("unlinked-image decision=%#v err=%v, want pending restart", decision, err)
+	}
+	if decision.Candidate == nil || decision.Candidate.Version != "0.57.0" {
+		t.Fatalf("unlinked-image candidate=%#v, want strictly newer candidate", decision.Candidate)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+}
+
+func TestDarwinWakeBinaryComparisonDefersWhenProcessImageIdentityIsUnavailable(t *testing.T) {
 	started := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
 	for _, tc := range []struct {
-		name     string
-		inspect  error
-		remove   bool
-		wantGone bool
+		name    string
+		inspect error
+		remove  bool
 	}{
-		{name: "ENOENT deleted path", inspect: os.ErrNotExist, remove: true, wantGone: true},
-		{name: "ESRCH deleted path", inspect: fmt.Errorf("resolve wake process executable: proc_pidpath pid %d: %w", 4242, unix.ESRCH), remove: true, wantGone: true},
-		{name: "ESRCH path still present", inspect: fmt.Errorf("resolve wake process executable: proc_pidpath pid %d: %w", 4242, unix.ESRCH), remove: false, wantGone: false},
+		{name: "ENOENT deleted path", inspect: os.ErrNotExist, remove: true},
+		{name: "ESRCH deleted path", inspect: fmt.Errorf("resolve wake process executable: proc_pidpath pid %d: %w", 4242, unix.ESRCH), remove: true},
+		{name: "ESRCH path still present", inspect: fmt.Errorf("resolve wake process executable: proc_pidpath pid %d: %w", 4242, unix.ESRCH), remove: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -534,17 +585,8 @@ func TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathRet
 				},
 				resolvedWakeBinary{Path: currentPath, Info: currentInfo},
 			)
-			if tc.wantGone {
-				if err != nil {
-					t.Fatalf("compare deleted recorded image: %v", err)
-				}
-				if !got.Stale || got.Method != wakeBinaryComparisonDarwinDeletedImage || got.Reason != deletedWakeImageReason {
-					t.Fatalf("deleted recorded image comparison = %#v, want proven stale", got)
-				}
-				return
-			}
 			if err == nil || got.Stale {
-				t.Fatalf("live image still present = %#v, %v; want unknown error", got, err)
+				t.Fatalf("unavailable live image = %#v, %v; want unknown error", got, err)
 			}
 		})
 	}
@@ -593,7 +635,7 @@ func TestDarwinWakeBinaryComparisonKeepsNonENOENTImageFailureUnknown(t *testing.
 	}
 }
 
-func TestDarwinWakeBinaryComparisonUsesMappedVnodeOverRecordedPathIdentity(t *testing.T) {
+func TestDarwinWakeBinaryComparisonDefersWhenRecordedIdentityDiffers(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "amq")
 	if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
 		t.Fatal(err)
@@ -618,8 +660,8 @@ func TestDarwinWakeBinaryComparisonUsesMappedVnodeOverRecordedPathIdentity(t *te
 		},
 		resolvedWakeBinary{Path: path, Info: info},
 	)
-	if err != nil || got.Stale || got.Method != wakeBinaryComparisonDarwinProcessImage {
-		t.Fatalf("mapped vnode comparison = %#v, %v; want current despite stale pathname identity", got, err)
+	if err == nil || got.Stale {
+		t.Fatalf("recorded identity mismatch = %#v, %v; want unknown error", got, err)
 	}
 }
 

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -249,9 +249,9 @@ func TestMaintainWakeSelfUpgradeUsesLiveProcessImageOverRecordedEvidence(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decision.Action != wakeSelfUpgradeActionRefused ||
-		!strings.Contains(decision.Reason, "not conclusively different from the live wake") {
-		t.Fatalf("live image decision = %#v, want refused", decision)
+	if decision.Action != wakeSelfUpgradeActionDeferred ||
+		!strings.Contains(decision.Reason, "unknown or ambiguous") {
+		t.Fatalf("live image decision = %#v, want deferred", decision)
 	}
 	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
 		t.Fatalf("same live image created restart record: %v", err)

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -249,9 +250,17 @@ func TestMaintainWakeSelfUpgradeUsesLiveProcessImageOverRecordedEvidence(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decision.Action != wakeSelfUpgradeActionDeferred ||
-		!strings.Contains(decision.Reason, "unknown or ambiguous") {
-		t.Fatalf("live image decision = %#v, want deferred", decision)
+	// Darwin cannot corroborate a recorded/live identity mismatch after the
+	// pathname may have been unlinked; Linux's /proc/<pid>/exe identity is
+	// conclusive and correctly refuses a same-image candidate.
+	if runtime.GOOS == "darwin" {
+		if decision.Action != wakeSelfUpgradeActionDeferred ||
+			!strings.Contains(decision.Reason, "unknown or ambiguous") {
+			t.Fatalf("live image decision = %#v, want deferred", decision)
+		}
+	} else if decision.Action != wakeSelfUpgradeActionRefused ||
+		!strings.Contains(decision.Reason, "not conclusively different from the live wake") {
+		t.Fatalf("live image decision = %#v, want refused", decision)
 	}
 	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
 		t.Fatalf("same live image created restart record: %v", err)


### PR DESCRIPTION
Refs bead agent-message-queue-xxt. Found by the v0.74.0 live proof: a wake launched from the Homebrew Cellar could never self-upgrade after `brew upgrade` cleanup removed its running image (the self-upgrade tick deferred forever on "live wake image path disagrees with recorded image evidence"). Implemented by codex.

When the recorded Cellar pathname is gone, compare the live mapped executable's
device and inode with the recorded wake image evidence. Matching identity is
conclusive deleted-image evidence and allows the strictly newer candidate to
restart the wake. A mismatched or unreadable identity remains inconclusive and
defers; existing pathname replacement checks remain fail-closed.

Linux parity: Linux compares os.Stat("/proc/<pid>/exe") dev/ino against the
current binary with no pathname check (doctor_stale_wake_binary_linux.go:17-31),
so the unlinked-image defect is Darwin-only. An unreadable live identity
(proc_pidpath ENOENT/ESRCH) now defers instead of reporting "deleted image".

Tests:
- focused Darwin and self-upgrade tests
- full internal/cli package
- GOOS=linux go vet ./...
- GOOS=windows go vet ./...
- golangci-lint 2.13.1
- smoke, contract-check, and hook-env-check

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathReturnsENOENT: renamed to TestDarwinWakeBinaryComparisonDefersWhenProcessImageIdentityIsUnavailable because unreadable live identity must defer.
TestDarwinWakeBinaryComparisonUsesMappedVnodeOverRecordedPathIdentity: renamed to TestDarwinWakeBinaryComparisonDefersWhenRecordedIdentityDiffers because recorded/live dev-ino mismatch must defer.
END_WAKE_TEST_CHANGE_JUSTIFICATION

