### PR TITLE
feat(keepalive): support native Windows agent adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         run: go test ./internal/cli -run '^TestDrainInboxItems' -count=1
       - name: Windows launch API compatibility
         run: go test ./launchapi -run '^TestWindowsCompatibilityAdvertisesOnlyCallableLaunchSurface$' -count=1
+      - name: Native Windows Codex and Claude adapters
+        run: go test ./internal/keepalive/adapter -run '^(TestWindows|TestClaudePrint|TestCodexQueue)' -count=1
 
   # Darwin test leg. Linux + a windows claim job run elsewhere; this gates the
   # defect class where a test passes on Linux but fails on macOS (e.g. macOS

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,12 +30,13 @@ builds:
       - -s -w -X main.version={{.Version}}
     goos:
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
     hooks:
       post:
-        - sh -ceu 'codesign --force --sign - --identifier io.github.avivsinai.amq-keepalive "$1"' _ "{{ .Path }}"
+        - sh -ceu 'if [ "$2" = darwin ]; then codesign --force --sign - --identifier io.github.avivsinai.amq-keepalive "$1"; fi' _ "{{ .Path }}" "{{ .Os }}"
 
   - id: amq-bridge
     main: ./cmd/amq-bridge
@@ -84,6 +85,9 @@ archives:
     ids: [amq-keepalive]
     formats: [tar.gz]
     name_template: "amq-keepalive_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
   - id: amq-bridge
     ids: [amq-bridge]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -115,9 +115,10 @@ Download from [Releases](https://github.com/avivsinai/agent-message-queue/releas
 | Native Windows (x86_64) | `amq_*_windows_amd64.zip` |
 | WSL (x86_64) | `amq_*_linux_amd64.tar.gz` |
 
-The optional macOS wake supervisor is published separately as
-`amq-keepalive_*_darwin_arm64.tar.gz` or
-`amq-keepalive_*_darwin_amd64.tar.gz`. It is intentionally not installed by
+The optional keepalive companion is published separately as
+`amq-keepalive_*_darwin_arm64.tar.gz`,
+`amq-keepalive_*_darwin_amd64.tar.gz`, or
+`amq-keepalive_*_windows_{amd64,arm64}.zip`. It is intentionally not installed by
 the Homebrew formula. AMQ saves the resolved injector executable as part of a
 wake's identity; a versioned Homebrew Cellar path can disappear during cleanup
 and prevent an exact retirement. Install the companion as a regular executable
@@ -195,8 +196,8 @@ or the default `%USERPROFILE%\scoop`; global scope comes from
 after an authoritative direct check confirms the latest version (already
 current, or after a successful immediate replacement). A scheduled replacement
 is refreshed on the next successful check (best-effort). On Windows, `--all`
-skips companions because they are not published there, then continues with the
-core upgrade. Companion links are revalidated by their primary path; a
+upgrades a directly installed `amq-keepalive.exe` and skips `amq-bridge` and
+`amq-acp`, which are not published there. Companion links are revalidated by their primary path; a
 secondary same-name alias repointed during download is not detected.
 
 ### Platform capability matrix
@@ -211,6 +212,9 @@ secondary same-name alias repointed during download is not detected.
 WSL is a Linux environment: install a Linux asset there, not the Windows ZIP.
 On native Windows, `doctor --ops` can report wake lock files but cannot verify
 live wake process identity or auto-fix `unverified` locks.
+The separately published native `amq-keepalive.exe` supports direct
+`inject codex-queue` and `inject claude-print`; that submitted-message path is
+not an implementation of `amq wake`, `coop exec`, or terminal supervision.
 The native Windows launch API advertises only `launch_intent_v1` and
 `plan_only_commands_v1`; managed Prepare/Apply, lifecycle, and tmux features
 are omitted and fail negotiation.

--- a/README.md
+++ b/README.md
@@ -250,15 +250,16 @@ current, or after a successful immediate replacement). A later companion
 failure does not change that result. A scheduled replacement is reflected when
 the next successful check refreshes the cache (best-effort).
 
-On Windows, `amq upgrade --all` prints a skip line for companions because
-companion binaries are not published for Windows, then continues with the
-core upgrade.
+On Windows, `amq upgrade --all` upgrades a directly installed
+`amq-keepalive.exe`; it skips `amq-bridge` and `amq-acp`, which are not
+published for Windows, then continues with the core upgrade.
 
 ### Keepalive companion
 
 `amq-keepalive` is developed and released from this repository alongside AMQ.
 `make build` produces both binaries, and each AMQ release includes a separate
-`amq-keepalive` archive stamped with the same release version. Verify a build
+`amq-keepalive` archive stamped with the same release version, including a
+native Windows ZIP. Verify a build
 with any equivalent form:
 
 ```bash
@@ -735,9 +736,11 @@ Files are universal, debuggable, and work everywhere. No connection strings, no 
 Those require infrastructure. AMQ is for local inter-process communication where agents share a filesystem. No server to configure or keep running.
 
 **What about Windows?**
-Native Windows supports the core queue, but not `coop exec` or `wake`. Use WSL
-with the Linux binary for the complete co-op workflow. See the explicit
-[platform capability matrix](INSTALL.md#platform-capability-matrix).
+Native Windows supports the core queue and direct submitted injection into a
+live Codex or Claude Code session through `amq-keepalive.exe`; it does not
+support `coop exec`, `amq wake`, or terminal supervision. Use WSL with the
+Linux binary for the complete co-op workflow. See the explicit [platform
+capability matrix](INSTALL.md#platform-capability-matrix).
 
 **Is this production-ready?**
 For local development workflows, yes. AMQ is intentionally simple—it's not trying to be a distributed message broker.

--- a/docs/adr-wake-capability-vector.md
+++ b/docs/adr-wake-capability-vector.md
@@ -51,6 +51,30 @@ match the TTY contract. `notifier_live` is not consumption.
 | Claude Code print (`claude-print`) | `activation=none` + `delivery=submitted` + `session=existing-exact` + `requires_human=false`. Target grammar is only `claude-print:session:<uuid>` (no `:new`). **Shipped** in `internal/keepalive/adapter/claudeprint.go`, registered in `DefaultRegistry` and `DefaultRegistryWithLogf`. Probe resolves `claude` (LookPath → basename via `launch.ProviderForExecutable` → EvalSymlinks → regular+exec → `--help` contains `--resume`, `--output-format`, `--replay-user-messages`) and executes the resolved path. Session jsonl is exactly one `~/.claude/projects/*/<uuid>.jsonl` (scan, not decoded escaped names; slash-to-dash is lossy). Child cwd is the **last** jsonl `cwd` field; missing directory refuses. Owner gate: readable well-formed `~/.claude/sessions/<pid>.json` with matching `sessionId` and a live filename pid (`kill(pid,0)`; ESRCH = stale, never deleted) is `ErrTargetDegraded`; unreadable, malformed, non-positive pid, or pid-mismatched records fail closed. Concurrent AMQ injects take `flock LOCK_EX|LOCK_NB` on `<statedir>/claude-print/<uuid>/inject.lock` before that scan. Claude CLI itself does not refuse dual writers. Inject spawns Setsid process group, stdin one stream-json user line then close (payload never argv), stdout+stderr to `<statedir>/claude-print/<uuid>/<utc-ts>.stream.jsonl` (0600). **Submitted** = the post-init `type=user` `isReplay=true` echo of this child's stdin line (not turn finished; `result` is the child's). Live 2.1.246 `--replay-user-messages` does not echo historical user turns. Fixed permission argv: `--permission-mode auto --allowedTools 'Bash(amq *)'` (dontAsk denies Bash). `CLAUDE_CONFIG_DIR` is ambient (§9.4). Desktop sees the turn only if that same child enabled `--remote-control` (not in the default argv). | yes |
 | Grok Bot.app | none | **not a wake seat** (Mac operator UI for host G) |
 
+### Native Windows submitted adapters (2026-08-30)
+
+The `codex-queue` and `claude-print` capability vectors above are also
+implemented for native Windows direct injection. This is not a native port of
+the TTY wake lifecycle.
+
+- Executable probes resolve `codex.exe` and `claude.exe`, not shell-only
+  `.cmd` shims. A regular Windows executable does not need Unix execute bits.
+- Codex writer activity is tested by attempting a non-blocking exclusive
+  `LockFileEx` across the lock file. `ERROR_LOCK_VIOLATION` means held; a
+  successful temporary lock is immediately released and means idle. This was
+  live-verified against Codex Desktop on 2026-08-30.
+- Claude owner liveness uses `OpenProcess(SYNCHRONIZE)` and a zero-time
+  `WaitForSingleObject`. Concurrent injects use `LockFileEx` on the adapter's
+  `inject.lock`.
+- The resumed Claude process is assigned to a Windows Job Object before its
+  stdin payload is released. Timeout cleanup terminates the job, not only the
+  parent PID. Claude Code 2.1.251 live-verified the post-init `isReplay:true`
+  echo and result on 2026-08-30.
+
+The released Windows `amq-keepalive.exe` exposes this through direct
+`inject`. `amq wake`, `coop exec`, `attach`, `reattach`, and `supervise` remain
+unsupported natively, so none of those Unix terminal guarantees are implied.
+
 Hermes HTTP `/v1/runs` and `hermes acp` stdio are other processes, not the GUI
 seat. `claude-cli://` is the terminal handler, not GUI wake. This Mac's
 ChatGPT.app is `com.openai.codex` / `codex://`; Computer Use cannot automate

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -11,7 +11,8 @@ checked, and retired through the public `amq` CLI.
 ## Build and version
 
 `make build` creates `./amq` and `./amq-keepalive` with the same release stamp.
-The release publishes a separate keepalive archive under the same AMQ tag.
+The release publishes a separate keepalive archive under the same AMQ tag,
+including a ZIP containing `amq-keepalive.exe` for native Windows.
 
 ```sh
 make build
@@ -33,6 +34,22 @@ The supported target forms are:
 - `claude-print:session:<uuid>` for an existing Claude Code session (`claude -p --resume` stream-json; submitted when the child echoes this inject's stdin with `isReplay` after `system/init`);
 - `file` targets for deterministic development and tests.
 
+On native Windows, the supported contract is direct `inject` through
+`codex-queue` or `claude-print`. Codex writer activity is proven with a
+non-blocking `LockFileEx` probe; Claude children run in a Windows Job Object so
+timeout cleanup terminates the process tree, and the per-session injection lock
+also uses `LockFileEx`. The executable probes deliberately resolve
+`codex.exe`/`claude.exe`, not shell-only `.cmd` shims.
+
+This does not make the Unix terminal lifecycle native on Windows:
+`amq wake`, `coop exec`, `attach`, `reattach`, and `supervise` remain outside
+the Windows support contract. Use `amq-keepalive.exe inject` directly:
+
+```powershell
+amq-keepalive.exe inject codex-queue "codex-queue:thread:$env:CODEX_THREAD_ID" "check the AMQ inbox"
+amq-keepalive.exe inject claude-print "claude-print:session:<uuid>" "check the AMQ inbox"
+```
+
 cmux short references such as `surface:2` are rejected because they can drift.
 cmux UUIDs are canonicalized before registration, and the adapter fails closed
 when a surface UUID is missing, not `type==terminal`, or physically ambiguous.
@@ -51,6 +68,7 @@ shell inside the matching surface:
 AMQ_CMUX_LIVE=1 go test ./internal/keepalive/adapter -run TestCmuxLiveDiscoverProbe -count=1 -v
 AMQ_GHOSTTY_LIVE=1 go test ./internal/keepalive/adapter -run TestGhosttyLiveDiscoverProbe -count=1 -v
 AMQ_CLAUDE_LIVE=1 go test ./internal/keepalive/adapter -run TestClaudePrintLiveResumeAck -count=1 -v
+AMQ_CODEX_LIVE=1 AMQ_CODEX_LIVE_THREAD=<uuid> go test ./internal/keepalive/adapter -run TestCodexQueueLiveEnqueue -count=1 -v
 ```
 
 ## Attach and reattach

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -114,7 +114,7 @@ func runUpgrade(args []string, currentVersion string) error {
 	} else if handled {
 		return nil
 	}
-	if err := skipUnavailableCompanionsOnWindows(allFlag, runtime.GOOS); err != nil {
+	if err := reportUnavailableCompanionsOnWindows(allFlag, runtime.GOOS); err != nil {
 		return err
 	}
 
@@ -480,19 +480,20 @@ func upgradeCompanionsWithScoopRoots(
 	homebrewPrefixes []string,
 	scoopRoots []update.ScoopInstallRoot,
 ) error {
+	companions := companionBinariesAvailableOn(companionBinariesForUpgrade, runtime.GOOS)
 	searchDirs, homeErr := companionSearchDirsForUpgrade(rawAMQPath, amqDest)
 	if homeErr != nil {
 		if err := writeStdoutLine(fmt.Sprintf("warning: cannot resolve user home directory for companion search; skipping ~/.local/bin: %v", homeErr)); err != nil {
 			return err
 		}
 	}
-	plan, err := discoverCompanionPlan(companionBinariesForUpgrade, searchDirs, amqDest, homebrewPrefixes, scoopRoots)
+	plan, err := discoverCompanionPlan(companions, searchDirs, amqDest, homebrewPrefixes, scoopRoots)
 	if err != nil {
 		return err
 	}
 
 	prepared := make([]preparedCompanionUpgrade, 0, len(plan))
-	for _, name := range companionBinariesForUpgrade {
+	for _, name := range companions {
 		_, ok := plan[name]
 		if !ok {
 			if err := writeStdoutLine(name + " not found; skipping."); err != nil {
@@ -511,7 +512,7 @@ func upgradeCompanionsWithScoopRoots(
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	for _, name := range companionBinariesForUpgrade {
+	for _, name := range companions {
 		target, ok := plan[name]
 		if !ok {
 			continue
@@ -1116,15 +1117,24 @@ func selectUpgradeDestination(path, resolved string, writable func(string) error
 	)
 }
 
-func skipUnavailableCompanionsOnWindows(all *bool, goos string) error {
+func reportUnavailableCompanionsOnWindows(all *bool, goos string) error {
 	if all == nil || !*all || goos != "windows" {
 		return nil
 	}
-	if err := writeStdoutLine("--all: companion binaries are not published for Windows; skipping"); err != nil {
-		return err
+	return writeStdoutLine("--all: only amq-keepalive is published for Windows; skipping amq-bridge and amq-acp")
+}
+
+func companionBinariesAvailableOn(names []string, goos string) []string {
+	if goos != "windows" {
+		return append([]string(nil), names...)
 	}
-	*all = false
-	return nil
+	available := make([]string, 0, 1)
+	for _, name := range names {
+		if name == "amq-keepalive" {
+			available = append(available, name)
+		}
+	}
+	return available
 }
 
 func selectUpgradeDestinationWithRoots(path, resolved string, writable func(string) error, homebrewPrefixes []string, scoopApps string) (string, error) {

--- a/internal/cli/upgrade_platform_test.go
+++ b/internal/cli/upgrade_platform_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReportUnavailableCompanionsOnWindowsKeepsKeepaliveEnabled(t *testing.T) {
+	all := true
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return reportUnavailableCompanionsOnWindows(&all, "windows")
+	})
+	if err != nil {
+		t.Fatalf("reportUnavailableCompanionsOnWindows: %v", err)
+	}
+	if !all {
+		t.Fatal("--all was disabled even though amq-keepalive is available on Windows")
+	}
+	if stdout != "--all: only amq-keepalive is published for Windows; skipping amq-bridge and amq-acp\n" {
+		t.Fatalf("stdout = %q, want exact Windows skip line", stdout)
+	}
+}
+
+func TestCompanionBinariesAvailableOnFiltersWindowsOnly(t *testing.T) {
+	names := []string{"amq-keepalive", "amq-bridge", "amq-acp"}
+	if got := companionBinariesAvailableOn(names, "windows"); !reflect.DeepEqual(got, []string{"amq-keepalive"}) {
+		t.Fatalf("Windows companions = %#v, want only amq-keepalive", got)
+	}
+	got := companionBinariesAvailableOn(names, "linux")
+	if !reflect.DeepEqual(got, names) {
+		t.Fatalf("Linux companions = %#v, want %#v", got, names)
+	}
+	got[0] = "mutated"
+	if names[0] != "amq-keepalive" {
+		t.Fatal("companion filter aliased its input")
+	}
+}

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -720,22 +720,6 @@ func TestDerivedRawHomebrewPrefixProtectsEvidencedBin(t *testing.T) {
 	}
 }
 
-func TestSkipUnavailableCompanionsOnWindows(t *testing.T) {
-	all := true
-	stdout, _, err := captureEnvOutput(t, func() error {
-		return skipUnavailableCompanionsOnWindows(&all, "windows")
-	})
-	if err != nil {
-		t.Fatalf("skipUnavailableCompanionsOnWindows: %v", err)
-	}
-	if all {
-		t.Fatal("--all remained enabled on Windows")
-	}
-	if stdout != "--all: companion binaries are not published for Windows; skipping\n" {
-		t.Fatalf("stdout = %q, want exact Windows skip line", stdout)
-	}
-}
-
 func TestPathWithinDirectoryEachClause(t *testing.T) {
 	parent := t.TempDir()
 	inside := filepath.Join(parent, "bin", "amq")

--- a/internal/keepalive/adapter/claudeprint.go
+++ b/internal/keepalive/adapter/claudeprint.go
@@ -246,7 +246,7 @@ func (c ClaudePrint) pinExecutable(ctx context.Context) (string, error) {
 	if lookPath == nil {
 		lookPath = exec.LookPath
 	}
-	looked, err := lookPath("claude")
+	looked, err := lookPath(platformExecutableName("claude"))
 	if err != nil {
 		return "", fmt.Errorf("claude not found on PATH (%w); put claude on PATH", err)
 	}
@@ -268,7 +268,7 @@ func (c ClaudePrint) pinExecutable(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("stat claude at %s: %w; put claude on PATH", resolved, err)
 	}
-	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+	if !isExecutableRegularFile(info) {
 		return "", fmt.Errorf("claude at %s is not an executable regular file; put claude on PATH", resolved)
 	}
 	out, err := c.runner().Run(ctx, resolved, "--help")

--- a/internal/keepalive/adapter/claudeprint_live_test.go
+++ b/internal/keepalive/adapter/claudeprint_live_test.go
@@ -18,7 +18,7 @@ func TestClaudePrintLiveResumeAck(t *testing.T) {
 	if os.Getenv("AMQ_CLAUDE_LIVE") != "1" {
 		t.Skip("set AMQ_CLAUDE_LIVE=1 to resume a scratch Claude session")
 	}
-	claudePath, err := exec.LookPath("claude")
+	claudePath, err := exec.LookPath(platformExecutableName("claude"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/keepalive/adapter/claudeprint_other.go
+++ b/internal/keepalive/adapter/claudeprint_other.go
@@ -1,4 +1,4 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package adapter
 

--- a/internal/keepalive/adapter/claudeprint_windows.go
+++ b/internal/keepalive/adapter/claudeprint_windows.go
@@ -1,0 +1,189 @@
+//go:build windows
+
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+type platformProcessSpawner struct{}
+
+func (platformProcessSpawner) Start(_ context.Context, spec processSpec) (startedProcess, error) {
+	log, err := os.OpenFile(spec.LogPath, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = log.Close() }()
+
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = stdinReader.Close() }()
+
+	cmd := exec.Command(spec.Path, spec.Args...)
+	cmd.Dir = spec.Dir
+	cmd.Stdin = stdinReader
+	cmd.Stdout = log
+	cmd.Stderr = log
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+	if err := cmd.Start(); err != nil {
+		_ = stdinWriter.Close()
+		return nil, err
+	}
+	_ = stdinReader.Close()
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		_ = stdinWriter.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("create process job: %w", err)
+	}
+	process, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.SYNCHRONIZE,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err == nil {
+		err = windows.AssignProcessToJobObject(job, process)
+		_ = windows.CloseHandle(process)
+	}
+	if err != nil {
+		_ = stdinWriter.Close()
+		_ = windows.CloseHandle(job)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("assign process job: %w", err)
+	}
+
+	// Keep the child blocked on stdin until it belongs to the job. If setup
+	// fails above, no payload can have landed and the inject remains replayable.
+	if _, err := io.Copy(stdinWriter, bytes.NewReader(spec.Stdin)); err != nil {
+		_ = stdinWriter.Close()
+		_ = windows.TerminateJobObject(job, 1)
+		_ = cmd.Wait()
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("write child stdin: %w", err)
+	}
+	if err := stdinWriter.Close(); err != nil {
+		_ = windows.TerminateJobObject(job, 1)
+		_ = cmd.Wait()
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("close child stdin: %w", err)
+	}
+
+	return &windowsStartedProcess{cmd: cmd, job: job}, nil
+}
+
+type windowsStartedProcess struct {
+	cmd  *exec.Cmd
+	mu   sync.Mutex
+	job  windows.Handle
+	once sync.Once
+}
+
+func (p *windowsStartedProcess) PID() int { return p.cmd.Process.Pid }
+
+func (p *windowsStartedProcess) Wait() error {
+	err := p.cmd.Wait()
+	p.closeJob()
+	return err
+}
+
+func (p *windowsStartedProcess) KillGroup() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	job := p.job
+	if job == 0 {
+		return nil
+	}
+	if err := windows.TerminateJobObject(job, 1); err != nil {
+		if killErr := p.cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return errors.Join(err, killErr)
+		}
+	}
+	return nil
+}
+
+func (p *windowsStartedProcess) closeJob() {
+	p.once.Do(func() {
+		p.mu.Lock()
+		job := p.job
+		p.job = 0
+		p.mu.Unlock()
+		if job != 0 {
+			_ = windows.CloseHandle(job)
+		}
+	})
+}
+
+func pidAlive(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false, nil
+		}
+		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			return true, nil
+		}
+		return false, fmt.Errorf("open process: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	status, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false, fmt.Errorf("wait process: %w", err)
+	}
+	switch status {
+	case uint32(windows.WAIT_TIMEOUT):
+		return true, nil
+	case windows.WAIT_OBJECT_0:
+		return false, nil
+	default:
+		return false, fmt.Errorf("wait process returned status %#x", status)
+	}
+}
+
+func tryFlockExclusive(path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	var overlapped windows.Overlapped
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		^uint32(0),
+		^uint32(0),
+		&overlapped,
+	)
+	if err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, errInjectBusy
+		}
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/keepalive/adapter/claudeprint_windows_test.go
+++ b/internal/keepalive/adapter/claudeprint_windows_test.go
@@ -1,0 +1,186 @@
+//go:build windows
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsProcessHelperEnv = "AMQ_TEST_WINDOWS_PROCESS_HELPER"
+const windowsProcessGrandchildPIDEnv = "AMQ_TEST_WINDOWS_GRANDCHILD_PID"
+
+func TestWindowsProcessHelper(t *testing.T) {
+	switch os.Getenv(windowsProcessHelperEnv) {
+	case "parent":
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		executable, err := os.Executable()
+		if err != nil {
+			os.Exit(2)
+		}
+		child := exec.Command(executable, "-test.run=^TestWindowsProcessHelper$")
+		child.Env = replaceTestEnv(os.Environ(), windowsProcessHelperEnv, "grandchild")
+		if err := child.Start(); err != nil {
+			os.Exit(3)
+		}
+		if err := os.WriteFile(os.Getenv(windowsProcessGrandchildPIDEnv), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			_ = child.Process.Kill()
+			os.Exit(4)
+		}
+		_ = child.Wait()
+		os.Exit(0)
+	case "grandchild":
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	default:
+		return
+	}
+}
+
+func TestWindowsClaudePrintSpawnerTerminatesItsProcessTree(t *testing.T) {
+	t.Setenv(windowsProcessHelperEnv, "parent")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(t.TempDir(), "child.log")
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	grandchildPIDPath := filepath.Join(t.TempDir(), "grandchild.pid")
+	t.Setenv(windowsProcessGrandchildPIDEnv, grandchildPIDPath)
+	proc, err := (platformProcessSpawner{}).Start(context.Background(), processSpec{
+		Path:    executable,
+		Args:    []string{"-test.run=^TestWindowsProcessHelper$"},
+		Dir:     t.TempDir(),
+		Stdin:   []byte("payload\n"),
+		LogPath: logPath,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = proc.KillGroup() })
+	if alive, err := pidAlive(proc.PID()); err != nil || !alive {
+		t.Fatalf("spawned pid alive = %v, %v; want true", alive, err)
+	}
+	grandchildPID := waitForTestPID(t, grandchildPIDPath)
+	if alive, err := pidAlive(grandchildPID); err != nil || !alive {
+		t.Fatalf("grandchild pid alive = %v, %v; want true", alive, err)
+	}
+	if err := proc.KillGroup(); err != nil {
+		t.Fatalf("KillGroup() error = %v", err)
+	}
+	wait := make(chan error, 1)
+	go func() { wait <- proc.Wait() }()
+	select {
+	case <-wait:
+	case <-time.After(5 * time.Second):
+		t.Fatal("job did not terminate within 5s")
+	}
+	if alive, err := pidAlive(proc.PID()); err != nil || alive {
+		t.Fatalf("terminated pid alive = %v, %v; want false", alive, err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		alive, aliveErr := pidAlive(grandchildPID)
+		if aliveErr != nil {
+			t.Fatalf("grandchild pid liveness: %v", aliveErr)
+		}
+		if !alive {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("job termination left the grandchild process alive")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestWindowsClaudePrintKillGroupFallsBackWhenJobHandleFails(t *testing.T) {
+	t.Setenv(windowsProcessHelperEnv, "grandchild")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(executable, "-test.run=^TestWindowsProcessHelper$")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	proc := &windowsStartedProcess{cmd: cmd, job: windows.InvalidHandle}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	if err := proc.KillGroup(); err != nil {
+		t.Fatalf("KillGroup() fallback error = %v", err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("fallback-killed process exited successfully; want a killed exit")
+	}
+}
+
+func TestWindowsClaudePrintPIDLivenessDistinguishesLiveAndAbsent(t *testing.T) {
+	if alive, err := pidAlive(os.Getpid()); err != nil || !alive {
+		t.Fatalf("current pid alive = %v, %v; want true", alive, err)
+	}
+	if alive, err := pidAlive(2147483647); err != nil || alive {
+		t.Fatalf("absent pid alive = %v, %v; want false", alive, err)
+	}
+}
+
+func TestWindowsClaudePrintInjectLockIsExclusiveAndReusable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inject.lock")
+	unlock, err := tryFlockExclusive(path)
+	if err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+	if _, err := tryFlockExclusive(path); !errors.Is(err, errInjectBusy) {
+		t.Fatalf("second lock error = %v, want errInjectBusy", err)
+	}
+	unlock()
+	reunlock, err := tryFlockExclusive(path)
+	if err != nil {
+		t.Fatalf("lock after release: %v", err)
+	}
+	reunlock()
+}
+
+func replaceTestEnv(env []string, key, value string) []string {
+	prefix := strings.ToUpper(key) + "="
+	out := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		if !strings.HasPrefix(strings.ToUpper(item), prefix) {
+			out = append(out, item)
+		}
+	}
+	return append(out, key+"="+value)
+}
+
+func waitForTestPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+			if parseErr != nil || pid <= 0 {
+				t.Fatalf("grandchild pid file = %q, %v", raw, parseErr)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for grandchild pid")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/keepalive/adapter/cmux_live_test.go
+++ b/internal/keepalive/adapter/cmux_live_test.go
@@ -319,6 +319,7 @@ func cmuxLiveTTYReady(tty string) bool {
 }
 
 func TestCmuxLiveFindSurfaceEntryAndTTYReady(t *testing.T) {
+	skipCmuxNonDarwin(t)
 	blank := cmuxTreeWithSurfaceRecords(map[string]string{"id": testCmuxSurfaceID, "tty": ""})
 	entry, tty, ok := cmuxLiveFindSurfaceEntry(blank, testCmuxSurfaceID)
 	if !ok || len(entry) == 0 {

--- a/internal/keepalive/adapter/cmux_test.go
+++ b/internal/keepalive/adapter/cmux_test.go
@@ -429,6 +429,7 @@ func TestCmuxInventoryRejectsNonPTYPathWithoutOwnershipKey(t *testing.T) {
 }
 
 func TestCanonicalCmuxTTYAcceptsOnlyDocumentedForms(t *testing.T) {
+	skipCmuxNonDarwin(t)
 	tests := []struct {
 		name  string
 		value string
@@ -1226,6 +1227,7 @@ func containsSubstring(list []string, want string) bool {
 }
 
 func TestCmuxExecutablePrefersBundledEnvironmentPath(t *testing.T) {
+	skipCmuxNonDarwin(t)
 	dir := t.TempDir()
 	bundled := filepath.Join(dir, "cmux")
 	if err := os.WriteFile(bundled, []byte("#!/bin/sh\n"), 0o700); err != nil {

--- a/internal/keepalive/adapter/codexqueue.go
+++ b/internal/keepalive/adapter/codexqueue.go
@@ -130,7 +130,7 @@ func (c CodexQueue) pinExecutable(ctx context.Context) (string, error) {
 	if lookPath == nil {
 		lookPath = exec.LookPath
 	}
-	looked, err := lookPath("codex")
+	looked, err := lookPath(platformExecutableName("codex"))
 	if err != nil {
 		return "", fmt.Errorf("codex not found on PATH (%w); put a codex >= 0.149 first in PATH", err)
 	}
@@ -154,7 +154,7 @@ func (c CodexQueue) pinExecutable(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("stat codex at %s: %w; put a codex >= 0.149 first in PATH", resolved, err)
 	}
-	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+	if !isExecutableRegularFile(info) {
 		return "", fmt.Errorf("codex at %s is not an executable regular file; put a codex >= 0.149 first in PATH", resolved)
 	}
 	out, err := c.runner().Run(ctx, resolved, "queue", "--help")

--- a/internal/keepalive/adapter/codexqueue_live_test.go
+++ b/internal/keepalive/adapter/codexqueue_live_test.go
@@ -45,8 +45,21 @@ func TestCodexQueueLiveEnqueue(t *testing.T) {
 		t.Fatalf("read thread-writer-locks: %v", err)
 	}
 	insp := platformWriterLockInspector{}
-	var uuid string
+	uuid := strings.TrimSpace(os.Getenv("AMQ_CODEX_LIVE_THREAD"))
+	if uuid != "" {
+		if !lowercaseThreadUUIDRe.MatchString(uuid) {
+			t.Fatalf("AMQ_CODEX_LIVE_THREAD %q is not a lowercase thread uuid", uuid)
+		}
+		lockPath := filepath.Join(home, "thread-writer-locks", uuid+".lock")
+		held, heldErr := insp.Held(context.Background(), lockPath)
+		if heldErr != nil || !held {
+			t.Fatalf("AMQ_CODEX_LIVE_THREAD writer held = %v, %v; open that thread and retry", held, heldErr)
+		}
+	}
 	for _, e := range entries {
+		if uuid != "" {
+			break
+		}
 		name := e.Name()
 		if !strings.HasSuffix(name, ".lock") {
 			continue
@@ -87,7 +100,7 @@ func TestCodexQueueLiveEnqueue(t *testing.T) {
 
 func liveCodexPath() (string, error) {
 	var candidates []string
-	if p, err := exec.LookPath("codex"); err == nil {
+	if p, err := exec.LookPath(platformExecutableName("codex")); err == nil {
 		candidates = append(candidates, p)
 	}
 	candidates = append(candidates, "/opt/homebrew/bin/codex")

--- a/internal/keepalive/adapter/executable.go
+++ b/internal/keepalive/adapter/executable.go
@@ -1,0 +1,20 @@
+package adapter
+
+import (
+	"os"
+	"runtime"
+)
+
+// isExecutableRegularFile applies the host's executable-file contract.
+// Windows does not expose Unix execute permission bits through FileMode; a
+// regular .exe selected by LookPath is executable by construction.
+func isExecutableRegularFile(info os.FileInfo) bool {
+	return info.Mode().IsRegular() && (runtime.GOOS == "windows" || info.Mode().Perm()&0o111 != 0)
+}
+
+func platformExecutableName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}

--- a/internal/keepalive/adapter/file_test.go
+++ b/internal/keepalive/adapter/file_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func TestFileAdapterInjectsPayloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat target: %v", err)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
+	if got := info.Mode().Perm(); runtime.GOOS != "windows" && got != 0o600 {
 		t.Fatalf("file mode = %v, want 0600", got)
 	}
 }

--- a/internal/keepalive/adapter/writerlock_other.go
+++ b/internal/keepalive/adapter/writerlock_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package adapter
 

--- a/internal/keepalive/adapter/writerlock_windows.go
+++ b/internal/keepalive/adapter/writerlock_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+type platformWriterLockInspector struct{}
+
+func (platformWriterLockInspector) Held(ctx context.Context, path string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var overlapped windows.Overlapped
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		^uint32(0),
+		^uint32(0),
+		&overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("LockFileEx: %w", err)
+	}
+	if err := windows.UnlockFileEx(
+		windows.Handle(f.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped,
+	); err != nil {
+		return false, fmt.Errorf("UnlockFileEx: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}

--- a/internal/keepalive/adapter/writerlock_windows_test.go
+++ b/internal/keepalive/adapter/writerlock_windows_test.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsWriterLockInspectorDistinguishesHeldIdleAndMissing(t *testing.T) {
+	inspector := platformWriterLockInspector{}
+	path := filepath.Join(t.TempDir(), "thread.lock")
+
+	if held, err := inspector.Held(context.Background(), path); err != nil || held {
+		t.Fatalf("missing lock held = %v, %v; want false", held, err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if held, err := inspector.Held(context.Background(), path); err != nil || held {
+		t.Fatalf("idle lock held = %v, %v; want false", held, err)
+	}
+
+	unlock, err := tryFlockExclusive(path)
+	if err != nil {
+		t.Fatalf("hold writer lock: %v", err)
+	}
+	if held, err := inspector.Held(context.Background(), path); err != nil || !held {
+		t.Fatalf("active lock held = %v, %v; want true", held, err)
+	}
+	unlock()
+	if held, err := inspector.Held(context.Background(), path); err != nil || held {
+		t.Fatalf("released lock held = %v, %v; want false", held, err)
+	}
+}
+
+func TestWindowsWriterLockInspectorHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := (platformWriterLockInspector{}).Held(ctx, filepath.Join(t.TempDir(), "thread.lock"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Held() error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -330,9 +330,9 @@ func AssetName(tag, goos, goarch string) (string, error) {
 // AssetNameFor returns the release archive asset name for a given binary
 // (amq, amq-keepalive, amq-bridge, amq-acp). The archive name template is
 // <binary>_<version>_<os>_<arch>.<ext>, matching .goreleaser.yaml's
-// name_template per build. Only amq publishes a Windows zip; companions are
-// darwin/linux tar.gz, but this function does not enforce that — the caller
-// picks the asset for a binary the release actually publishes.
+// name_template per build. amq and amq-keepalive publish Windows zip assets;
+// the other companions are darwin/linux tar.gz. This function does not
+// enforce that matrix — the caller picks an asset the release publishes.
 func AssetNameFor(binaryName, tag, goos, goarch string) (string, error) {
 	if err := validateBinaryName(binaryName); err != nil {
 		return "", err

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -32,6 +32,20 @@ Requires `amq` binary in PATH. Install:
 curl -fsSL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/install.sh | bash
 ```
 
+### Native Windows submitted injection
+
+The native Windows core queue works, and the separately published
+`amq-keepalive.exe` can submit to an exact live Codex or Claude Code session:
+
+```powershell
+amq-keepalive.exe inject codex-queue "codex-queue:thread:$env:CODEX_THREAD_ID" "check the AMQ inbox"
+amq-keepalive.exe inject claude-print "claude-print:session:<uuid>" "check the AMQ inbox"
+```
+
+Do not translate this into `amq wake` or `coop exec`: native Windows does not
+provide their Unix terminal lifecycle. `codex-queue` also requires an active
+writer for the exact thread; an idle lock file is not sufficient.
+
 ## Environment Rules
 
 AMQ primarily uses `AM_ROOT` (which mailbox tree) and `AM_ME` (which agent).


### PR DESCRIPTION
## Summary

Add native Windows implementations for the existing `codex-queue` and
`claude-print` submitted-injection adapters, and publish
`amq-keepalive.exe` as a Windows ZIP.

This deliberately does not advertise `amq wake`, `coop exec`, or terminal
supervision as native Windows features. The Windows support contract is direct
`amq-keepalive.exe inject` into an exact live Codex or Claude Code session.

## Changes

- resolve `codex.exe` / `claude.exe` and accept regular Windows executables
  without Unix mode bits;
- prove Codex writer activity and serialize Claude injects with non-blocking
  `LockFileEx` locks;
- inspect Claude owner PIDs with `OpenProcess` / `WaitForSingleObject`;
- place resumed Claude processes in a Job Object and terminate the complete
  process tree on timeout;
- publish amd64/arm64 Windows keepalive ZIPs and let direct `amq upgrade --all`
  upgrade only the Windows companion that exists;
- add a focused native Windows CI gate and document the narrower capability in
  the install guide, ADR, README, and canonical CLI skill;
- platform-gate three macOS-only cmux assertions and the Unix-only permission
  bit assertion so the complete adapter package can run natively on Windows.

## Testing

- `go test ./internal/keepalive/adapter -count=10` on native Windows;
- hostile parent/grandchild Job Object termination test, 20 runs;
- Windows race detector: full adapter once plus focused Windows/Codex/Claude
  tests for 10 runs (`CGO_ENABLED=1`, MinGW-w64 GCC 16.1.0);
- Gremlins v0.6.0 mutation gate on the new Windows mechanics: 28/28 killed,
  0 lived, 0 uncovered, 100% efficacy and mutant coverage;
- live Codex exact-thread queue test and packaged-binary CLI enqueue;
- live Claude Code 2.1.251 disposable-session resume, including the matching
  post-init `isReplay:true` echo and result;
- GoReleaser v2.18.0 snapshot built all configured targets and produced both
  Windows keepalive ZIPs;
- same-SHA fork GitHub Actions run
  [`33314863690`](https://github.com/lask3802/agent-message-queue/actions/runs/33314863690)
  passed the complete Linux build/test/smoke/lint job, macOS full test, and
  Windows claim plus native Codex/Claude adapter gates;
- clean WSL clone: skill symlink checks, `go vet ./...`, and golangci-lint
  v2.13.1 (`0 issues`) passed. Three WSL full-suite failures were reproduced
  unchanged on pristine v0.75.0 (`253b5ef`).

## Related Issues

N/A
