### PR TITLE
feat(bridge): envelope v2 and G-initiated peer-exchange docs

### DIFF
--- a/cmd/amq-bridge/README.md
+++ b/cmd/amq-bridge/README.md
@@ -16,8 +16,8 @@ sending envelopes. The root contains:
 
 - `bridge/host-id` (mode `0600`), the local host alias;
 - `bridge/identity` (mode `0600`), the active generation and private seed; and
-- `bridge/trusted/<source_host>` (mode `0600`), the trusted peer generation and
-  public key.
+- `bridge/trusted/<source_host>/<generation>` (mode `0600`), the trusted
+  peer's public key for the named generation.
 
 `scripts/amq-host-bootstrap.sh` writes `host-id`. Then initialize and export
 the public record:
@@ -28,41 +28,80 @@ amq-bridge identity public --root "$AM_ROOT"
 ```
 
 Copy only that public identity record to the peer's
-`<root>/bridge/trusted/<source_host>` path. Never copy the private seed.
+`<root>/bridge/trusted/<source_host>/<generation>` path. Never copy the
+private seed. Keep the current and immediately previous trusted generations
+during rotation; remove an old generation only after no in-flight object names
+it. The overlap is bounded to two generations.
 `--allow-source-host` is only an exact routing allowlist and does not
 authenticate the peer. The receiver verifies the Ed25519 signature before
 applying an envelope.
 
-## Local file apply
+## Manual file apply (recovery)
 
-This is the proven bidirectional hop. There is no public locker. Drop one
-complete JSON `internal/bridge.Envelope` under the ignored local queue path
-`<AMQ root>/bridge/drop/`, then run:
+This is a manual/recovery path, not the live G-Mac peer-exchange class. There
+is no public locker. Publish one complete JSON `internal/bridge.Envelope` as a
+hash-named regular file under the ignored local queue path
+`<AMQ root>/bridge/drop/new/<object_sha256>.envelope`, then run:
 
 ```sh
 amq-bridge apply-file \
   --root "$AM_ROOT" \
-  --file "$AM_ROOT/bridge/drop/envelope.json"
+  --file "$AM_ROOT/bridge/drop/new/<object_sha256>.envelope"
 ```
 
 The command reads only that regular, non-symlink file. It loads the local
-`bridge/host-id` and the trusted public key selected by the envelope's
-`source_host`, verifies the Ed25519 signature and payload digest, requires the
-`dest_alias` host to match the local host-id, and then calls the same
-`ApplyEnvelope` Maildir path as the courier. It prints and durably records a
-`destination_maildir_committed` receipt under `<AMQ root>/bridge/receipts/`.
-Repeating the same file is an idempotent replay; the same transfer key with a
-different payload is a conflict. Unsigned or forged envelopes, foreign
-destinations, symlinks, and files outside `bridge/drop` are rejected. The
-same command on the peer host applies the reverse hop. Run
+`bridge/host-id` and the trusted public key at
+`trusted/<source_host>/<key_generation>`, verifies the v2 Ed25519 signature
+and payload digest, requires the `dest_alias` host to match the local host-id,
+and then calls the same `ApplyEnvelope` Maildir path as the courier. It prints
+and durably records a `destination_maildir_committed` receipt under
+`<AMQ root>/bridge/receipts/`. Repeating the same file is an idempotent
+replay; the same transfer key with a different payload is a conflict.
+The command consumes only files directly under `bridge/drop/new/`.
+`bridge/drop/tmp/`, `*.part` files, symlinks, unsigned or forged envelopes,
+foreign destinations, and files outside `bridge/drop/new/` are rejected. The
+same recovery command can run on either host. Run
 `scripts/amq-bot-envelope-hop-probe.sh` to sign a drop file; set
 `AMQ_BOT_ENVELOPE_HOP_THREAD` when the payload must keep an existing opaque
 thread id.
 
-## HTTPS courier
+## G-initiated peer exchange
 
-When an operator provisions a rendezvous, the courier dials out. AMQ does
-not ship a hosted relay. The default outbound spool is:
+For G-Mac traffic, this is the live courier class. Host G is the only dialer:
+it starts a fixed, config-pinned `amq-bridge peer-stdio` session and the Mac
+helper responds. The session is duplex, so G-to-Mac envelopes and
+Mac-to-G outcomes can move in one session, but the Mac does not initiate the
+class. `amq` itself remains local and daemon-free.
+
+Envelope v2 is the emitted peer-exchange format. The exchange moves exact,
+hash-named object files, not re-serialized AMQ messages:
+
+```text
+tx/<peer>/{tmp,new,committed,rejected}
+status-tx/<peer>/{tmp,new,returned}
+rx/<peer>/{tmp,new,done,quarantine}
+status-rx/<peer>/{tmp,new,done,quarantine}
+```
+
+The receiver writes an envelope to `rx/<peer>/tmp`, fsyncs it, and
+no-replace renames it to `rx/<peer>/new/<object_sha256>.envelope`. That
+durable destination rename is `transport_accepted`; it does not apply the
+payload or retire the source `tx` object. The source retires `tx` only after a
+verified signed `destination_maildir_committed` or `destination_rejected`
+outcome. Outcomes use `status-tx/<peer>/new` and may move to
+`status-tx/<peer>/returned` after transfer. Peer exchange never creates or
+uses `sent/`; that directory remains HTTPS-only.
+
+`OFFER`/`WANT` inventory is limited to the `tx`, `status-tx`, `rx`, and
+`status-rx` trees. The courier never reads Maildir, `applied/`, or
+`apply-journal/`. `STORED` means that the kind-specific destination sink is
+durable; it is not apply, source archive, or consumer drain.
+
+## Optional HTTPS courier
+
+When an operator provisions a rendezvous, this implemented optional courier
+class can dial out. It is not the live G-Mac hop or the live architecture.
+AMQ does not ship a hosted relay. Its outbound spool is:
 
 ```
 <AMQ root>/bridge/outbox/<source-handle>/new/
@@ -71,9 +110,11 @@ not ship a hosted relay. The default outbound spool is:
 Place complete AMQ message files there. `amq-bridge enqueue --dest-alias` writes
 a sibling `.dest` sidecar next to the spool `.md`, and the courier stamps that
 `dest_alias` on the wire (not `--dest-alias` on the courier if a sidecar exists).
-After the rendezvous returns the exact `transport_accepted` receipt, the courier
-archives the file in the sibling `sent/` directory and writes a typed receipt
-under `<AMQ root>/bridge/receipts/`.
+After the rendezvous returns the exact `transport_accepted` receipt, this
+HTTPS-only spool may archive the file in the sibling `sent/` directory and
+write a typed receipt under `<AMQ root>/bridge/receipts/`. This legacy HTTPS
+archive rule does not apply to peer-exchange `tx` objects, which wait for a
+terminal destination outcome.
 
 One bounded bidirectional cycle on a host uses a **local** receive alias and
 a **remote** send alias. Do not poll a foreign dest alias into this root:
@@ -100,8 +141,8 @@ The rendezvous contract is:
 
 The receiver allowlist is exact. A polled envelope for another alias, an
 unknown envelope field, a digest conflict, or an ACK before local Maildir
-commit is rejected. Until a rendezvous exists, use apply-file; do not treat
-this courier loop as the live hop.
+commit is rejected. Until a rendezvous exists, use peer exchange or
+apply-file; do not treat this optional HTTPS loop as the live hop.
 
 ## Host G (Grok computer)
 
@@ -112,18 +153,21 @@ the proven layout). G update/reset and a second Bot seat on the same VM
 remain untested.
 
 1. Pin `AM_ROOT` / `AM_ME` in operator config, never in Bot chat.
-2. Set `bridge/host-id` to the G host alias. It must match `--source-host` for
-   push and the host component of `--receive-alias` for poll. Copy G's public
-   identity record to the Mac's `bridge/trusted/grok` file, and copy the Mac's
-   public identity record to G's `bridge/trusted/mac` file.
-3. Apply inbound envelopes with `amq-bridge apply-file` on G. Reverse hops
-   use the same command on the Mac. If a rendezvous exists, run the courier
-   with G as `--source-host` and Mac aliases on `--allow-dest`. G does not
-   listen.
-4. Bot submit is config-only enqueue (`amq-bridge enqueue --config FILE
-   --dest-alias host/agent`, stdin = one AMQ message). It writes a sibling
-   `.dest` sidecar next to the spool `.md`. Prompt/chat must not pass
-   `--root`, `--rendezvous`, `--me`, or `--spool` to `enqueue`.
+2. Set `bridge/host-id` to the G host alias. It must match the local source
+   host and the host component of any receiver-owned alias. Copy G's public
+   identity record to the Mac's `bridge/trusted/grok/<generation>` path, and
+   copy the Mac's public identity record to G's
+   `bridge/trusted/mac/<generation>` path.
+3. Start the G-initiated peer-stdio exchange with the fixed Mac helper. G is
+   the dialer and the Mac is the responder; the session transfers both
+   directions' envelopes and outcomes. Apply inbound envelopes locally after
+   they reach `rx/<peer>/new`. G does not listen.
+4. Live peer exchange uses one config-only submit-intent record per AMQ
+   message (`amq-bridge enqueue --config FILE --dest-alias host/agent`, stdin
+   = one AMQ message). The signer emits Envelope v2 from that intent; it does
+   not create a sibling `.dest` sidecar or use the HTTPS spool. `.dest`
+   sidecars are HTTPS-only. Prompt/chat must not pass `--root`, `--rendezvous`,
+   `--me`, or `--spool` to `enqueue`.
 5. Bot chat must invoke the fixed wrapper
    [`scripts/amq-bridge-bot-enqueue.sh`](../../scripts/amq-bridge-bot-enqueue.sh)
    instead of `amq-bridge enqueue` directly. Its argv is exactly

--- a/cmd/amq-bridge/apply_file_test.go
+++ b/cmd/amq-bridge/apply_file_test.go
@@ -59,7 +59,13 @@ func TestApplyFileReplayAndConflictPreserveMaildirAndReceipt(t *testing.T) {
 		t.Fatalf("inbox entries after replay = %d, want 1", len(entries))
 	}
 
-	conflict := applyFileTestEnvelope(t, env.TransferID, []byte("different"))
+	conflict := env
+	conflict.Payload = []byte("different")
+	digest := sha256.Sum256(conflict.Payload)
+	conflict.PayloadSHA256 = hex.EncodeToString(digest[:])
+	if err := bridge.SignEnvelope(&conflict, testHostKey("grok-host", "1")); err != nil {
+		t.Fatal(err)
+	}
 	writeApplyFileEnvelope(t, root, "envelope.json", conflict)
 	err = runApplyFile([]string{"--root", root, "--file", path})
 	if !errors.Is(err, os.ErrExist) {
@@ -97,11 +103,11 @@ func TestApplyFileRejectsUnsignedEnvelopeBeforeMaildirCommit(t *testing.T) {
 	ensureHostID(t, root, "mac")
 	ensureTrusted(t, root, "grok-host")
 	env := applyFileTestEnvelope(t, "unsigned-file", []byte("unsigned"))
-	env.Signature = ""
-	raw, err := json.Marshal(env)
+	raw, err := bridge.MarshalEnvelope(env)
 	if err != nil {
 		t.Fatal(err)
 	}
+	raw = []byte(strings.Replace(string(raw), `"signature":"`+env.Signature+`"`, `"signature":""`, 1))
 	path := writeApplyFileRaw(t, root, "unsigned.json", raw)
 
 	if err := runApplyFile([]string{"--root", root, "--file", path}); err == nil {
@@ -116,6 +122,7 @@ func TestApplyFileRejectsForeignDestinationAndSymlink(t *testing.T) {
 	ensureTrusted(t, root, "grok-host")
 	env := applyFileTestEnvelope(t, "foreign-file", []byte("foreign"))
 	env.DestAlias = "other/claude"
+	env.TransferID = bridge.DeriveTransferID(env.SourceHost, env.SourceHandle, env.SourceMessageID, env.DestAlias)
 	if err := bridge.SignEnvelope(&env, testHostKey("grok-host", "1")); err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +188,6 @@ func applyFileTestEnvelope(t *testing.T, transferID string, payload []byte) brid
 	sum := sha256.Sum256(payload)
 	env := bridge.Envelope{
 		Version:         bridge.EnvelopeVersion,
-		TransferID:      transferID,
 		SourceHost:      "grok-host",
 		SourceHandle:    "codex",
 		DestAlias:       "mac/claude",
@@ -191,6 +197,7 @@ func applyFileTestEnvelope(t *testing.T, transferID string, payload []byte) brid
 		KeyGeneration:   "1",
 		Payload:         payload,
 	}
+	env.TransferID = bridge.DeriveTransferID(env.SourceHost, env.SourceHandle, env.SourceMessageID, env.DestAlias)
 	if err := bridge.SignEnvelope(&env, testHostKey("grok-host", "1")); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/amq-bridge/courier.go
+++ b/cmd/amq-bridge/courier.go
@@ -588,10 +588,9 @@ func (c *Courier) readSpool() ([]spoolItem, error) {
 
 func envelopeForMessage(cfg Config, destAlias, messageID, threadID string, payload []byte) bridge.Envelope {
 	digest := sha256.Sum256(payload)
-	transferDigest := sha256.Sum256([]byte(cfg.SourceHost + "\x00" + messageID + "\x00" + destAlias))
 	return bridge.Envelope{
 		Version:         bridge.EnvelopeVersion,
-		TransferID:      "xfer-" + hex.EncodeToString(transferDigest[:16]),
+		TransferID:      bridge.DeriveTransferID(cfg.SourceHost, cfg.SourceHandle, messageID, destAlias),
 		SourceHost:      cfg.SourceHost,
 		SourceHandle:    cfg.SourceHandle,
 		DestAlias:       destAlias,

--- a/cmd/amq-bridge/courier_test.go
+++ b/cmd/amq-bridge/courier_test.go
@@ -663,7 +663,6 @@ func testEnvelope(t *testing.T, transferID string) bridge.Envelope {
 	digest := sha256.Sum256(payload)
 	env := bridge.Envelope{
 		Version:         bridge.EnvelopeVersion,
-		TransferID:      transferID,
 		SourceHost:      "grok-host",
 		SourceHandle:    "codex",
 		DestAlias:       "mac/claude",
@@ -673,6 +672,7 @@ func testEnvelope(t *testing.T, transferID string) bridge.Envelope {
 		KeyGeneration:   "1",
 		Payload:         payload,
 	}
+	env.TransferID = bridge.DeriveTransferID(env.SourceHost, env.SourceHandle, env.SourceMessageID, env.DestAlias)
 	if err := bridge.SignEnvelope(&env, testHostKey("grok-host", "1")); err != nil {
 		t.Fatal(err)
 	}

--- a/docs/adr-bridge-protocol.md
+++ b/docs/adr-bridge-protocol.md
@@ -33,17 +33,32 @@ existing Maildir `publishTmpNoReplace` on a stable transfer filename.
 The wire unit is the signed envelope below. Local apply is the same
 `ApplyEnvelope` path in every hop.
 
-v1 hops without a public locker use **`amq-bridge apply-file`**: the operator
-moves one envelope into `<root>/bridge/drop/` on the destination host; that
-host verifies and commits it. The reverse hop is the same command on the
-peer. This is the proven bidirectional path.
+The supported G-Mac courier class is **G-initiated peer exchange**. Host G is
+the only dialer: it starts a fixed, config-pinned peer-stdio session and the
+Mac helper is the responder. The session is duplex, so envelopes and signed
+outcomes can move in both directions, but the Mac does not initiate this
+class. `amq` Core remains local and daemon-free; no socket is added to it.
 
-The courier class remains **HTTPS store-and-forward**. Both nodes dial out.
-Host G accepts no inbound connection. The rendezvous is an opaque blob store
-with lease, retry, backoff, and bounded batches. It never reads AMQ handles
-or Maildir state. AMQ does not ship a hosted relay. A public rendezvous is
-operator-provided; until one exists, do not treat HTTPS poll/push as the live
-hop.
+The initiator offers objects from `tx/<peer>/new` and
+`status-tx/<peer>/new`. A receiver writes exact object bytes to a private
+`tmp` file, fsyncs the file, and no-replace renames the file into
+`rx/<peer>/new/<object_sha256>.envelope` (or the corresponding
+`status-rx` path for an outcome). That durable rename is
+`transport_accepted`. It is transport acceptance only: apply-watch later
+verifies and applies the envelope, and the source does not retire its `tx`
+object at this stage.
+
+The manually operated **`amq-bridge apply-file`** path remains available for
+recovery and file-based exchange. It verifies a complete hash-named regular
+file published under `drop/new/` and uses the same local apply and receipt
+rules; it is not a remote drain or a Maildir synchronizer.
+
+HTTPS store-and-forward remains implemented as an optional courier class for
+an operator-provided rendezvous. It is not the live G-Mac hop or the live
+architecture. The rendezvous is an opaque blob store with lease, retry,
+backoff, and bounded batches; it never reads AMQ handles or Maildir state.
+AMQ does not ship a hosted relay, and operators must not treat HTTPS
+poll/push as the active peer exchange.
 
 Not v1: git, Maildir sync, reverse tunnels, inbound SSH to G, remote drain,
 or sockets inside `amq`.
@@ -62,16 +77,19 @@ The wire unit is a versioned envelope. Required fields:
 - `payload_sha256`
 - `key_generation`
 - `signature` (hex encoding of a 64-byte Ed25519 signature)
-- `payload` (exact AMQ message bytes)
+- `payload_b64` (unpadded standard-base64 encoding of exact AMQ message bytes)
 
 Unknown fields and the following names are rejected: paths, roots, argv, env,
 executable names, endpoints, and remote session selectors.
 
-The signature covers canonical v1 envelope bytes. Canonicalization excludes the
-`signature` field and the raw `payload` bytes, but includes `payload_sha256`.
-The receiver verifies the signature before local Maildir apply. The
-`key_generation` selects the local identity on the sender and the trusted
-public key on the receiver.
+The G-initiated peer exchange emits **Envelope v2**: one compact JSON object,
+fixed key order, unknown fields refused, and `payload_b64` decoded with raw
+standard base64 (no padding or whitespace). The signature preimage is the
+length-prefixed v2 field contract, not a re-serialized payload. The receiver
+hashes the exact envelope file bytes for `envelope_sha256`, recomputes the
+decoded `payload_sha256` and `transfer_id`, and verifies the signature before
+any claimed identifier can become a path. Version 1 is not emitted by this
+class.
 
 The payload is an ordinary AMQ message. Project/job/session values inside it
 are untrusted context, never routing keys.
@@ -82,24 +100,32 @@ Keep three layers distinct:
 
 | State | Meaning |
 | --- | --- |
-| `transport_accepted` | The HTTPS courier accepted the envelope. `apply-file` does not emit this stage. |
-| `destination_maildir_committed` | `publishTmpNoReplace` committed `xfer-<transfer_id>.md`. |
+| `transport_accepted` | The destination durably renamed the exact envelope bytes into `rx/<peer>/new/<object_sha256>.envelope`. It does not retire the source `tx` object. |
+| `destination_maildir_committed` | `ApplyEnvelope` committed `xfer-<source_host>-<transfer_id>.md` into the destination Maildir. |
+| `destination_rejected` | The authenticated destination emitted a terminal rejection, such as `alias_not_accepted` or `transfer_conflict`. |
 | consumer-local drain/start/complete | Optional; may stay on the consuming host. |
 
-ACK only after durable Maildir commit. Lost ACK replays the same
-`(source_host, transfer_id, payload_sha256)` and must not create a second
-message. Same key, different digest is conflict (`EEXIST` / explicit error).
-Crash between commit and ACK is `uncertain` until a later identical replay
-confirms the dest bytes.
+The source retires `tx/<peer>/new` only after a verified signed
+`destination_maildir_committed` or `destination_rejected` outcome. A
+`transport_accepted` outcome is diagnostic and never archives the source
+object. Lost outcomes replay the same transfer and must not create a second
+message. A same-key, different-digest replay is `transfer_conflict` and binds
+the received envelope and payload digests in the rejection outcome.
+
+Outcome objects travel through `status-tx/<peer>/new` and may move to
+`status-tx/<peer>/returned` after a successful peer transfer. `sent/` is not
+used by peer exchange; it remains an HTTPS-only archive.
 
 ### Authorization
 
-The rendezvous is an untrusted HTTPS blob store. It does not authenticate a
-host, and `--allow-source-host` is a routing allowlist, not authentication.
-The receiving host verifies the Ed25519 signature against its local trusted
-key, then maps `dest_alias` through that allowlist. Claimed handle, labels,
-prompt text, and remote paths are not authority. All Grok Bots on G are one
-host principal until a live test proves otherwise.
+For the optional HTTPS class, the rendezvous is an untrusted blob store. It
+does not authenticate a host, and `--allow-source-host` is a routing allowlist,
+not authentication. For peer exchange, the fixed helper configuration and
+the Ed25519 signature provide the host binding. The receiving host verifies
+the signature against its local trusted generation, then maps `dest_alias`
+through its allowlist. Claimed handle, labels, prompt text, and remote paths
+are not authority. All Grok Bots on G are one host principal until a live test
+proves otherwise.
 
 Each queue root has these bridge identity files:
 
@@ -108,15 +134,64 @@ Each queue root has these bridge identity files:
   poll.
 - `<root>/bridge/identity` (mode `0600`): the local key generation and
   Ed25519 private seed.
-- `<root>/bridge/trusted/<source_host>` (mode `0600`): the trusted peer's key
-  generation and Ed25519 public key.
+- `<root>/bridge/trusted/<source_host>/<generation>` (mode `0600`): the
+  trusted peer's Ed25519 public key for the named generation.
 
 Bootstrap writes `host-id`. `amq-bridge identity init` then writes `identity`
 for that host. Copy only the public key record to the peer's
-`trusted/<source_host>` file; never copy a private seed. A trusted generation
-is selected locally and must match the signed envelope. Revocation is local
-and immediate: delete the trusted file or replace it with a new trusted
-generation before accepting more envelopes.
+`trusted/<source_host>/<generation>` path; never copy a private seed. During
+rotation, keep the current and immediately previous generations as a bounded
+two-generation overlap. Verify the generation named in each envelope. Remove
+an old generation only after doctor reports zero in-flight objects naming it.
+Do not accept a third generation as an implicit overlap or use a flat
+`trusted/<source_host>` path for v2.
+
+### G-initiated exchange layout and stages
+
+The peer-exchange WAL is separate from the HTTPS spool:
+
+```text
+tx/<peer>/{tmp,new,committed,rejected}
+status-tx/<peer>/{tmp,new,returned}
+rx/<peer>/{tmp,new,done,quarantine}
+status-rx/<peer>/{tmp,new,done,quarantine}
+drop/{tmp,new}
+```
+
+The G initiator and Mac responder exchange only hash-named envelope and
+outcome objects. `OFFER`/`WANT` inventory is limited to those courier trees;
+the courier never reads Maildir, `applied/`, or `apply-journal/`. `STORED`
+means that the kind-specific `rx` or `status-rx` sink is durable. It does not
+mean apply, source archive, or consumer drain.
+
+### Implementer contract: amq-ad6 addenda
+
+These eight addenda are normative and override older wording in this ADR or
+the design source:
+
+1. **Hash-named publish.** Create with `O_EXCL` in `tmp`, write, fsync, hash
+   with SHA-256, and no-replace rename to `<64hex>.<kind>`, then fsync the
+   directory. Maildir publication is `tmp` to no-replace
+   `new/xfer-<source>-<transfer>.md`. Hash before the final filename.
+2. **Bounds.** `max_payload_bytes=8MiB`, `max_object_bytes=12MiB`,
+   `max_offered_bytes_per_session=16MiB`, and `max_offer_count=64`.
+3. **Apply lock.** Acquire `flock` on
+   `apply-locks/<source>/<transfer>.lock` before ledger, ACL, or journal
+   work. `O_EXCL` is the compare-and-set for terminal `applied` only.
+4. **Conflict binding.** A `transfer_conflict` binds the currently received
+   envelope and payload digests. The source finds `tx` by
+   `envelope_sha256`. Receipts are
+   `bridge/receipts/<peer>/<envelope_sha256>.outcome`.
+5. **Unique exchange.** OFFER and WANT are unique. PUT equals OFFER. Send
+   one PUT per WANT and then `PUT_END`; missing PUT aborts.
+6. **Durable cursor.** Persist the offer cursor. Process outcomes first, and
+   advance the cursor on `STORED` or `not-WANT`.
+7. **Signer binding.** The local `source_host` signs. Bind From, Id, and
+   Thread (and To when present) from the AMQ payload. Resume the same digest;
+   a different digest is `submit/failed`.
+8. **Driver boundary.** There is no signed-bundle PR. PR 10 is SSH
+   forced-command plus local-exec only. `drop/` uses hash-named publication
+   into `drop/new/`.
 
 ### Bot client on G
 
@@ -140,11 +215,13 @@ principal until a live test proves isolation.
 
 ## Consequences
 
-- Courier code implements this envelope and HTTPS poll/push. It does not add
-  listeners to `amq`.
-- `amq-bridge apply-file` is the proven bidirectional hop: same envelope,
-  same local apply, no public locker.
-- Operators may provision a public HTTPS rendezvous. AMQ does not ship a
-  hosted relay as Core.
+- Courier code implements this envelope and G-initiated peer-stdio exchange;
+  HTTPS poll/push remains optional. It does not add listeners to `amq`.
+- `amq-bridge apply-file` is the manual/recovery path: it uses the same
+  envelope and local apply rules without a public locker, but it is not the
+  live G-Mac peer-exchange class.
+- G is the only peer-exchange dialer, and destination apply remains the
+  commit. Operators may provision a public HTTPS rendezvous, but AMQ does not
+  ship a hosted relay as Core.
 - G is a normal AMQ install. Pin `AM_ROOT` in operator config, never in Bot
   chat. Durable state belongs under a path that survives Bot client close.

--- a/docs/adr-two-host-fleets.md
+++ b/docs/adr-two-host-fleets.md
@@ -51,7 +51,7 @@ message into its own Maildir.
 `amq-bridge` is not Maildir sync, not a remote `drain` of a foreign mailbox,
 and not a socket inside `amq`.
 
-Bidirectional v1 means all of:
+Bidirectional exchange means all of:
 
 1. **Alias send** — the sender addresses a receiver-owned alias.
 2. **Crash-idempotent local apply** — the destination host commits the
@@ -59,13 +59,19 @@ Bidirectional v1 means all of:
 3. **Reply on the same opaque thread ID** — the reply uses that thread ID
    as an opaque correlation key, not as routing authority.
 
-Both bridge nodes dial out. Host G accepts no inbound SSH. Reachability is
-operator-provided. The signed envelope and local apply path are frozen in
-[the companion bridge protocol ADR](adr-bridge-protocol.md). Proven
-bidirectional hops use `amq-bridge apply-file` on the destination host.
-HTTPS store-and-forward remains the courier class when an operator
-provisions a rendezvous; AMQ does not ship a hosted relay. Git is not the
-default cross-host transport. Core has no sockets.
+For the peer-exchange courier, host G is the only dialer. G starts a fixed,
+config-pinned `amq-bridge` peer-stdio session and the Mac helper responds.
+The session is duplex, so mail and signed outcomes can move in both
+directions; the Mac does not initiate this class. Host G accepts no inbound
+SSH. Reachability is operator-provided. The signed envelope and local apply
+path are frozen in [the companion bridge protocol ADR](adr-bridge-protocol.md).
+The manually operated `amq-bridge apply-file` path remains available for
+recovery and file-based exchange.
+
+HTTPS store-and-forward remains implemented as an optional courier class for
+an operator-provided rendezvous. It is not the live G-Mac hop or the live
+architecture. Git is not the default cross-host transport. Core has no
+sockets.
 
 ### Routing aliases
 
@@ -100,18 +106,25 @@ identities are not a second trust boundary.
 
 ### Receipts stay typed
 
-v1 receipt states stay distinct. They are not collapsed:
+Receipt states stay distinct. They are not collapsed:
 
 | State | Meaning |
 | --- | --- |
-| `transport_accepted` | The bridge accepted the send for transport. |
+| `transport_accepted` | The destination durably placed the exact envelope object in `rx/<peer>/new/`. |
 | `destination_maildir_committed` | The destination host applied the message into its Maildir. |
+| `destination_rejected` | The authenticated destination returned a terminal rejection. |
 | consumer-local `drain` / `start` / `complete` | A consumer on that host ingested or progressed the work. |
 
 `transport_accepted` is not `destination_maildir_committed`. Destination
-commit is not consumer-local evidence. Consumer evidence may stay local in
-v1; a remote party must not treat a wake, a transport ACK, or a missing
-remote drain receipt as proof of consumption.
+commit is not consumer-local evidence, and it does not retire the source
+`tx` object. The source retires `tx` only after a verified signed
+`destination_maildir_committed` or `destination_rejected` outcome. Consumer
+evidence may stay local; a remote party must not treat a wake, a transport
+ACK, or a missing remote drain receipt as proof of consumption.
+
+Peer-exchange outcomes use `status-tx/<peer>/returned`; `sent/` remains an
+HTTPS-only archive. Trusted peer keys use
+`trusted/<host>/<generation>` with a bounded two-generation rotation overlap.
 
 ### Wake (out of scope except the kill-list)
 

--- a/internal/bridge/apply_test.go
+++ b/internal/bridge/apply_test.go
@@ -17,7 +17,7 @@ func testEnvelope(payload []byte) Envelope {
 	sum := sha256.Sum256(payload)
 	return Envelope{
 		Version:         EnvelopeVersion,
-		TransferID:      "t1",
+		TransferID:      DeriveTransferID("grok-host", "codex", "msg-1", "mac/claude"),
 		SourceHost:      "grok-host",
 		SourceHandle:    "codex",
 		DestAlias:       "mac/claude",
@@ -86,15 +86,16 @@ func TestApplyEnvelopeIgnoresUntrustedPayloadRoutingHints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := ApplyEnvelope(root, "mac", "claude", testEnvelope(payload))
+	env := testEnvelope(payload)
+	result, err := ApplyEnvelope(root, "mac", "claude", env)
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	want := filepath.Join(fsq.AgentInboxNew(base, "claude"), TransferFilename("grok-host", "t1"))
+	want := filepath.Join(fsq.AgentInboxNew(base, "claude"), TransferFilename(env.SourceHost, env.TransferID))
 	if result.Path != want {
 		t.Fatalf("path = %q, want dest_alias mailbox %q", result.Path, want)
 	}
-	if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(base, "attacker"), TransferFilename("grok-host", "t1"))); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(base, "attacker"), TransferFilename(env.SourceHost, env.TransferID))); !os.IsNotExist(err) {
 		t.Fatalf("payload routed into attacker mailbox: %v", err)
 	}
 }
@@ -133,7 +134,8 @@ func TestApplyEnvelopeReplayAndConflict(t *testing.T) {
 	t.Cleanup(func() { _ = root.Close() })
 
 	payload := []byte("hello-bridge")
-	first, err := ApplyEnvelope(root, "mac", "claude", testEnvelope(payload))
+	env := testEnvelope(payload)
+	first, err := ApplyEnvelope(root, "mac", "claude", env)
 	if err != nil || first.Replayed {
 		t.Fatalf("first apply: %#v %v", first, err)
 	}
@@ -141,18 +143,18 @@ func TestApplyEnvelopeReplayAndConflict(t *testing.T) {
 		t.Fatalf("missing dest: %v", statErr)
 	}
 
-	replay, err := ApplyEnvelope(root, "mac", "claude", testEnvelope(payload))
+	replay, err := ApplyEnvelope(root, "mac", "claude", env)
 	if err != nil || !replay.Replayed {
 		t.Fatalf("replay: %#v %v", replay, err)
 	}
 
 	conflict := testEnvelope([]byte("other-digest"))
-	conflict.TransferID = "t1"
+	conflict.TransferID = env.TransferID
 	_, err = ApplyEnvelope(root, "mac", "claude", conflict)
 	if !errors.Is(err, os.ErrExist) {
 		t.Fatalf("conflict = %v, want EEXIST", err)
 	}
-	got, readErr := os.ReadFile(filepath.Join(fsq.AgentInboxNew(base, "claude"), TransferFilename("grok-host", "t1")))
+	got, readErr := os.ReadFile(filepath.Join(fsq.AgentInboxNew(base, "claude"), TransferFilename(env.SourceHost, env.TransferID)))
 	if readErr != nil || string(got) != string(payload) {
 		t.Fatalf("conflict overwrote dest: %q %v", got, readErr)
 	}
@@ -169,6 +171,7 @@ func TestApplyEnvelopeReplayAndConflict(t *testing.T) {
 
 	otherHost := testEnvelope(payload)
 	otherHost.SourceHost = "other-host"
+	otherHost.TransferID = DeriveTransferID(otherHost.SourceHost, otherHost.SourceHandle, otherHost.SourceMessageID, otherHost.DestAlias)
 	other, err := ApplyEnvelope(root, "mac", "claude", otherHost)
 	if err != nil || other.Replayed {
 		t.Fatalf("distinct source host: %#v %v", other, err)

--- a/internal/bridge/auth.go
+++ b/internal/bridge/auth.go
@@ -1,14 +1,15 @@
 package bridge
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -43,9 +44,8 @@ func TrustedPath(root, host string) string {
 }
 
 func GenerateHostKey(generation string) (HostKey, error) {
-	generation = strings.TrimSpace(generation)
-	if generation == "" {
-		return HostKey{}, fmt.Errorf("key generation is required")
+	if err := validateBridgeIdentifier("key generation", generation); err != nil {
+		return HostKey{}, err
 	}
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -55,23 +55,32 @@ func GenerateHostKey(generation string) (HostKey, error) {
 }
 
 func CanonicalBytes(env Envelope) []byte {
-	return []byte(strings.Join([]string{
-		"amq-bridge-envelope-v1",
-		"version=" + strconv.Itoa(env.Version),
-		"transfer_id=" + env.TransferID,
-		"source_host=" + env.SourceHost,
-		"source_handle=" + env.SourceHandle,
-		"dest_alias=" + env.DestAlias,
-		"source_message_id=" + env.SourceMessageID,
-		"thread_id=" + env.ThreadID,
-		"payload_sha256=" + strings.ToLower(env.PayloadSHA256),
-		"key_generation=" + env.KeyGeneration,
-	}, "\n"))
+	var preimage bytes.Buffer
+	appendField := func(value string) {
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(value)))
+		_, _ = preimage.Write(length[:])
+		_, _ = preimage.WriteString(value)
+	}
+	appendField("amq-bridge-envelope-v2")
+	appendField("2")
+	appendField(env.TransferID)
+	appendField(env.SourceHost)
+	appendField(env.SourceHandle)
+	appendField(env.DestAlias)
+	appendField(env.SourceMessageID)
+	appendField(env.ThreadID)
+	appendField(env.PayloadSHA256)
+	appendField(env.KeyGeneration)
+	return preimage.Bytes()
 }
 
 func SignEnvelope(env *Envelope, key HostKey) error {
 	if env == nil {
 		return fmt.Errorf("bridge envelope is required")
+	}
+	if err := validateEnvelope(*env, false); err != nil {
+		return err
 	}
 	if env.KeyGeneration != key.Generation {
 		return fmt.Errorf("envelope key_generation %q does not match identity generation %q", env.KeyGeneration, key.Generation)
@@ -82,6 +91,9 @@ func SignEnvelope(env *Envelope, key HostKey) error {
 
 func VerifyEnvelope(env Envelope, pub ed25519.PublicKey, generation string) error {
 	if err := ValidateEnvelope(env); err != nil {
+		return err
+	}
+	if err := validateBridgeIdentifier("trusted key generation", generation); err != nil {
 		return err
 	}
 	if env.KeyGeneration != generation {
@@ -120,7 +132,7 @@ func LoadHostIDFromDeliveryRoot(root *fsq.DeliveryRoot) (string, error) {
 
 func parseHostID(path string, data []byte) (string, error) {
 	host := strings.TrimSpace(string(data))
-	if err := fsq.ValidateHandle(host); err != nil {
+	if err := validateBridgeIdentifier("host-id", host); err != nil {
 		return "", fmt.Errorf("bridge host-id: %w", err)
 	}
 	if string(data) != host+"\n" && string(data) != host {
@@ -130,7 +142,7 @@ func parseHostID(path string, data []byte) (string, error) {
 }
 
 func WriteHostID(root, host string) error {
-	if err := fsq.ValidateHandle(host); err != nil {
+	if err := validateBridgeIdentifier("host-id", host); err != nil {
 		return fmt.Errorf("bridge host-id: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Join(root, "bridge"), 0o700); err != nil {
@@ -155,6 +167,12 @@ func LoadIdentity(root string) (HostKey, error) {
 }
 
 func WriteIdentity(root string, key HostKey) error {
+	if err := validateBridgeIdentifier("key generation", key.Generation); err != nil {
+		return err
+	}
+	if len(key.Private) != ed25519.PrivateKeySize {
+		return fmt.Errorf("bridge identity private key must be %d bytes", ed25519.PrivateKeySize)
+	}
 	if err := os.MkdirAll(filepath.Join(root, "bridge"), 0o700); err != nil {
 		return fmt.Errorf("create bridge directory: %w", err)
 	}
@@ -163,7 +181,7 @@ func WriteIdentity(root string, key HostKey) error {
 }
 
 func LoadTrusted(root, host string) (ed25519.PublicKey, string, error) {
-	if err := fsq.ValidateHandle(host); err != nil {
+	if err := validateBridgeIdentifier("trusted source host", host); err != nil {
 		return nil, "", fmt.Errorf("trusted source host: %w", err)
 	}
 	fields, err := readKeyFields(TrustedPath(root, host), "public")
@@ -185,7 +203,7 @@ func LoadTrusted(root, host string) (ed25519.PublicKey, string, error) {
 // envelope claim until this exact trusted file is loaded and signature
 // verification succeeds.
 func LoadTrustedFromDeliveryRoot(root *fsq.DeliveryRoot, host string) (ed25519.PublicKey, string, error) {
-	if err := fsq.ValidateHandle(host); err != nil {
+	if err := validateBridgeIdentifier("trusted source host", host); err != nil {
 		return nil, "", fmt.Errorf("trusted source host: %w", err)
 	}
 	rel := filepath.Join("bridge", TrustedDirName, host)
@@ -208,12 +226,11 @@ func LoadTrustedFromDeliveryRoot(root *fsq.DeliveryRoot, host string) (ed25519.P
 }
 
 func WriteTrusted(root, host string, pub ed25519.PublicKey, generation string) error {
-	if err := fsq.ValidateHandle(host); err != nil {
+	if err := validateBridgeIdentifier("trusted source host", host); err != nil {
 		return fmt.Errorf("trusted source host: %w", err)
 	}
-	generation = strings.TrimSpace(generation)
-	if generation == "" {
-		return fmt.Errorf("trusted host generation is required")
+	if err := validateBridgeIdentifier("trusted host generation", generation); err != nil {
+		return err
 	}
 	if len(pub) != ed25519.PublicKeySize {
 		return fmt.Errorf("trusted host public key must be %d bytes", ed25519.PublicKeySize)
@@ -246,7 +263,7 @@ func parseKeyFields(path string, data []byte, secretField string) (map[string]st
 		fields[key] = value
 	}
 	generation := fields["generation"]
-	if generation == "" || generation != strings.TrimSpace(generation) {
+	if err := validateBridgeIdentifier("generation", generation); err != nil {
 		return nil, fmt.Errorf("%s generation is invalid", path)
 	}
 	if fields[secretField] == "" {

--- a/internal/bridge/auth_test.go
+++ b/internal/bridge/auth_test.go
@@ -1,10 +1,13 @@
 package bridge
 
 import (
+	"bytes"
 	"crypto/ed25519"
+	"encoding/binary"
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -18,9 +21,81 @@ func TestSignAndVerifyEnvelopeRoundTrip(t *testing.T) {
 	if err := SignEnvelope(&env, key); err != nil {
 		t.Fatal(err)
 	}
+	if env.Version != 2 {
+		t.Fatalf("envelope version = %d, want v2", env.Version)
+	}
 	if err := VerifyEnvelope(env, key.Public(), "1"); err != nil {
 		t.Fatalf("verify: %v", err)
 	}
+}
+
+func TestV1CanonicalBytesHadLFFieldCollision(t *testing.T) {
+	left := testEnvelope([]byte("legacy"))
+	left.ThreadID = "thread\npayload_sha256=one"
+	left.PayloadSHA256 = "two"
+	right := left
+	right.ThreadID = "thread"
+	right.PayloadSHA256 = "one\npayload_sha256=two"
+
+	if !bytes.Equal(legacyV1CanonicalBytes(left), legacyV1CanonicalBytes(right)) {
+		t.Fatal("test setup did not reproduce the v1 LF collision")
+	}
+	if bytes.Equal(CanonicalBytes(left), CanonicalBytes(right)) {
+		t.Fatal("v2 length-prefixed preimages still collide")
+	}
+}
+
+func TestCanonicalBytesUsesLengthPrefixedV2Fields(t *testing.T) {
+	env := testEnvelope([]byte("payload"))
+	got := CanonicalBytes(env)
+	want := []string{
+		"amq-bridge-envelope-v2",
+		"2",
+		env.TransferID,
+		env.SourceHost,
+		env.SourceHandle,
+		env.DestAlias,
+		env.SourceMessageID,
+		env.ThreadID,
+		env.PayloadSHA256,
+		env.KeyGeneration,
+	}
+	for i, wantField := range want {
+		if len(got) < 4 {
+			t.Fatalf("field %d has no length prefix", i)
+		}
+		length := int(binary.BigEndian.Uint32(got[:4]))
+		got = got[4:]
+		if length != len(wantField) || len(got) < length || string(got[:length]) != wantField {
+			t.Fatalf("field %d = %q with length %d, want %q with length %d", i, got[:min(length, len(got))], length, wantField, len(wantField))
+		}
+		got = got[length:]
+	}
+	if len(got) != 0 {
+		t.Fatalf("canonical preimage has %d trailing bytes", len(got))
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func legacyV1CanonicalBytes(env Envelope) []byte {
+	return []byte(strings.Join([]string{
+		"amq-bridge-envelope-v1",
+		"version=" + strconv.Itoa(env.Version),
+		"transfer_id=" + env.TransferID,
+		"source_host=" + env.SourceHost,
+		"source_handle=" + env.SourceHandle,
+		"dest_alias=" + env.DestAlias,
+		"source_message_id=" + env.SourceMessageID,
+		"thread_id=" + env.ThreadID,
+		"payload_sha256=" + env.PayloadSHA256,
+		"key_generation=" + env.KeyGeneration,
+	}, "\n"))
 }
 
 func TestVerifyEnvelopeRejectsForgedSourceHost(t *testing.T) {

--- a/internal/bridge/envelope.go
+++ b/internal/bridge/envelope.go
@@ -3,18 +3,38 @@ package bridge
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base32"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-const EnvelopeVersion = 1
+const (
+	EnvelopeVersion = 2
 
-// Envelope is the v1 amq-bridge wire unit. Extra JSON fields are rejected.
+	// MaxPayloadBytes and MaxObjectBytes are the v2 protocol limits. The
+	// payload limit applies after raw-standard-base64 decoding; the object
+	// limit applies to the exact JSON file bytes on the wire.
+	MaxPayloadBytes = 8 * 1024 * 1024
+	MaxObjectBytes  = 12 * 1024 * 1024
+
+	bridgeIdentifierMaxBytes = 63
+	bridgeAliasMaxBytes      = 127
+	bridgeMessageIDMaxBytes  = 200
+	transferIDBytes          = 52
+)
+
+var (
+	rawBase32Encoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+	rawBase64Encoding = base64.RawStdEncoding.Strict()
+)
+
+// Envelope is the v2 amq-bridge wire unit. Extra JSON fields are rejected.
+// Payload remains []byte for callers that apply the decoded message locally;
+// its wire representation is the payload_b64 JSON string below.
 type Envelope struct {
 	Version         int    `json:"version"`
 	TransferID      string `json:"transfer_id"`
@@ -26,22 +46,120 @@ type Envelope struct {
 	PayloadSHA256   string `json:"payload_sha256"`
 	KeyGeneration   string `json:"key_generation"`
 	Signature       string `json:"signature"`
-	Payload         []byte `json:"payload"`
+	Payload         []byte `json:"-"`
+}
+
+// envelopeJSON fixes both the v2 field name and the writer's key order. It is
+// deliberately separate from Envelope so encoding/json cannot apply its
+// padded []byte convention to Payload.
+type envelopeJSON struct {
+	Version         int    `json:"version"`
+	TransferID      string `json:"transfer_id"`
+	SourceHost      string `json:"source_host"`
+	SourceHandle    string `json:"source_handle"`
+	DestAlias       string `json:"dest_alias"`
+	SourceMessageID string `json:"source_message_id"`
+	ThreadID        string `json:"thread_id"`
+	PayloadSHA256   string `json:"payload_sha256"`
+	KeyGeneration   string `json:"key_generation"`
+	Signature       string `json:"signature"`
+	PayloadB64      string `json:"payload_b64"`
+}
+
+func (env Envelope) MarshalJSON() ([]byte, error) {
+	if err := ValidateEnvelope(env); err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(envelopeJSON{
+		Version:         env.Version,
+		TransferID:      env.TransferID,
+		SourceHost:      env.SourceHost,
+		SourceHandle:    env.SourceHandle,
+		DestAlias:       env.DestAlias,
+		SourceMessageID: env.SourceMessageID,
+		ThreadID:        env.ThreadID,
+		PayloadSHA256:   env.PayloadSHA256,
+		KeyGeneration:   env.KeyGeneration,
+		Signature:       env.Signature,
+		PayloadB64:      rawBase64Encoding.EncodeToString(env.Payload),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("bridge envelope: %w", err)
+	}
+	if len(raw) > MaxObjectBytes {
+		return nil, fmt.Errorf("bridge envelope object exceeds %d bytes", MaxObjectBytes)
+	}
+	return raw, nil
+}
+
+func (env *Envelope) UnmarshalJSON(data []byte) error {
+	if env == nil {
+		return fmt.Errorf("bridge envelope is required")
+	}
+	if len(data) > MaxObjectBytes {
+		return fmt.Errorf("bridge envelope object exceeds %d bytes", MaxObjectBytes)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var wire envelopeJSON
+	if err := dec.Decode(&wire); err != nil {
+		return fmt.Errorf("bridge envelope: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("bridge envelope has trailing JSON")
+		}
+		return fmt.Errorf("bridge envelope trailer: %w", err)
+	}
+	payload, err := decodePayloadB64(wire.PayloadB64)
+	if err != nil {
+		return err
+	}
+	candidate := Envelope{
+		Version:         wire.Version,
+		TransferID:      wire.TransferID,
+		SourceHost:      wire.SourceHost,
+		SourceHandle:    wire.SourceHandle,
+		DestAlias:       wire.DestAlias,
+		SourceMessageID: wire.SourceMessageID,
+		ThreadID:        wire.ThreadID,
+		PayloadSHA256:   wire.PayloadSHA256,
+		KeyGeneration:   wire.KeyGeneration,
+		Signature:       wire.Signature,
+		Payload:         payload,
+	}
+	if err := ValidateEnvelope(candidate); err != nil {
+		return err
+	}
+	*env = candidate
+	return nil
 }
 
 func MarshalEnvelope(env Envelope) ([]byte, error) {
 	if err := ValidateEnvelope(env); err != nil {
 		return nil, err
 	}
-	return json.Marshal(env)
+	raw, err := json.Marshal(env)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) > MaxObjectBytes {
+		return nil, fmt.Errorf("bridge envelope object exceeds %d bytes", MaxObjectBytes)
+	}
+	return raw, nil
 }
 
 func UnmarshalEnvelope(raw []byte) (Envelope, error) {
+	if len(raw) > MaxObjectBytes {
+		return Envelope{}, fmt.Errorf("bridge envelope object exceeds %d bytes", MaxObjectBytes)
+	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	var env Envelope
 	if err := dec.Decode(&env); err != nil {
-		return Envelope{}, fmt.Errorf("bridge envelope: %w", err)
+		return Envelope{}, err
 	}
 	var trailing any
 	if err := dec.Decode(&trailing); err != io.EOF {
@@ -57,66 +175,71 @@ func UnmarshalEnvelope(raw []byte) (Envelope, error) {
 }
 
 func ValidateEnvelope(env Envelope) error {
+	return validateEnvelope(env, true)
+}
+
+func validateEnvelope(env Envelope, requireSignature bool) error {
 	if env.Version != EnvelopeVersion {
 		return fmt.Errorf("bridge envelope version %d is unsupported", env.Version)
 	}
-	for _, field := range []struct {
-		name, value string
-	}{
-		{"transfer_id", env.TransferID},
-		{"source_host", env.SourceHost},
-		{"source_handle", env.SourceHandle},
-		{"dest_alias", env.DestAlias},
-		{"source_message_id", env.SourceMessageID},
-		{"thread_id", env.ThreadID},
-		{"payload_sha256", env.PayloadSHA256},
-		{"key_generation", env.KeyGeneration},
-		{"signature", env.Signature},
-	} {
-		if strings.TrimSpace(field.value) == "" || field.value != strings.TrimSpace(field.value) {
-			return fmt.Errorf("bridge envelope %s is invalid", field.name)
-		}
+	if err := validateBridgeIdentifier("source_host", env.SourceHost); err != nil {
+		return fmt.Errorf("bridge envelope %w", err)
 	}
-	if err := fsq.ValidateHandle(env.SourceHost); err != nil {
-		return fmt.Errorf("bridge envelope source_host: %w", err)
+	if err := validateBridgeIdentifier("source_handle", env.SourceHandle); err != nil {
+		return fmt.Errorf("bridge envelope %w", err)
 	}
-	if err := fsq.ValidateHandle(env.SourceHandle); err != nil {
-		return fmt.Errorf("bridge envelope source_handle: %w", err)
-	}
-	host, agent, err := ParseAlias(env.DestAlias)
-	if err != nil {
+	if _, _, err := ParseAlias(env.DestAlias); err != nil {
 		return err
 	}
-	_ = host
-	_ = agent
+	if err := validateBridgeMessageID("source_message_id", env.SourceMessageID); err != nil {
+		return fmt.Errorf("bridge envelope %w", err)
+	}
+	if err := validateBridgeMessageID("thread_id", env.ThreadID); err != nil {
+		return fmt.Errorf("bridge envelope %w", err)
+	}
+	if err := validateLowerHex("payload_sha256", env.PayloadSHA256, sha256.Size*2); err != nil {
+		return fmt.Errorf("bridge envelope %w", err)
+	}
+	if err := validateBridgeIdentifier("key_generation", env.KeyGeneration); err != nil {
+		return fmt.Errorf("bridge envelope %w", err)
+	}
 	if err := validateTransferID(env.TransferID); err != nil {
 		return err
 	}
-	sum := sha256.Sum256(env.Payload)
-	got := hex.EncodeToString(sum[:])
-	if !strings.EqualFold(env.PayloadSHA256, got) {
-		return fmt.Errorf("bridge envelope payload_sha256 does not match payload")
+	wantTransferID := DeriveTransferID(env.SourceHost, env.SourceHandle, env.SourceMessageID, env.DestAlias)
+	if env.TransferID != wantTransferID {
+		return fmt.Errorf("bridge envelope transfer_id does not match routing fields")
 	}
 	if len(env.Payload) == 0 {
 		return fmt.Errorf("bridge envelope payload is empty")
 	}
-	sig, err := hex.DecodeString(env.Signature)
-	if err != nil || len(sig) != 64 {
-		return fmt.Errorf("bridge envelope signature is invalid")
+	if len(env.Payload) > MaxPayloadBytes {
+		return fmt.Errorf("bridge envelope payload exceeds %d bytes", MaxPayloadBytes)
+	}
+	sum := sha256.Sum256(env.Payload)
+	if env.PayloadSHA256 != hex.EncodeToString(sum[:]) {
+		return fmt.Errorf("bridge envelope payload_sha256 does not match payload")
+	}
+	if requireSignature {
+		if err := validateLowerHex("signature", env.Signature, ed25519SignatureHexBytes); err != nil {
+			return fmt.Errorf("bridge envelope %w", err)
+		}
 	}
 	return nil
 }
 
+const ed25519SignatureHexBytes = 64 * 2
+
 func ParseAlias(alias string) (host, agent string, err error) {
-	host, agent, ok := strings.Cut(alias, "/")
-	if !ok || strings.Contains(agent, "/") {
+	if len(alias) == 0 || len(alias) > bridgeAliasMaxBytes || strings.Count(alias, "/") != 1 {
 		return "", "", fmt.Errorf("bridge dest_alias %q must be host/agent", alias)
 	}
-	if err := fsq.ValidateHandle(host); err != nil {
-		return "", "", fmt.Errorf("bridge dest_alias host: %w", err)
+	host, agent, _ = strings.Cut(alias, "/")
+	if err := validateBridgeIdentifier("dest_alias host", host); err != nil {
+		return "", "", fmt.Errorf("bridge %w", err)
 	}
-	if err := fsq.ValidateHandle(agent); err != nil {
-		return "", "", fmt.Errorf("bridge dest_alias agent: %w", err)
+	if err := validateBridgeIdentifier("dest_alias agent", agent); err != nil {
+		return "", "", fmt.Errorf("bridge %w", err)
 	}
 	return host, agent, nil
 }
@@ -125,12 +248,108 @@ func TransferFilename(sourceHost, transferID string) string {
 	return "xfer-" + sourceHost + "-" + transferID + ".md"
 }
 
+// DeriveTransferID returns the v2 transfer id for the immutable routing
+// claims. Callers that accept untrusted values must validate those values
+// before using the result in a path.
+func DeriveTransferID(sourceHost, sourceHandle, sourceMessageID, destAlias string) string {
+	preimage := []byte("amq-xfer-v2\x00" + sourceHost + "\x00" + sourceHandle + "\x00" + sourceMessageID + "\x00" + destAlias)
+	sum := sha256.Sum256(preimage)
+	return strings.ToLower(rawBase32Encoding.EncodeToString(sum[:]))
+}
+
 func validateTransferID(id string) error {
-	if strings.ContainsAny(id, "/\\.") || strings.HasPrefix(id, "-") || strings.HasPrefix(id, ".") {
-		return fmt.Errorf("bridge envelope transfer_id is invalid")
+	if len(id) != transferIDBytes {
+		return fmt.Errorf("bridge envelope transfer_id must be %d lowercase base32 characters", transferIDBytes)
 	}
-	if err := fsq.ValidateHandle(id); err != nil {
-		return fmt.Errorf("bridge envelope transfer_id: %w", err)
+	if id != strings.ToLower(id) {
+		return fmt.Errorf("bridge envelope transfer_id must be lowercase")
+	}
+	if _, err := rawBase32Encoding.DecodeString(strings.ToUpper(id)); err != nil {
+		return fmt.Errorf("bridge envelope transfer_id is invalid: %w", err)
 	}
 	return nil
 }
+
+func decodePayloadB64(encoded string) ([]byte, error) {
+	if encoded == "" {
+		return nil, fmt.Errorf("bridge envelope payload_b64 is empty")
+	}
+	if strings.TrimSpace(encoded) != encoded || strings.ContainsAny(encoded, " \t\r\n") {
+		return nil, fmt.Errorf("bridge envelope payload_b64 contains whitespace")
+	}
+	if strings.Contains(encoded, "=") {
+		return nil, fmt.Errorf("bridge envelope payload_b64 must not be padded")
+	}
+	payload, err := rawBase64Encoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("bridge envelope payload_b64 is invalid: %w", err)
+	}
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("bridge envelope payload is empty")
+	}
+	if len(payload) > MaxPayloadBytes {
+		return nil, fmt.Errorf("bridge envelope payload exceeds %d bytes", MaxPayloadBytes)
+	}
+	if rawBase64Encoding.EncodeToString(payload) != encoded {
+		return nil, fmt.Errorf("bridge envelope payload_b64 is not canonical raw standard base64")
+	}
+	return payload, nil
+}
+
+func validateBridgeIdentifier(name, value string) error {
+	if len(value) == 0 {
+		return fmt.Errorf("%s is invalid", name)
+	}
+	if len(value) > bridgeIdentifierMaxBytes {
+		return fmt.Errorf("%s exceeds %d bytes", name, bridgeIdentifierMaxBytes)
+	}
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if i == 0 {
+			if !isLowerASCII(b) && !isASCIIDigit(b) {
+				return fmt.Errorf("%s is invalid", name)
+			}
+			continue
+		}
+		if !isLowerASCII(b) && !isASCIIDigit(b) && b != '_' && b != '-' {
+			return fmt.Errorf("%s is invalid", name)
+		}
+	}
+	return nil
+}
+
+func validateBridgeMessageID(name, value string) error {
+	if len(value) == 0 {
+		return fmt.Errorf("%s is invalid", name)
+	}
+	if len(value) > bridgeMessageIDMaxBytes {
+		return fmt.Errorf("%s exceeds %d bytes", name, bridgeMessageIDMaxBytes)
+	}
+	if value[0] == ' ' || value[len(value)-1] == ' ' {
+		return fmt.Errorf("%s has surrounding space", name)
+	}
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if b < 0x20 || b > 0x7e || b == '/' || b == '\\' {
+			return fmt.Errorf("%s is invalid", name)
+		}
+	}
+	return nil
+}
+
+func validateLowerHex(name, value string, wantLen int) error {
+	if len(value) != wantLen {
+		return fmt.Errorf("%s must be %d lowercase hex characters", name, wantLen)
+	}
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if !(b >= '0' && b <= '9') && !(b >= 'a' && b <= 'f') {
+			return fmt.Errorf("%s must be lowercase hex", name)
+		}
+	}
+	return nil
+}
+
+func isLowerASCII(b byte) bool { return b >= 'a' && b <= 'z' }
+
+func isASCIIDigit(b byte) bool { return b >= '0' && b <= '9' }

--- a/internal/bridge/envelope.go
+++ b/internal/bridge/envelope.go
@@ -343,9 +343,10 @@ func validateLowerHex(name, value string, wantLen int) error {
 	}
 	for i := 0; i < len(value); i++ {
 		b := value[i]
-		if !(b >= '0' && b <= '9') && !(b >= 'a' && b <= 'f') {
-			return fmt.Errorf("%s must be lowercase hex", name)
+		if (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') {
+			continue
 		}
+		return fmt.Errorf("%s must be lowercase hex", name)
 	}
 	return nil
 }

--- a/internal/bridge/envelope.go
+++ b/internal/bridge/envelope.go
@@ -330,7 +330,9 @@ func validateBridgeMessageID(name, value string) error {
 	}
 	for i := 0; i < len(value); i++ {
 		b := value[i]
-		if b < 0x20 || b > 0x7e || b == '/' || b == '\\' {
+		// '/' is allowed: AMQ p2p threads are p2p/<a>__<b>. These scalars
+		// never become filesystem path components.
+		if b < 0x20 || b > 0x7e || b == '\\' {
 			return fmt.Errorf("%s is invalid", name)
 		}
 	}

--- a/internal/bridge/envelope_test.go
+++ b/internal/bridge/envelope_test.go
@@ -65,6 +65,14 @@ func TestValidateEnvelopeRejectsLFInThreadID(t *testing.T) {
 	}
 }
 
+func TestValidateEnvelopeAcceptsSlashInThreadID(t *testing.T) {
+	env := testEnvelope([]byte("p2p"))
+	env.ThreadID = "p2p/codex__grok"
+	if err := ValidateEnvelope(env); err != nil {
+		t.Fatalf("AMQ p2p thread_id rejected: %v", err)
+	}
+}
+
 func TestValidateEnvelopePayloadLimit(t *testing.T) {
 	max := bytes.Repeat([]byte{'x'}, MaxPayloadBytes)
 	if err := ValidateEnvelope(testEnvelope(max)); err != nil {

--- a/internal/bridge/envelope_test.go
+++ b/internal/bridge/envelope_test.go
@@ -1,0 +1,114 @@
+package bridge
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEnvelopeV2JSONRoundTripUsesRawStandardPayload(t *testing.T) {
+	env := testEnvelope([]byte("f"))
+	raw, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte(`"payload":`)) {
+		t.Fatalf("wire envelope used the v1 payload field: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte(`"payload_b64":"Zg"`)) {
+		t.Fatalf("wire envelope did not use raw payload_b64: %s", raw)
+	}
+	if bytes.Contains(raw, []byte("=")) {
+		t.Fatalf("wire envelope contains base64 padding: %s", raw)
+	}
+	decoded, err := UnmarshalEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decoded.Payload, env.Payload) {
+		t.Fatalf("decoded payload = %q, want %q", decoded.Payload, env.Payload)
+	}
+}
+
+func TestUnmarshalEnvelopeRejectsPaddedV1PayloadField(t *testing.T) {
+	raw, err := MarshalEnvelope(testEnvelope([]byte("a")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = bytes.Replace(raw, []byte(`"payload_b64":"YQ"`), []byte(`"payload":"YQ=="`), 1)
+	if _, err := UnmarshalEnvelope(raw); err == nil {
+		t.Fatal("padded v1 payload field was accepted")
+	}
+	raw, err = MarshalEnvelope(testEnvelope([]byte("a")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = bytes.Replace(raw, []byte(`"payload_b64":"YQ"`), []byte(`"payload_b64":"YQ=="`), 1)
+	if _, err := UnmarshalEnvelope(raw); err == nil {
+		t.Fatal("padded payload_b64 was accepted")
+	}
+}
+
+func TestUnmarshalEnvelopeRejectsV1ByDefault(t *testing.T) {
+	env := testEnvelope([]byte("v1"))
+	env.Version = 1
+	if _, err := MarshalEnvelope(env); err == nil {
+		t.Fatal("v1 envelope was marshaled")
+	}
+}
+
+func TestValidateEnvelopeRejectsLFInThreadID(t *testing.T) {
+	env := testEnvelope([]byte("line"))
+	env.ThreadID = "thread\nid"
+	if err := ValidateEnvelope(env); err == nil || !strings.Contains(err.Error(), "thread_id") {
+		t.Fatalf("LF thread_id error = %v, want thread_id rejection", err)
+	}
+}
+
+func TestValidateEnvelopePayloadLimit(t *testing.T) {
+	max := bytes.Repeat([]byte{'x'}, MaxPayloadBytes)
+	if err := ValidateEnvelope(testEnvelope(max)); err != nil {
+		t.Fatalf("maximum payload rejected: %v", err)
+	}
+	raw, err := MarshalEnvelope(testEnvelope(max))
+	if err != nil {
+		t.Fatalf("maximum payload could not be serialized: %v", err)
+	}
+	if len(raw) > MaxObjectBytes {
+		t.Fatalf("maximum payload object length = %d, exceeds %d", len(raw), MaxObjectBytes)
+	}
+	if decoded, err := UnmarshalEnvelope(raw); err != nil || !bytes.Equal(decoded.Payload, max) {
+		t.Fatalf("maximum payload could not be decoded: %v", err)
+	}
+	tooLarge := append(max, 'x')
+	if err := ValidateEnvelope(testEnvelope(tooLarge)); err == nil || !strings.Contains(err.Error(), "payload") {
+		t.Fatalf("payload over limit error = %v, want payload rejection", err)
+	}
+	if _, err := MarshalEnvelope(testEnvelope(tooLarge)); err == nil {
+		t.Fatal("payload over limit was serialized")
+	}
+}
+
+func TestUnmarshalEnvelopeObjectLimit(t *testing.T) {
+	raw := bytes.Repeat([]byte{'x'}, MaxObjectBytes+1)
+	if _, err := UnmarshalEnvelope(raw); err == nil || !strings.Contains(err.Error(), "object") {
+		t.Fatalf("oversized object error = %v, want object limit rejection", err)
+	}
+}
+
+func TestDeriveTransferIDUsesLowercaseBase32SHA256Shape(t *testing.T) {
+	id := DeriveTransferID("grok-host", "codex", "msg-1", "mac/claude")
+	if len(id) != 52 {
+		t.Fatalf("transfer_id length = %d, want 52", len(id))
+	}
+	if err := validateTransferID(id); err != nil {
+		t.Fatalf("derived transfer_id = %q: %v", id, err)
+	}
+	const want = "ulpa7ailolhzdzs2safnkkejahkxl2d4arl2iokz6ugbvc3pprjq"
+	if id != want {
+		t.Fatalf("derived transfer_id = %q, want %q", id, want)
+	}
+	if strings.ToUpper(id) == id {
+		t.Fatalf("derived transfer_id is not lowercase: %q", id)
+	}
+}

--- a/scripts/amq-bot-envelope-hop-probe-tool/main.go
+++ b/scripts/amq-bot-envelope-hop-probe-tool/main.go
@@ -86,17 +86,14 @@ func runWrite(args []string) error {
 	if err != nil {
 		return err
 	}
-	transferID := strings.TrimSpace(*transferIDFlag)
-	if transferID == "" {
-		transferID, err = randomID("xfer-probe-")
-		if err != nil {
-			return fmt.Errorf("generate transfer id: %w", err)
-		}
+	messageID, err := randomID("probe-message-")
+	if err != nil {
+		return fmt.Errorf("generate message id: %w", err)
 	}
-	if err := fsq.ValidateHandle(transferID); err != nil {
-		return fmt.Errorf("transfer id: %w", err)
+	transferID := bridge.DeriveTransferID(sourceHost, sourceHandle, messageID, destAlias)
+	if requested := strings.TrimSpace(*transferIDFlag); requested != "" && requested != transferID {
+		return fmt.Errorf("transfer id %q does not match routing fields", requested)
 	}
-	messageID := "probe-message-" + strings.TrimPrefix(transferID, "xfer-probe-")
 	threadID := strings.TrimSpace(*threadFlag)
 	if threadID == "" {
 		threadID = "probe/" + transferID

--- a/scripts/amq-bot-envelope-hop-probe.sh
+++ b/scripts/amq-bot-envelope-hop-probe.sh
@@ -49,6 +49,15 @@ valid_transfer_id() {
 	esac
 }
 
+valid_xfer_id() {
+	id=$1
+	[ ${#id} -eq 52 ] || return 1
+	case "$id" in
+		*[!a-z2-7]*) return 1 ;;
+		*) return 0 ;;
+	esac
+}
+
 validate_config() {
 	valid_transfer_id "$source_host" || unproven "invalid source host: $source_host"
 	case "$dest_alias" in
@@ -107,16 +116,11 @@ write_probe() {
 		unproven "cannot set G directory mode on $g_dir"
 	fi
 
-	nonce=$(LC_ALL=C od -An -N16 -tx1 /dev/urandom | tr -d '[:space:]') ||
-		unproven 'cannot generate transfer nonce'
-	transfer_id=xfer-probe-$nonce
-	valid_transfer_id "$transfer_id" || unproven 'generated invalid transfer id'
-	target=$g_dir/envelope-$transfer_id.json
+	target=$g_dir/envelope-pending.json
 	if [ -n "$thread_id" ]; then
 		output=$(run_writer \
 			--root "$g_root" \
 			--output "$target" \
-			--transfer-id "$transfer_id" \
 			--source-host "$source_host" \
 			--source-handle "$source_handle" \
 			--dest-alias "$dest_alias" \
@@ -126,12 +130,17 @@ write_probe() {
 		output=$(run_writer \
 			--root "$g_root" \
 			--output "$target" \
-			--transfer-id "$transfer_id" \
 			--source-host "$source_host" \
 			--source-handle "$source_handle" \
 			--dest-alias "$dest_alias") ||
 			unproven "cannot create signed envelope $target"
 	fi
+	transfer_id=$(printf '%s\n' "$output" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_ID=//p')
+	valid_xfer_id "$transfer_id" || unproven 'writer printed an invalid transfer id'
+	final=$g_dir/envelope-$transfer_id.json
+	mv "$target" "$final" || unproven "cannot publish $final"
+	output=$(printf '%s\n' "$output" | sed "s|^BOT_ENVELOPE_HOP_SOURCE=.*|BOT_ENVELOPE_HOP_SOURCE=$final|")
+	target=$final
 	mode=$(file_mode "$target") || unproven "cannot inspect mode on $target"
 	case "$mode" in
 		600|0600) ;;
@@ -195,8 +204,8 @@ check_receipt() {
 
 check_probe() {
 	transfer_id=$1
-	valid_transfer_id "$transfer_id" ||
-		unproven 'transfer id must use lowercase [a-z0-9_-] without path components'
+	valid_xfer_id "$transfer_id" ||
+		unproven 'transfer id must be 52 lowercase RFC 4648 base32 characters'
 	check_host_files "${dest_alias%%/*}"
 	source=$mac_dir/envelope-$transfer_id.json
 	[ -f "$source" ] || unproven "moved envelope is missing: $source"

--- a/scripts/amq-bot-envelope-hop-probe_test.sh
+++ b/scripts/amq-bot-envelope-hop-probe_test.sh
@@ -46,7 +46,8 @@ first_id="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_
 first_source="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_SOURCE=//p')"
 grok_public="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_PUBLIC=//p')"
 grok_generation="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_KEY_GENERATION=//p')"
-[[ "$first_id" == xfer-probe-* ]] || fail "write did not print a probe transfer id"
+[[ ${#first_id} -eq 52 ]] || fail "write did not print a 52-char transfer id"
+case "$first_id" in *[!a-z2-7]*) fail "write printed a non-base32 transfer id" ;; esac
 [[ -f "$first_source" ]] || fail "write did not create $first_source"
 [[ -n "$grok_public" && -n "$grok_generation" ]] || fail "write did not expose trusted public identity metadata"
 
@@ -101,7 +102,8 @@ PY
 second_write="$(write_probe)"
 second_id="$(printf '%s\n' "$second_write" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_ID=//p')"
 second_source="$(printf '%s\n' "$second_write" | sed -n 's/^BOT_ENVELOPE_HOP_SOURCE=//p')"
-[[ "$second_id" == xfer-probe-* ]] || fail "second write did not print a probe transfer id"
+[[ ${#second_id} -eq 52 ]] || fail "second write did not print a 52-char transfer id"
+case "$second_id" in *[!a-z2-7]*) fail "second write printed a non-base32 transfer id" ;; esac
 [[ -f "$second_source" ]] || fail "second write did not create $second_source"
 
 unsigned_root="$work/unsigned-root"


### PR DESCRIPTION
Pro GO spec v2.2 plus addenda. Lands amq-ad6.1 and amq-ad6.2: ADR/README for G-initiated peer exchange, Envelope v2 wire (`payload_b64`, length-prefix domain, derived transfer IDs, 8 MiB/12 MiB caps, v1 refuse). Hop-probe now derives transfer IDs. AMQ `p2p/` thread slashes are valid on the envelope.

HTTPS store-and-forward stays implemented and is not the live hop. apply-file is recovery only.

```
BEGIN_COMMIT_OVERRIDE
feat(bridge): envelope v2 length-prefix and payload_b64

docs(bridge): document G-initiated peer exchange

fix(bridge): derive hop-probe ids and allow slash in thread_id
END_COMMIT_OVERRIDE
```