### PR TITLE
feat(wake): add durable notification-attempt ledger

### DIFF
--- a/internal/cli/trace.go
+++ b/internal/cli/trace.go
@@ -437,6 +437,20 @@ func notificationAttemptLimitation(state string) string {
 	}
 }
 
+// hasWriteFailedNotification reports whether any notification evidence
+// carries StateWriteFailed — the prepared record could not be persisted, but
+// the wake injected anyway. trace uses this to print "recording failed"
+// rather than "no attempt recorded" (Requirement 3: the two facts must not
+// print the same sentence).
+func hasWriteFailedNotification(evidence []traceEvidence) bool {
+	for _, ev := range evidence {
+		if ev.Notification != nil && ev.Notification.State == notificationattempt.StateWriteFailed {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *traceCollector) addTarget(located traceLocatedHeader, authority string) {
 	c.targets = append(c.targets, located)
 	header := located.header
@@ -599,8 +613,19 @@ func (c *traceCollector) finishLegs() {
 				leg.Detail = "current file visibility found; original directory sync durability is no_evidence"
 				leg.NextStep = "inspect retained send output before retrying; do not infer retry safety from current file presence"
 			case "notification":
-				leg.Detail = "durable notifier write-attempt evidence found; this never proves human or TUI observation"
-				leg.NextStep = "treat prepared-without-result as indeterminate and written only as a byte-write outcome"
+				// Requirement 3: distinguish "no attempt recorded" from "recording
+				// failed". If any evidence has StateWriteFailed, the prepared write
+				// itself errored (the ledger could not persist the record) but the
+				// wake injected anyway — the ledger never blocks delivery. An
+				// operator debugging a missed doorbell must not conclude the wake
+				// never tried.
+				if hasWriteFailedNotification(leg.Evidence) {
+					leg.Detail = "notification attempt was made but the attempt record could not be persisted; the wake injects regardless of ledger write success"
+					leg.NextStep = "the notification was attempted — investigate the injection path, not the ledger; the missing record is a persistence gap, not a missed attempt"
+				} else {
+					leg.Detail = "durable notifier write-attempt evidence found; this never proves human or TUI observation"
+					leg.NextStep = "treat prepared-without-result as indeterminate and written only as a byte-write outcome"
+				}
 			}
 		} else {
 			leg.Status = "no_evidence"

--- a/internal/cli/trace.go
+++ b/internal/cli/trace.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 	"github.com/avivsinai/agent-message-queue/internal/receipt"
 )
 
@@ -42,19 +43,20 @@ type traceLeg struct {
 }
 
 type traceEvidence struct {
-	Authority  string              `json:"authority"`
-	Path       string              `json:"path,omitempty"`
-	Agent      string              `json:"agent,omitempty"`
-	Area       string              `json:"area,omitempty"`
-	Box        string              `json:"box,omitempty"`
-	Message    *traceMessage       `json:"message,omitempty"`
-	Route      *traceRouteEvidence `json:"route,omitempty"`
-	DLQ        *fsq.DLQEnvelope    `json:"dlq,omitempty"`
-	Receipt    *receipt.Receipt    `json:"receipt,omitempty"`
-	Relation   *traceRelation      `json:"relation,omitempty"`
-	State      string              `json:"state,omitempty"`
-	Durability string              `json:"durability,omitempty"`
-	Limitation string              `json:"limitation,omitempty"`
+	Authority    string                       `json:"authority"`
+	Path         string                       `json:"path,omitempty"`
+	Agent        string                       `json:"agent,omitempty"`
+	Area         string                       `json:"area,omitempty"`
+	Box          string                       `json:"box,omitempty"`
+	Message      *traceMessage                `json:"message,omitempty"`
+	Route        *traceRouteEvidence          `json:"route,omitempty"`
+	DLQ          *fsq.DLQEnvelope             `json:"dlq,omitempty"`
+	Receipt      *receipt.Receipt             `json:"receipt,omitempty"`
+	Relation     *traceRelation               `json:"relation,omitempty"`
+	Notification *notificationattempt.Attempt `json:"notification,omitempty"`
+	State        string                       `json:"state,omitempty"`
+	Durability   string                       `json:"durability,omitempty"`
+	Limitation   string                       `json:"limitation,omitempty"`
 }
 
 type traceMessage struct {
@@ -111,7 +113,8 @@ func runTrace(args []string) error {
 		"Join current on-disk evidence for one message without mutating the queue.",
 		"",
 		"Phase A reports message copies, route fields, visible delivery artifacts, DLQ entries,",
-		"delivery receipts, thread references, and explicit no_evidence for notification attempts.",
+		"delivery receipts, thread references, and durable agent-owned notification write attempts.",
+		"Notification evidence never proves that a TUI or person saw, displayed, or submitted it.",
 	)
 
 	messageID := ""
@@ -192,6 +195,7 @@ func collectTrace(root, messageID string) traceResult {
 	collector.scanMessages()
 	collector.scanDLQ()
 	collector.scanReceipts()
+	collector.scanNotificationAttempts()
 	collector.joinHeaders()
 	collector.finishLegs()
 	return collector.result()
@@ -201,8 +205,8 @@ func (c *traceCollector) result() traceResult {
 	status := "found"
 	hasEvidence := false
 	hasErrors := false
-	for name, leg := range c.legs {
-		if name != "notification" && len(leg.Evidence) > 0 {
+	for _, leg := range c.legs {
+		if len(leg.Evidence) > 0 {
 			hasEvidence = true
 		}
 		if leg.Status == "error" {
@@ -232,6 +236,7 @@ func (c *traceCollector) listAgents() []string {
 		c.addError("dlq", fmt.Sprintf("scan agents: %v", err))
 		c.addError("receipts", fmt.Sprintf("scan agents: %v", err))
 		c.addError("thread", fmt.Sprintf("scan agents: %v", err))
+		c.addError("notification", fmt.Sprintf("scan agents: %v", err))
 		return []string{}
 	}
 	agents := make([]string, 0, len(entries))
@@ -400,6 +405,38 @@ func (c *traceCollector) scanReceipts() {
 	}
 }
 
+func (c *traceCollector) scanNotificationAttempts() {
+	for _, agent := range c.agents {
+		attempts, err := notificationattempt.ListDeliveryRoot(c.deliveryRoot, agent, c.messageID)
+		if err != nil {
+			c.addError("notification", fmt.Sprintf("scan agent %s notification attempts: %v", agent, err))
+			continue
+		}
+		for i := range attempts {
+			attempt := attempts[i]
+			c.addEvidence("notification", traceEvidence{
+				Authority:    "notification_attempt",
+				Path:         filepath.ToSlash(filepath.Join("agents", agent, "receipts")),
+				Agent:        agent,
+				State:        attempt.State,
+				Notification: &attempt,
+				Limitation:   notificationAttemptLimitation(attempt.State),
+			})
+		}
+	}
+}
+
+func notificationAttemptLimitation(state string) string {
+	switch state {
+	case notificationattempt.StateIndeterminate:
+		return "prepared without a durable result is indeterminate; it does not prove that notification bytes were written"
+	case notificationattempt.OutcomeWritten:
+		return "written means only that notifier bytes were accepted; it does not prove seen, displayed, or submitted"
+	default:
+		return "failed records a notifier write failure; it does not establish any terminal or user-visible state"
+	}
+}
+
 func (c *traceCollector) addTarget(located traceLocatedHeader, authority string) {
 	c.targets = append(c.targets, located)
 	header := located.header
@@ -542,7 +579,7 @@ func (c *traceCollector) finishLegs() {
 			next:   "inspect the message thread with 'amq thread --id <thread-id> --json' when a parsable header is available",
 		},
 		"notification": {
-			detail: "notification attempt history is unavailable because Phase A has no durable attempt ledger",
+			detail: "no durable notification attempt record was found",
 			next:   "run 'amq doctor --ops' for current wake health; do not infer historical notification success",
 		},
 	}
@@ -561,6 +598,9 @@ func (c *traceCollector) finishLegs() {
 			case "delivery":
 				leg.Detail = "current file visibility found; original directory sync durability is no_evidence"
 				leg.NextStep = "inspect retained send output before retrying; do not infer retry safety from current file presence"
+			case "notification":
+				leg.Detail = "durable notifier write-attempt evidence found; this never proves human or TUI observation"
+				leg.NextStep = "treat prepared-without-result as indeterminate and written only as a byte-write outcome"
 			}
 		} else {
 			leg.Status = "no_evidence"
@@ -582,7 +622,7 @@ func (c *traceCollector) addError(legName, detail string) {
 }
 
 func (c *traceCollector) addRootError(err error) {
-	for _, name := range []string{"message", "dlq", "receipts", "thread"} {
+	for _, name := range []string{"message", "dlq", "receipts", "thread", "notification"} {
 		c.addError(name, fmt.Sprintf("open root: %v", err))
 	}
 }
@@ -668,6 +708,10 @@ func traceEvidenceText(legName string, evidence traceEvidence) string {
 	case "thread":
 		if evidence.Relation != nil {
 			return fmt.Sprintf("%s %s", evidence.Relation.Relation, evidence.Relation.MessageID)
+		}
+	case "notification":
+		if evidence.Notification != nil {
+			return fmt.Sprintf("%s by %s at %s", evidence.State, evidence.Agent, evidence.Notification.Prepared.RecordedAt)
 		}
 	}
 	return ""

--- a/internal/cli/trace_test.go
+++ b/internal/cli/trace_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 )
 
 type traceResultJSON struct {
@@ -16,6 +17,46 @@ type traceResultJSON struct {
 	MessageID string                  `json:"message_id"`
 	Status    string                  `json:"status"`
 	Legs      map[string]traceLegJSON `json:"legs"`
+}
+
+func TestTraceJoinsWrittenAndIndeterminateNotificationAttempts(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writer := notificationattempt.NewWriter(root, "codex")
+	written, err := writer.Prepare([]string{"msg-notification"}, "raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Result(written, notificationattempt.OutcomeWritten, "terminal bytes accepted"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Prepare([]string{"msg-notification"}, "external"); err != nil {
+		t.Fatal(err)
+	}
+
+	result := collectTrace(root, "msg-notification")
+	leg := result.Legs["notification"]
+	if leg.Status != "evidence" || len(leg.Evidence) != 2 {
+		t.Fatalf("notification leg = %+v", leg)
+	}
+	states := map[string]bool{}
+	for _, evidence := range leg.Evidence {
+		states[evidence.State] = true
+		if evidence.Authority != "notification_attempt" || evidence.Notification == nil {
+			t.Fatalf("notification evidence = %+v", evidence)
+		}
+		if strings.Contains(evidence.Limitation, "seen") && evidence.State == notificationattempt.StateIndeterminate {
+			t.Fatalf("indeterminate limitation should explain missing result: %+v", evidence)
+		}
+	}
+	if !states[notificationattempt.OutcomeWritten] || !states[notificationattempt.StateIndeterminate] {
+		t.Fatalf("notification states = %v", states)
+	}
 }
 
 type traceLegJSON struct {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,135 +14,55 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 )
 
 type wakeConfig struct {
-	me                            string
-	root                          string
-	session                       string
-	injectCmd                     string
-	injectVia                     string // external command for injection (replaces TIOCSTI)
-	injectArgs                    []string
-	wakeOwner                     *wakeOwner
-	injectTimeout                 time.Duration
-	bell                          bool
-	debounce                      time.Duration
-	previewLen                    int
-	strict                        bool
-	fallbackWarn                  bool
-	injectMode                    string // auto, raw, paste
-	requestedInjectMode           string
-	retryUntil                    string
-	legacyTIOCSTIDemoted          bool
-	debug                         bool
-	deferWhileInput               bool
-	inputQuietFor                 time.Duration
-	inputPollInterval             time.Duration
-	inputMaxHold                  time.Duration
-	interrupt                     bool
-	interruptLabel                string
-	interruptPriority             string
-	interruptKey                  string
-	interruptNotice               string
-	interruptCooldown             time.Duration
-	lastInterrupt                 time.Time
-	controlStop                   <-chan struct{}
-	restartSignals                chan os.Signal
-	beforeTerminalWrite           func() error
-	terminalWrite                 func(string) error
-	inspectTerminalGeneration     func() wakeLockInspection
-	terminalGeneration            string
-	terminalImageVersion          string
-	terminalTTY                   string
-	selfUpgrade                   wakeSelfUpgradeState
-	baselineRequested             bool
-	baselineInherited             bool
-	baselineExisting              map[string]wakeFileIdentity
-	inputDelivery                 wakeInputDeliveryState
-	inputRecoveryRequired         bool
-	doorbell                      wakeDoorbellState
-	doorbellNow                   func() time.Time
-	lastAttemptAttention          bool
-	lastAttemptTransientAttention bool
-	onBaselineReady               func(map[string]wakeFileIdentity) error
-	onPrepared                    func(wakeAdmissionWatcher) error
-	retainedAgent                 wakeRetainedAgent
-	retainedInbox                 wakeInboxReader
-	touchPresence                 func() error
-	maintenanceTicks              <-chan time.Time
-	maintenanceOutputs            []*os.File
-	preconditionCheck             func(*wakeConfig) error
-	onPendingNotify               func()
-	onNotificationAttemptComplete func()
-	recordNotifierStatus          func(status, mode, reason string) error
-	pendingNotifierStatus         *wakeNotifierStatus
-	recordDoorbellStatus          func(parked bool, attempts uint) error
-	pendingDoorbellStatus         *wakeDoorbellStatus
-	reportedDoorbellStatus        wakeDoorbellStatus
-	recordAttention               func(wakeAttentionEmission) error
-	attentionEnv                  func(string) string
-	attentionIsTTY                func() bool
-	attentionWrite                func([]byte) (int, error)
-	diagnosticIsTTY               func() bool
-}
-
-type wakeNotifierStatus struct {
-	status string
-	mode   string
-	reason string
-}
-
-type wakeDoorbellStatus struct {
-	parked   bool
-	attempts uint
-}
-
-const maxWakeNotificationSenderClauses = 8
-
-type wakeInputDeliveryPhase uint8
-
-const (
-	wakeInputDeliveryIdle wakeInputDeliveryPhase = iota
-	wakeInputPayloadPending
-	wakeInputRawPreludePending
-	wakeInputPrimarySubmitPending
-	wakeInputRawFirstSubmitQueued
-	wakeInputRawRescuePending
-	wakeInputRawRescueQueued
-)
-
-type wakeInputDeliveryState struct {
-	phase               wakeInputDeliveryPhase
-	mode                string
-	payload             string
-	acceptedBytes       int
-	acceptanceUncertain bool
-}
-
-func (state *wakeInputDeliveryState) reset() {
-	*state = wakeInputDeliveryState{}
-}
-
-func (state wakeInputDeliveryState) pending() bool {
-	return state.phase != wakeInputDeliveryIdle
-}
-
-func (state wakeInputDeliveryState) confirmedInput() bool {
-	return state.acceptedBytes > 0 ||
-		(state.phase != wakeInputDeliveryIdle &&
-			state.phase != wakeInputPayloadPending)
-}
-
-func (state wakeInputDeliveryState) blocksDemotion() bool {
-	return state.confirmedInput() || state.acceptanceUncertain
+	me                   string
+	root                 string
+	session              string
+	injectCmd            string
+	injectVia            string // external command for injection (replaces TIOCSTI)
+	injectArgs           []string
+	wakeOwner            *wakeOwner
+	injectTimeout        time.Duration
+	bell                 bool
+	debounce             time.Duration
+	previewLen           int
+	strict               bool
+	fallbackWarn         bool
+	injectMode           string // auto, raw, paste
+	debug                bool
+	deferWhileInput      bool
+	inputQuietFor        time.Duration
+	inputPollInterval    time.Duration
+	inputMaxHold         time.Duration
+	interrupt            bool
+	interruptLabel       string
+	interruptPriority    string
+	interruptKey         string
+	interruptNotice      string
+	interruptCooldown    time.Duration
+	lastInterrupt        time.Time
+	controlStop          <-chan struct{}
+	beforeTerminalWrite  func() error
+	terminalWrite        func(string) error
+	terminalGeneration   string
+	terminalTTY          string
+	baselineRequested    bool
+	baselineInherited    bool
+	baselineExisting     map[string]wakeFileIdentity
+	onBaselineReady      func(map[string]wakeFileIdentity) error
+	onPrepared           func(wakeAdmissionWatcher) error
+	retainedInbox        wakeInboxReader
+	touchPresence        func() error
+	recordNotifierStatus func(status, mode, reason string) error
+	notificationWritten  bool
+	notificationDetail   string
 }
 
 type wakeAdmissionWatcher interface {
 	Errors() <-chan error
-}
-
-type wakeRetainedAgent interface {
-	isWakeRetainedAgent()
 }
 
 type wakeInboxReader interface {
@@ -149,85 +70,12 @@ type wakeInboxReader interface {
 	ReadHeader(name string) (format.Header, error)
 }
 
-type wakeInboxFileInfoReader interface {
-	FileInfo(name string) (os.FileInfo, error)
-}
-
-type wakeInboxScanError struct {
-	err error
-}
-
-func (err *wakeInboxScanError) Error() string {
-	return err.err.Error()
-}
-
-func (err *wakeInboxScanError) Unwrap() error {
-	return err.err
-}
-
-type wakeTerminalPartialProgressError struct {
-	err error
-}
-
-func (err *wakeTerminalPartialProgressError) Error() string {
-	return err.err.Error()
-}
-
-func (err *wakeTerminalPartialProgressError) Unwrap() error {
-	return err.err
-}
-
-func isWakeTerminalPartialProgress(err error) bool {
-	var partial *wakeTerminalPartialProgressError
-	return errors.As(err, &partial)
-}
-
-type wakeInputDemotionBlockedError struct {
-	err error
-}
-
-func (err *wakeInputDemotionBlockedError) Error() string {
-	return "terminal input has confirmed or uncertain progress; refusing to discard its exact completion debt: " + err.err.Error()
-}
-
-func (err *wakeInputDemotionBlockedError) Unwrap() error {
-	return err.err
-}
-
-func isWakeInputDemotionBlocked(err error) bool {
-	var blocked *wakeInputDemotionBlockedError
-	return errors.As(err, &blocked)
-}
-
-type wakeTerminalProgressUncertainError struct {
-	err error
-}
-
-func (err *wakeTerminalProgressUncertainError) Error() string {
-	return "terminal input acceptance is uncertain; refusing to replay: " + err.err.Error()
-}
-
-func (err *wakeTerminalProgressUncertainError) Unwrap() error {
-	return err.err
-}
-
-func isWakeTerminalProgressUncertain(err error) bool {
-	var uncertain *wakeTerminalProgressUncertainError
-	return errors.As(err, &uncertain)
-}
-
-type wakeTerminalAcceptedProgress interface {
-	wakeAcceptedBytes() int
-}
-
 const defaultInjectTimeout = 5 * time.Second
 const (
-	wakeInjectModeAuto     = "auto"
-	wakeInjectModeRaw      = "raw"
-	wakeInjectModePaste    = "paste"
-	wakeInjectModeNone     = "none"
-	wakeRetryUntilDrained  = "drained"
-	wakeRetryUntilInjected = "injected"
+	wakeInjectModeAuto  = "auto"
+	wakeInjectModeRaw   = "raw"
+	wakeInjectModePaste = "paste"
+	wakeInjectModeNone  = "none"
 
 	coopWakeDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
 
@@ -236,12 +84,6 @@ const (
 	// rawInjectCRDrainTimeout bounds the wait for the submit CR itself to be
 	// consumed before deciding whether the second rescue CR is safe to send.
 	rawInjectCRDrainTimeout = 1 * time.Second
-	// Three samples require two follow-up confirmations after the first quiet
-	// observation, while adding at most two poll intervals to a real idle
-	// transition. Any active sample resets the evidence.
-	requiredInputQuietSamples = 3
-
-	wakeInputRecoveryNotice = "AMQ terminal input delivery is incomplete; inspect the composer, run amq drain --include-body, then restart this agent session"
 	// codexTUIEnterSuppressWindow mirrors codex-tui's
 	// PASTE_ENTER_SUPPRESS_WINDOW (codex-rs/tui/src/bottom_pane/paste_burst.rs,
 	// verified at rust-v0.144.1 and main): an Enter arriving within this window
@@ -260,93 +102,18 @@ const (
 	rawInjectSettleDelay = codexTUIEnterSuppressWindow + 30*time.Millisecond
 )
 
-func normalizeWakeRetryUntil(raw string) (string, error) {
-	value := strings.ToLower(strings.TrimSpace(raw))
-	if value == "" {
-		return wakeRetryUntilDrained, nil
-	}
-	switch value {
-	case wakeRetryUntilDrained, wakeRetryUntilInjected:
-		return value, nil
-	default:
-		return "", fmt.Errorf(
-			"invalid retry-until %q (supported: drained, injected)",
-			raw,
-		)
-	}
-}
-
-// validateStoredWakeRetryUntil accepts only exact persisted wire values.
-// CLI input may still use normalizeWakeRetryUntil; stored .wake.target /
-// .wake.state bytes must be "", "drained", or "injected" with no whitespace/case folding.
-func validateStoredWakeRetryUntil(raw string) error {
-	switch raw {
-	case "", wakeRetryUntilDrained, wakeRetryUntilInjected:
-		return nil
-	default:
-		return fmt.Errorf(
-			"noncanonical retry-until %q (stored values: empty, drained, injected)",
-			raw,
-		)
-	}
-}
-
 var (
 	tiocstiInject          = func(text string) error { return tiocsti.Inject(text) }
 	waitForRawInputDrained = waitForTTYInputDrain
-	waitForWakeInputQuiet  = waitForTTYInputQuiet
 	rawInjectSleep         = time.Sleep
 )
 
 type wakeMsgInfo struct {
+	id       string
 	from     string
 	subject  string
 	priority string
 	labels   []string
-}
-
-type wakePayloadProvenance string
-
-const (
-	wakePayloadSystemFixed  wakePayloadProvenance = "system_fixed"
-	wakePayloadPeerHeaders  wakePayloadProvenance = "peer_headers"
-	wakePayloadOperatorFlag wakePayloadProvenance = "operator_flag"
-)
-
-type wakePayload struct {
-	text       string
-	provenance wakePayloadProvenance
-}
-
-type wakeNotification struct {
-	input      wakePayload
-	output     wakePayload
-	submitOnly bool
-}
-
-func peerWakeNotification(output string) wakeNotification {
-	return wakeNotification{
-		input: wakePayload{
-			text:       coopWakeDoorbell,
-			provenance: wakePayloadSystemFixed,
-		},
-		output: wakePayload{
-			text:       output,
-			provenance: wakePayloadPeerHeaders,
-		},
-	}
-}
-
-func validCoopWakeDoorbell(prompt string) bool {
-	return prompt == coopWakeDoorbell
-}
-
-func operatorWakeNotification(text string) wakeNotification {
-	payload := wakePayload{
-		text:       text,
-		provenance: wakePayloadOperatorFlag,
-	}
-	return wakeNotification{input: payload, output: payload}
 }
 
 type ttyInputState struct {
@@ -391,47 +158,6 @@ func inputDeferralDelay(state ttyInputState, now, deadline time.Time, quietFor, 
 	return delay
 }
 
-func waitForInputQuiet(
-	sample func() (ttyInputState, error),
-	nowFn func() time.Time,
-	sleepFn func(time.Duration, ttyInputState, string),
-	quietFor, maxHold, pollInterval time.Duration,
-) (allowInjection bool, activeReason string, err error) {
-	if maxHold <= 0 {
-		return true, "", nil
-	}
-
-	deadline := nowFn().Add(maxHold)
-	quietSamples := 0
-	for {
-		now := nowFn()
-		state, sampleErr := sample()
-		if sampleErr != nil {
-			return true, "", sampleErr
-		}
-
-		active, reason := state.active(now, quietFor)
-		if active {
-			quietSamples = 0
-		} else {
-			quietSamples++
-			if quietSamples >= requiredInputQuietSamples {
-				return true, "", nil
-			}
-			reason = "quiet confirmation incomplete"
-		}
-		if !now.Before(deadline) {
-			return false, reason, nil
-		}
-
-		delay := inputDeferralDelay(state, now, deadline, quietFor, pollInterval)
-		if delay <= 0 {
-			return false, reason, nil
-		}
-		sleepFn(delay, state, reason)
-	}
-}
-
 func shouldDeferBeforeInject(cfg *wakeConfig, deferForInput bool) bool {
 	return deferForInput && cfg.deferWhileInput && cfg.injectVia == "" && cfg.injectMode != wakeInjectModeNone
 }
@@ -447,15 +173,16 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		entries, err = os.ReadDir(inboxNew)
 	}
 	if err != nil {
-		return &wakeInboxScanError{
-			err: fmt.Errorf("read wake inbox %s: %w", inboxNew, err),
+		if os.IsNotExist(err) {
+			return nil
 		}
+		return err
 	}
 
 	var messages []wakeMsgInfo
+	senderCounts := make(map[string]int)
 	var interruptMessages []wakeMsgInfo
 	interruptCounts := make(map[string]int)
-	currentPending := make(map[string]os.FileInfo)
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -465,19 +192,9 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
 			continue
 		}
-		var fileInfo os.FileInfo
-		var infoErr error
-		if retained, ok := cfg.retainedInbox.(wakeInboxFileInfoReader); ok {
-			fileInfo, infoErr = retained.FileInfo(name)
-		} else {
-			fileInfo, infoErr = entry.Info()
-		}
-		pendingInfo := fileInfo
-		if infoErr != nil {
-			pendingInfo = nil
-		}
 		if baselineIdentity, ignored := cfg.baselineExisting[name]; ignored {
-			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, fileInfo) {
+			info, infoErr := entry.Info()
+			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, info) {
 				continue
 			}
 			delete(cfg.baselineExisting, name)
@@ -489,13 +206,17 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		} else {
 			header, err = format.ReadHeaderFile(filepath.Join(inboxNew, name))
 		}
-		if err != nil && os.IsNotExist(err) {
-			continue
-		}
-		currentPending[name] = pendingInfo
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
 			// Count corrupt messages too
-			messages = append(messages, wakeMsgInfo{from: "unknown", subject: "(parse error)"})
+			messages = append(messages, wakeMsgInfo{
+				id:      strings.TrimSuffix(name, filepath.Ext(name)),
+				from:    "unknown",
+				subject: "(parse error)",
+			})
+			senderCounts["unknown"]++
 			continue
 		}
 
@@ -509,6 +230,7 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		priority := strings.TrimSpace(header.Priority)
 
 		info := wakeMsgInfo{
+			id:       header.ID,
 			from:     from,
 			subject:  subject,
 			priority: priority,
@@ -516,6 +238,7 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 
 		messages = append(messages, info)
+		senderCounts[from]++
 
 		if cfg.interrupt && isInterruptMessage(info, cfg) {
 			interruptMessages = append(interruptMessages, info)
@@ -523,51 +246,35 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 	}
 
-	if cfg.inputRecoveryRequired &&
-		dischargeWakeInputRecoveryAfterProgress(cfg, currentPending) &&
-		len(messages) == 0 {
+	if len(messages) == 0 {
 		return nil
 	}
-	if len(messages) == 0 {
-		if cfg.inputRecoveryRequired {
-			return deliverWakeInputRecoveryAttention(
-				cfg,
-				currentPending,
-			)
-		}
-		cfg.doorbell.reset()
-		persistWakeDoorbellStatusBestEffort(cfg)
-		return reconcileWakeInputAfterInboxDrain(cfg)
+	messageIDs := wakeMessageIDs(messages)
+
+	// A supervised/co-op wake is only a fixed doorbell. Message headers,
+	// session names, custom notices, commands, and urgency never become
+	// terminal input.
+	if usesCoopDoorbell(cfg) {
+		return attemptNotification(cfg, messageIDs, coopWakeDoorbell, len(interruptMessages) == 0)
 	}
 
 	if cfg.interrupt && len(interruptMessages) > 0 {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
-		notice := peerWakeNotification(interruptText)
-		if cfg.interruptNotice != "" {
-			notice = operatorWakeNotification(interruptText)
-		}
-		if cfg.inputRecoveryRequired {
-			return deliverNewMessageNotification(cfg, notice, false, currentPending)
-		}
 		if cfg.injectMode == wakeInjectModeNone {
-			return deliverNewMessageNotification(cfg, notice, false, currentPending)
+			bell := cfg.bell
+			cfg.bell = true
+			err := attemptNotification(cfg, messageIDs, interruptText, false)
+			cfg.bell = bell
+			return err
 		}
 		now := time.Now()
-		if !usesCoopDoorbell(cfg) &&
-			cfg.interruptKey != "" &&
-			shouldInterruptNow(cfg, now) {
+		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
 			if cfg.injectVia != "" {
 				allowed, guardErr := authorizeTerminalWrite(cfg)
 				if guardErr != nil {
 					return guardErr
 				}
 				if allowed {
-					// Exit zero is the strongest acceptance evidence the v0
-					// external transport exposes. It cannot prove the provider
-					// delivered the key, but advancing the cooldown bounds
-					// duplicate control-key injection. A false-success provider
-					// may therefore suppress one genuine interrupt until the
-					// next window; stronger evidence needs a structured protocol.
 					if err := injectVia(cfg, cfg.interruptKey); err == nil {
 						cfg.lastInterrupt = now
 						time.Sleep(50 * time.Millisecond)
@@ -581,394 +288,73 @@ func notifyNewMessages(cfg *wakeConfig) error {
 						return writeErr
 					}
 				}
-				// The raw path can require positive terminal-write evidence
-				// instead of inferring acceptance from a process exit status.
 				if writeErr == nil && wrote {
 					cfg.lastInterrupt = now
 					time.Sleep(50 * time.Millisecond)
 				}
 			}
 		}
-		return deliverNewMessageNotification(cfg, notice, false, currentPending)
+		return attemptNotification(cfg, messageIDs, interruptText, false)
 	}
 
-	var notice wakeNotification
+	// Build notification text
+	var text string
 	if cfg.injectCmd != "" {
-		// Power user mode: inject the operator-authored command.
-		text := "\n" + sanitizeForTTY(cfg.injectCmd) + "\n"
-		notice = operatorWakeNotification(text)
+		// Power user mode: inject actual command
+		text = "\n" + cfg.injectCmd + "\n"
 	} else {
-		notice = peerWakeNotification(
-			buildNotificationText(cfg.session, messages, cfg.previewLen),
-		)
+		// Default: informational notice
+		text = buildNotificationText(cfg.session, messages, senderCounts, cfg.previewLen)
 	}
 
-	return deliverNewMessageNotification(cfg, notice, true, currentPending)
+	return attemptNotification(cfg, messageIDs, text, true)
 }
 
-func deliverNewMessageNotification(
-	cfg *wakeConfig,
-	notice wakeNotification,
-	deferForInput bool,
-	currentPending map[string]os.FileInfo,
-) error {
-	if cfg.inputRecoveryRequired {
-		if !dischargeWakeInputRecoveryAfterProgress(cfg, currentPending) {
-			return deliverWakeInputRecoveryAttention(cfg, currentPending)
-		}
-		if len(currentPending) == 0 {
-			return nil
+func wakeMessageIDs(messages []wakeMsgInfo) []string {
+	ids := make([]string, 0, len(messages))
+	for _, message := range messages {
+		if strings.TrimSpace(message.id) != "" {
+			ids = append(ids, message.id)
 		}
 	}
-	if cfg.injectMode == wakeInjectModeNone {
-		if cfg.inputDelivery.blocksDemotion() {
-			return &wakeInputDemotionBlockedError{
-				err: errors.New("input mode became none before retained terminal input completed"),
-			}
-		}
-		clearWakeInputState(cfg)
-	}
-	now := cfg.wakeDoorbellNow()
-	plan := cfg.doorbell.plan(now, currentPending)
-	persistWakeDoorbellStatusBestEffort(cfg)
-	if !plan.attempt {
-		return nil
-	}
-	if plan.progress && cfg.inputDelivery.pending() {
-		if err := reconcileWakeInputAfterInboxDrain(cfg); err != nil {
-			return err
-		}
-		if cfg.inputDelivery.pending() {
-			return nil
-		}
-	}
-	ownerBound := usesCoopDoorbell(cfg)
-	if cfg.injectMode != wakeInjectModeNone {
-		retainedInputPending := cfg.inputDelivery.pending()
-		if ownerBound {
-			notice.input = wakePayload{
-				text:       plan.prompt,
-				provenance: wakePayloadSystemFixed,
-			}
-		}
-		notice.submitOnly = plan.submitOnly
-		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
-		if isWakeInputDemotionBlocked(deliveryErr) {
-			return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
-		}
-		if cfg.injectMode == wakeInjectModeNone {
-			clearWakeInputState(cfg)
-			if shouldRecordWakeAttempt(deliveryErr) {
-				recordWakeAttempt(
-					cfg,
-					cfg.wakeDoorbellNow(),
-					currentPending,
-					deliveryErr,
-				)
-			}
-			return deliveryErr
-		}
-		if shouldRecordWakeAttempt(deliveryErr) {
-			if !plan.submitOnly &&
-				(!plan.contentChange || !retainedInputPending) &&
-				wakeInputAttemptConfirmed(cfg, deliveryErr) {
-				cfg.doorbell.confirmPresentation()
-			}
-			recordWakeAttempt(
-				cfg,
-				cfg.wakeDoorbellNow(),
-				currentPending,
-				deliveryErr,
-			)
-		}
-		return deliveryErr
-	}
-
-	deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
-	if isWakeInputDemotionBlocked(deliveryErr) {
-		return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
-	}
-	if shouldRecordWakeAttempt(deliveryErr) {
-		recordWakeAttempt(
-			cfg,
-			cfg.wakeDoorbellNow(),
-			currentPending,
-			deliveryErr,
-		)
-	}
-	return deliveryErr
+	return ids
 }
 
-func wakeInputAttemptConfirmed(cfg *wakeConfig, deliveryErr error) bool {
-	return deliveryErr == nil &&
-		cfg.injectMode != wakeInjectModeNone &&
-		!cfg.inputDelivery.pending() &&
-		!cfg.lastAttemptAttention &&
-		!cfg.lastAttemptTransientAttention
-}
-
-func recordWakeAttempt(
-	cfg *wakeConfig,
-	now time.Time,
-	currentPending map[string]os.FileInfo,
-	deliveryErr error,
-) {
-	if len(cfg.doorbell.cohort) == 0 {
-		cfg.doorbell.arm(currentPending)
-	}
-	if cfg.retryUntil == wakeRetryUntilInjected &&
-		deliveryErr == nil &&
-		!cfg.lastAttemptAttention &&
-		!cfg.lastAttemptTransientAttention {
-		cfg.doorbell.recordInjected(currentPending)
-		return
-	}
-	var attentionErr *wakeAttentionDeliveryError
-	if cfg.lastAttemptTransientAttention {
-		// Input deferral emitted attention but made no synthetic-input attempt,
-		// so it advances cadence without consuming the finite injection budget.
-		cfg.doorbell.recordDeferredInputAttempt(now)
-	} else if cfg.lastAttemptAttention || errors.As(deliveryErr, &attentionErr) {
-		cfg.doorbell.recordAttentionAttempt(now)
-	} else {
-		cfg.doorbell.recordAttempt(now)
-	}
-	persistWakeDoorbellStatusBestEffort(cfg)
-}
-
-func shouldRecordWakeAttempt(err error) bool {
-	if err == nil {
-		return true
-	}
-	return !isWakeTerminalAuthorityLoss(err) &&
-		!isWakeTerminalPartialProgress(err) &&
-		!isWakeInputDemotionBlocked(err) &&
-		!isWakeTerminalProgressUncertain(err)
-}
-
-func deliverWakeInputRecoveryAttention(
-	cfg *wakeConfig,
-	currentPending map[string]os.FileInfo,
-) error {
-	now := cfg.wakeDoorbellNow()
-	if !cfg.doorbell.planRecoveryAttention(now, currentPending) {
-		return nil
-	}
-	cfg.doorbell.recordRecoveryRequired(now, currentPending)
-	persistWakeDoorbellStatusBestEffort(cfg)
-	if err := emitWakeAttention(cfg, wakePayload{
-		text:       wakeInputRecoveryNotice,
-		provenance: wakePayloadSystemFixed,
-	}); err != nil {
-		return err
-	}
-	cfg.doorbell.recordRecoveryAttentionDelivered()
-	if len(currentPending) == 0 {
-		cfg.doorbell.noteRecoveryInboxEmpty()
-	}
-	return nil
-}
-
-func enterWakeInputRecovery(
-	cfg *wakeConfig,
-	currentPending map[string]os.FileInfo,
-	cause error,
-) error {
-	markWakeInputRecoveryRequired(cfg, cause)
-	if err := deliverWakeInputRecoveryAttention(cfg, currentPending); err != nil {
-		return errors.Join(cause, err)
-	}
-	return nil
-}
-
-func markWakeInputRecoveryRequired(cfg *wakeConfig, cause error) {
-	cfg.inputRecoveryRequired = true
-	mode := effectiveInjectMode(cfg)
-	reason := wakeInputRecoveryNotice
-	if cause != nil {
-		reason += ": " + cause.Error()
-	}
-	if err := persistWakeNotifierStatus(
-		cfg,
-		wakeInputRecoveryRequiredStatus,
-		mode,
-		reason,
-	); err != nil {
-		_ = writeWakeDiagnostic(cfg, "amq wake: record input recovery-required status: %v\n", err)
-	}
-}
-
-func dischargeWakeInputRecoveryAfterProgress(
-	cfg *wakeConfig,
-	currentPending map[string]os.FileInfo,
-) bool {
-	if cfg == nil || !cfg.inputRecoveryRequired {
-		return false
-	}
-	progressed := len(currentPending) == 0
-	if !progressed && cfg.doorbell.phase == wakeDoorbellRecoveryRequired {
-		progressed = wakeCohortProgressed(cfg.doorbell.cohort, currentPending)
-	}
-	if !progressed {
-		return false
-	}
-
-	// Durable consumer progress proves that the composer state changed after
-	// the uncertain write. Never resume the old suffix: discard that debt and
-	// let any remaining cohort start with one fresh, complete doorbell. This
-	// accepts bounded composer noise over a permanently undriven session, while
-	// preserving the no-stacking rule for the old partial payload.
-	cfg.inputRecoveryRequired = false
-	clearWakeInputState(cfg)
-	cfg.doorbell.reset()
-	persistWakeDoorbellStatusBestEffort(cfg)
-	if err := persistWakeNotifierStatus(cfg, "", effectiveInjectMode(cfg), ""); err != nil {
-		_ = writeWakeDiagnostic(cfg, "amq wake: clear input recovery-required status: %v\n", err)
-	}
-	return true
-}
-
-func persistWakeNotifierStatus(cfg *wakeConfig, status, mode, reason string) error {
-	if cfg == nil || cfg.recordNotifierStatus == nil {
-		return nil
-	}
-	desired := &wakeNotifierStatus{status: status, mode: mode, reason: reason}
-	if err := cfg.recordNotifierStatus(status, mode, reason); err != nil {
-		cfg.pendingNotifierStatus = desired
-		return err
-	}
-	cfg.pendingNotifierStatus = nil
-	return nil
-}
-
-func retryPendingWakeNotifierStatus(cfg *wakeConfig) error {
-	if cfg == nil || cfg.pendingNotifierStatus == nil {
-		return nil
-	}
-	pending := cfg.pendingNotifierStatus
-	return persistWakeNotifierStatus(cfg, pending.status, pending.mode, pending.reason)
-}
-
-func persistWakeDoorbellStatusBestEffort(cfg *wakeConfig) {
-	if err := persistWakeDoorbellStatus(cfg); err != nil {
-		_ = writeWakeDiagnostic(cfg, "amq wake: persist doorbell parked status: %v; retrying\n", err)
-	}
-}
-
-func persistWakeDoorbellStatus(cfg *wakeConfig) error {
-	if cfg == nil || cfg.recordDoorbellStatus == nil {
-		return nil
-	}
-	attempts, parked := cfg.doorbell.parkedReminderAttempts()
-	desired := wakeDoorbellStatus{parked: parked, attempts: attempts}
-	if !parked {
-		desired.attempts = 0
-	}
-	if cfg.pendingDoorbellStatus == nil && desired == cfg.reportedDoorbellStatus {
-		return nil
-	}
-	if err := cfg.recordDoorbellStatus(desired.parked, desired.attempts); err != nil {
-		cfg.pendingDoorbellStatus = &desired
-		return err
-	}
-	cfg.reportedDoorbellStatus = desired
-	cfg.pendingDoorbellStatus = nil
-	return nil
-}
-
-func retryPendingWakeDoorbellStatus(cfg *wakeConfig) error {
-	if cfg == nil || cfg.pendingDoorbellStatus == nil || cfg.recordDoorbellStatus == nil {
-		return nil
-	}
-	pending := *cfg.pendingDoorbellStatus
-	if err := cfg.recordDoorbellStatus(pending.parked, pending.attempts); err != nil {
-		return err
-	}
-	cfg.reportedDoorbellStatus = pending
-	cfg.pendingDoorbellStatus = nil
-	return nil
-}
-
-func (cfg *wakeConfig) wakeDoorbellNow() time.Time {
-	if cfg.doorbellNow != nil {
-		return cfg.doorbellNow()
-	}
-	return time.Now()
-}
-
-func snapshotWakeFileIdentities(current map[string]os.FileInfo) map[string]*wakeFileIdentity {
-	snapshot := make(map[string]*wakeFileIdentity, len(current))
-	for name, info := range current {
-		if info == nil {
-			snapshot[name] = nil
-			continue
-		}
-		if identity, ok := captureWakeFileIdentity(info); ok {
-			snapshot[name] = &identity
-			continue
-		}
-		snapshot[name] = nil
-	}
-	return snapshot
-}
-
-func sameKnownWakeCohort(
-	previous map[string]*wakeFileIdentity,
-	current map[string]os.FileInfo,
-) bool {
-	if len(previous) == 0 || len(previous) != len(current) {
-		return false
-	}
-	for name, previousIdentity := range previous {
-		info, exists := current[name]
-		if !exists || previousIdentity == nil || info == nil {
-			return false
-		}
-		currentIdentity, known := captureWakeFileIdentity(info)
-		if !known || currentIdentity != *previousIdentity {
-			return false
-		}
-	}
-	return true
-}
-
-func buildNotificationText(session string, messages []wakeMsgInfo, previewLen int) string {
+func buildNotificationText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int) string {
 	count := len(messages)
 	prefix := notificationPrefix("AMQ", session)
+
 	if count == 1 {
+		// Single message: show from + truncated subject
 		msg := messages[0]
 		subject := msg.subject
 		if subject == "" {
 			subject = "(no subject)"
 		}
-		return fmt.Sprintf(
-			"%s: message from %s - %s. Drain with: amq drain --include-body — then act on it",
-			prefix,
-			msg.from,
-			truncateSubject(subject, previewLen),
-		)
+		subject = truncateSubject(subject, previewLen)
+		return fmt.Sprintf("%s: message from %s - %s. Drain with: amq drain --include-body — then act on it", prefix, msg.from, subject)
 	}
 
-	senderCounts := make(map[string]int)
-	for _, msg := range messages {
-		senderCounts[msg.from]++
-	}
+	// Multiple messages: show counts by sender
+	var parts []string
 	senders := make([]string, 0, len(senderCounts))
-	for sender := range senderCounts {
-		senders = append(senders, sender)
+	for s := range senderCounts {
+		senders = append(senders, s)
 	}
 	sort.Strings(senders)
-	return fmt.Sprintf(
-		"%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
-		prefix,
-		count,
-		strings.Join(buildWakeSenderClauses(senders, senderCounts), ", "),
-	)
+
+	for _, sender := range senders {
+		c := senderCounts[sender]
+		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
+	}
+
+	return fmt.Sprintf("%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
+		prefix, count, strings.Join(parts, ", "))
 }
 
 func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int, custom string) string {
 	if custom != "" {
-		return sanitizeForTTY(custom)
+		return custom
 	}
 
 	count := len(messages)
@@ -985,30 +371,18 @@ func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map
 			prefix, msg.from, subject)
 	}
 
+	var parts []string
 	senders := make([]string, 0, len(senderCounts))
 	for s := range senderCounts {
 		senders = append(senders, s)
 	}
 	sort.Strings(senders)
-	parts := buildWakeSenderClauses(senders, senderCounts)
+	for _, sender := range senders {
+		c := senderCounts[sender]
+		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
+	}
 	return fmt.Sprintf("%s: %d urgent messages - %s. Drain with: amq drain --include-body — then act on it",
 		prefix, count, strings.Join(parts, ", "))
-}
-
-func buildWakeSenderClauses(senders []string, senderCounts map[string]int) []string {
-	limit := min(len(senders), maxWakeNotificationSenderClauses)
-	parts := make([]string, 0, limit+1)
-	for _, sender := range senders[:limit] {
-		parts = append(parts, fmt.Sprintf("%d from %s", senderCounts[sender], sender))
-	}
-	if omitted := len(senders) - limit; omitted > 0 {
-		label := "senders"
-		if omitted == 1 {
-			label = "sender"
-		}
-		parts = append(parts, fmt.Sprintf("%d other %s", omitted, label))
-	}
-	return parts
 }
 
 // notificationPrefix builds "AMQ [session]" or just "AMQ" when session is empty.
@@ -1065,18 +439,14 @@ func effectiveInjectMode(cfg *wakeConfig) string {
 		// Enter swallowing in some CLIs. Paste mode remains available via flag.
 		// Claude Code's Ink framework has buggy bracketed paste handling where CR gets
 		// coalesced with the paste-end sequence and swallowed by the input parser.
-		if wakeUsesAlternateScreenTUI(cfg.me) {
+		meLower := strings.ToLower(cfg.me)
+		if strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex") {
 			mode = wakeInjectModeRaw
 		} else {
 			mode = wakeInjectModePaste
 		}
 	}
 	return mode
-}
-
-func wakeUsesAlternateScreenTUI(me string) bool {
-	meLower := strings.ToLower(me)
-	return strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex")
 }
 
 func normalizeWakeInjectMode(raw string) (string, error) {
@@ -1092,295 +462,214 @@ func normalizeWakeInjectMode(raw string) (string, error) {
 	}
 }
 
-// injectNotification preserves the legacy test/internal string helper. New
-// production routing uses deliverWakeNotification so input and output sources
-// remain explicit.
-func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
-	payload := wakePayload{
-		text:       text,
-		provenance: wakePayloadSystemFixed,
-	}
-	return deliverWakeNotification(
-		cfg,
-		wakeNotification{input: payload, output: payload},
-		deferForInput,
-	)
+func writeWakeOutput(text string, bell bool) {
+	_ = writeWakeOutputChecked(text, bell)
 }
 
-func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
-	cfg.lastAttemptAttention = false
-	cfg.lastAttemptTransientAttention = false
-	ownerBound := usesCoopDoorbell(cfg)
-	if ownerBound {
-		if notice.submitOnly && notice.input.provenance == wakePayloadSystemFixed {
-			// A submit-only reminder is system-created from cohort state. It has
-			// no payload text to validate or replace.
-		} else if validCoopWakeDoorbell(notice.input.text) {
-			// The fixed doorbell is system-created before delivery.
-		} else {
-			notice.input = wakePayload{
-				text:       coopWakeDoorbell,
-				provenance: wakePayloadSystemFixed,
-			}
-		}
+func writeWakeOutputChecked(text string, bell bool) error {
+	if bell {
+		text = "\a" + text
 	}
-	if cfg.injectMode == wakeInjectModeNone {
-		return deliverWakeAttentionOnly(cfg, notice.output)
+	output := text + "\n"
+	n, err := fmt.Fprint(os.Stderr, output)
+	if err != nil {
+		return err
+	}
+	if n != len(output) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func attemptNotification(cfg *wakeConfig, messageIDs []string, text string, deferForInput bool) error {
+	writer := notificationattempt.NewWriter(cfg.root, cfg.me)
+	prepared, prepareErr := writer.Prepare(messageIDs, notificationAttemptMode(cfg))
+	if prepareErr != nil && cfg.debug {
+		_ = writeStderr("amq wake [debug]: persist prepared notification attempt: %v\n", prepareErr)
 	}
 
-	inputText := notice.input.text
-	if notice.submitOnly {
-		inputText = ""
+	err := injectNotification(cfg, text, deferForInput)
+	if prepareErr == nil {
+		outcome := notificationattempt.OutcomeFailed
+		if cfg.notificationWritten {
+			outcome = notificationattempt.OutcomeWritten
+		}
+		if resultErr := writer.Result(prepared, outcome, cfg.notificationDetail); resultErr != nil && cfg.debug {
+			_ = writeStderr("amq wake [debug]: persist notification attempt result: %v\n", resultErr)
+		}
 	}
-	plainText := inputText
-	if notice.submitOnly {
-		plainText = "\r"
+	return err
+}
+
+func notificationAttemptMode(cfg *wakeConfig) string {
+	if cfg.injectMode == wakeInjectModeNone {
+		return "stderr"
 	}
+	if cfg.injectVia != "" {
+		return "external"
+	}
+	return effectiveInjectMode(cfg)
+}
+
+func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
+	cfg.notificationWritten = false
+	cfg.notificationDetail = ""
+	ownerBound := usesCoopDoorbell(cfg)
+	if ownerBound {
+		text = coopWakeDoorbell
+	}
+	if cfg.injectMode == wakeInjectModeNone {
+		if err := writeWakeOutputChecked(text, cfg.bell && !ownerBound); err != nil {
+			cfg.notificationDetail = err.Error()
+		} else {
+			cfg.notificationWritten = true
+			cfg.notificationDetail = "notification bytes written to stderr"
+		}
+		return nil
+	}
+
+	// Keep plain text for stderr fallback
+	plainText := text
 	if cfg.bell && !ownerBound {
 		plainText = "\a" + plainText
 	}
 
 	if shouldDeferBeforeInject(cfg, deferForInput) {
-		if !waitForWakeInputQuiet(cfg) {
-			return deliverWakeTransientAttention(cfg, notice.output, nil)
-		}
+		waitForTTYInputQuiet(cfg)
 	}
 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
-	// The command receives the notification text as its last argument. Exit zero
-	// remains presentation-confirmation evidence. Post-text Enter/submit failure
-	// is encoded in child output as AMQ_INJECT_PROGRESS=uncertain; that path
-	// must not replay the payload.
+	// The command receives the notification text as its last argument.
 	if cfg.injectVia != "" {
-		if cfg.inputDelivery.acceptanceUncertain {
-			return &wakeInputDemotionBlockedError{
-				err: errors.New("a prior terminal write has uncertain acceptance"),
-			}
-		}
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {
-			return deliverWakeAttentionAfterInputRefusal(
-				cfg,
-				notice.output,
-				guardErr,
-			)
+			return guardErr
 		}
 		if !allowed {
-			return deliverWakeAttentionOnly(cfg, notice.output)
+			cfg.notificationDetail = "terminal write was not authorized"
+			return nil
 		}
 		if err := injectVia(cfg, plainText); err != nil {
-			var uncertain *wakeTerminalProgressUncertainError
-			if errors.As(err, &uncertain) {
-				cfg.inputDelivery.acceptanceUncertain = true
-				_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
-				cfg.fallbackWarn = false
-				return &wakeInputDemotionBlockedError{err: uncertain}
-			}
 			if cfg.fallbackWarn {
-				_ = writeWakeDiagnostic(cfg, "amq wake: --inject-via failed: %v\n", err)
-				_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
+				_ = writeStderr("amq wake: --inject-via failed: %v\n", err)
+				_ = writeStderr("amq wake: falling back to stderr notification\n")
 				cfg.fallbackWarn = false
 			}
-			return deliverWakeAttentionOnly(cfg, notice.output)
+			if fallbackErr := writeWakeOutputChecked(plainText, false); fallbackErr != nil {
+				cfg.notificationDetail = fmt.Sprintf("external notifier failed: %v; stderr fallback failed: %v", err, fallbackErr)
+			} else {
+				cfg.notificationWritten = true
+				cfg.notificationDetail = "external notifier failed; notification bytes written to stderr fallback"
+			}
+		} else {
+			cfg.notificationWritten = true
+			cfg.notificationDetail = "external notifier completed successfully"
 		}
 		return nil
 	}
 
 	mode := effectiveInjectMode(cfg)
 	if cfg.debug {
-		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: mode=%s text_len=%d\n", mode, len(inputText))
+		_ = writeStderr("amq wake [debug]: mode=%s text_len=%d\n", mode, len(text))
 	}
 	var injectErr error
-	inputAccepted := false
 	switch mode {
 	case wakeInjectModeRaw:
 		// Raw mode: inject text and CR separately to avoid paste detection.
 		// Ink treats multi-char input as paste, not keypresses. Sending text+CR
 		// as one chunk makes Ink see pasted text, not an Enter keypress.
-		injectedText := inputText
+		injectedText := text
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
-		if notice.submitOnly {
-			inputAccepted, injectErr = injectTerminalSubmitOnly(cfg, wakeInjectModeRaw)
-		} else {
-			inputAccepted, injectErr = injectRawNotification(cfg, injectedText)
-		}
-		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
+		injectErr = injectRawNotification(cfg, injectedText)
 
 	case wakeInjectModePaste:
 		// Paste mode: bracketed paste with delayed CR
 		// Works with crossterm/ratatui apps
 		// Send paste content first, then CR after short delay to avoid coalescing
-		pasteText := inputText
+		pasteText := text
 		if !ownerBound {
-			pasteText = "\x1b[200~" + inputText + "\x1b[201~"
+			pasteText = "\x1b[200~" + text + "\x1b[201~"
 		}
 		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
 		}
-		if notice.submitOnly {
-			inputAccepted, injectErr = injectTerminalSubmitOnly(cfg, wakeInjectModePaste)
-		} else {
-			inputAccepted, injectErr = injectTerminalNotification(
-				cfg,
-				wakeInjectModePaste,
-				pasteText,
-			)
+		wrote, err := writeTerminalChunk(cfg, pasteText)
+		if err != nil {
+			injectErr = err
+		} else if wrote {
+			// Small delay to ensure CR lands in separate read cycle
+			time.Sleep(25 * time.Millisecond)
+			_, injectErr = writeTerminalChunk(cfg, "\r")
 		}
-		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	default:
 		// Unknown mode, fall back to raw
 		if ownerBound {
-			if notice.submitOnly {
-				inputAccepted, injectErr = writeTerminalChunk(cfg, "\r")
-			} else {
-				wrote, err := writeTerminalChunk(cfg, inputText)
-				inputAccepted = wrote
-				if err != nil {
-					injectErr = err
-				} else if wrote {
-					submitted, err := writeTerminalChunk(cfg, "\r")
-					inputAccepted = inputAccepted || submitted
-					injectErr = err
-				}
+			wrote, err := writeTerminalChunk(cfg, text)
+			if err != nil {
+				injectErr = err
+			} else if wrote {
+				_, injectErr = writeTerminalChunk(cfg, "\r")
 			}
 		} else {
-			injectedText := inputText + "\r"
+			injectedText := text + "\r"
 			if cfg.bell {
 				injectedText = "\a" + injectedText
 			}
-			inputAccepted, injectErr = writeTerminalChunk(cfg, injectedText)
+			_, injectErr = writeTerminalChunk(cfg, injectedText)
 		}
 	}
 
 	if injectErr != nil {
-		if isWakeTerminalPartialProgress(injectErr) {
-			return injectErr
-		}
-		var uncertain *wakeTerminalProgressUncertainError
-		if errors.As(injectErr, &uncertain) {
-			cfg.inputDelivery.acceptanceUncertain = true
-			_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
-			cfg.fallbackWarn = false
-			return &wakeInputDemotionBlockedError{err: uncertain}
-		}
-		if isWakeInputDemotionBlocked(injectErr) {
-			return injectErr
-		}
 		var unsupported *wakeInjectorUnsupportedError
 		if errors.As(injectErr, &unsupported) {
 			mode := effectiveInjectMode(cfg)
 			reason := wakeInjectorUnsupportedReason(mode, injectErr)
-			if err := persistWakeNotifierStatus(
-				cfg,
-				wakeInjectorUnsupportedStatus,
-				mode,
-				reason,
-			); err != nil {
-				_ = writeWakeDiagnostic(cfg, "amq wake: record unsupported injector status: %v\n", err)
+			if cfg.recordNotifierStatus != nil {
+				if err := cfg.recordNotifierStatus(
+					wakeInjectorUnsupportedStatus,
+					mode,
+					reason,
+				); err != nil {
+					_ = writeStderr("amq wake: record unsupported injector status: %v\n", err)
+				}
 			}
-			if err := disableWakeInput(cfg, injectErr); err != nil {
-				return err
-			}
-			_ = writeWakeDiagnostic(cfg, "amq wake: warning: %s\n", reason)
+			cfg.injectMode = wakeInjectModeNone
+			_ = writeStderr("amq wake: warning: %s\n", reason)
 			cfg.fallbackWarn = false
-			return deliverWakeAttentionOnly(cfg, notice.output)
+			if fallbackErr := writeWakeOutputChecked(plainText, false); fallbackErr != nil {
+				cfg.notificationDetail = fmt.Sprintf("terminal injection unsupported: %v; stderr fallback failed: %v", injectErr, fallbackErr)
+			} else {
+				cfg.notificationWritten = true
+				cfg.notificationDetail = "terminal injection unsupported; notification bytes written to stderr fallback"
+			}
+			return nil
 		}
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(injectErr, &authorityErr) {
-			if !cfg.inputDelivery.confirmedInput() {
-				return deliverWakeAttentionAfterInputRefusal(
-					cfg,
-					notice.output,
-					injectErr,
-				)
-			}
+			cfg.notificationDetail = injectErr.Error()
 			return injectErr
 		}
 		if cfg.fallbackWarn {
-			_ = writeWakeDiagnostic(cfg, "amq wake: TIOCSTI injection failed: %v\n", injectErr)
-			_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
+			_ = writeStderr("amq wake: TIOCSTI injection failed: %v\n", injectErr)
+			_ = writeStderr("amq wake: falling back to stderr notification\n")
 			cfg.fallbackWarn = false
 		}
-		// Fallback: use the output-only attention tier; never retry input.
-		return deliverWakeAttentionOnly(cfg, notice.output)
-	}
-	if !inputAccepted {
-		return deliverWakeAttentionOnly(cfg, notice.output)
-	}
-
-	return nil
-}
-
-func deliverWakeAttentionAfterInputRefusal(
-	cfg *wakeConfig,
-	payload wakePayload,
-	cause error,
-) error {
-	if isWakeTerminalForegroundPGRPChanged(cause) {
-		return deliverWakeTransientAttention(cfg, payload, cause)
-	}
-	if isWakeTerminalAuthorityLoss(cause) {
-		// A replacement wake owns both terminal input and peer-rich attention.
-		// Let an inconclusive authority check continue narrating, but never let
-		// a conclusively stale driver speak alongside its replacement.
-		return cause
-	}
-	if err := deliverWakeAttentionOnly(cfg, payload); err != nil {
-		return errors.Join(cause, err)
-	}
-	return nil
-}
-
-func deliverWakeTransientAttention(
-	cfg *wakeConfig,
-	payload wakePayload,
-	cause error,
-) error {
-	if err := authorizePeerWakeAttention(cfg, payload); err != nil {
-		return err
-	}
-	now := cfg.wakeDoorbellNow()
-	if !cfg.doorbell.transientAttentionDue(now) {
-		return cause
-	}
-	cfg.lastAttemptTransientAttention = true
-	cfg.doorbell.recordTransientAttentionAttempt(now)
-	if err := emitWakeAttention(cfg, payload); err != nil {
-		return errors.Join(cause, err)
-	}
-	return cause
-}
-
-func deliverWakeAttentionOnly(cfg *wakeConfig, payload wakePayload) error {
-	if err := authorizePeerWakeAttention(cfg, payload); err != nil {
-		return err
-	}
-	if err := emitWakeAttention(cfg, payload); err != nil {
-		return err
-	}
-	cfg.lastAttemptAttention = true
-	return nil
-}
-
-func authorizePeerWakeAttention(cfg *wakeConfig, payload wakePayload) error {
-	if cfg == nil ||
-		payload.provenance == wakePayloadSystemFixed ||
-		cfg.root == "" ||
-		cfg.me == "" ||
-		strings.TrimSpace(cfg.terminalGeneration) == "" {
+		// Fallback: print plain text to stderr (no escape sequences)
+		if fallbackErr := writeWakeOutputChecked(plainText, false); fallbackErr != nil {
+			cfg.notificationDetail = fmt.Sprintf("terminal injection failed: %v; stderr fallback failed: %v", injectErr, fallbackErr)
+		} else {
+			cfg.notificationWritten = true
+			cfg.notificationDetail = "terminal injection failed; notification bytes written to stderr fallback"
+		}
 		return nil
 	}
-	// Fence notifications fired by mailbox-cohort state, including
-	// operator-authored interrupt text. System-fixed notices describe this
-	// process's own state and remain available for diagnostics.
-	// The platform layer owns the single generation classifier. Its typed
-	// error is reserved for a missing or readable-different retained
-	// generation; false with no error parks input but keeps attention alive.
-	_, _, err := classifyWakeGenerationPlatformState(cfg)
-	return err
+
+	cfg.notificationWritten = true
+	cfg.notificationDetail = "notification bytes written to terminal input"
+	return nil
 }
 
 func usesCoopDoorbell(cfg *wakeConfig) bool {
@@ -1424,11 +713,7 @@ func authorizeTerminalWrite(cfg *wakeConfig) (bool, error) {
 		cfg.terminalWrite == nil &&
 		cfg.root != "" &&
 		cfg.me != "" {
-		allowed, err := authorizeTerminalWritePlatformState(cfg)
-		if err != nil {
-			return false, &wakeTerminalAuthorityError{err: err}
-		}
-		if !allowed {
+		if !authorizeTerminalWritePlatform(cfg) {
 			return false, nil
 		}
 	}
@@ -1464,83 +749,6 @@ func writeTerminalChunk(cfg *wakeConfig, chunk string) (bool, error) {
 	return true, tiocstiInject(chunk)
 }
 
-func writePendingWakeInputChunk(
-	cfg *wakeConfig,
-	state *wakeInputDeliveryState,
-	chunk string,
-) (bool, error) {
-	if state.acceptanceUncertain {
-		return false, &wakeInputDemotionBlockedError{
-			err: errors.New("a prior terminal write has uncertain acceptance"),
-		}
-	}
-	if state.acceptedBytes < 0 || state.acceptedBytes > len(chunk) {
-		state.acceptanceUncertain = true
-		return false, &wakeTerminalProgressUncertainError{
-			err: fmt.Errorf(
-				"invalid retained input offset %d for %d-byte chunk",
-				state.acceptedBytes,
-				len(chunk),
-			),
-		}
-	}
-	remaining := chunk[state.acceptedBytes:]
-	wrote, err := writeTerminalChunk(cfg, remaining)
-	if err == nil {
-		if wrote {
-			state.acceptedBytes = 0
-		} else if state.confirmedInput() {
-			return false, &wakeTerminalPartialProgressError{
-				err: errors.New("terminal write authorization is temporarily unavailable"),
-			}
-		}
-		return wrote, nil
-	}
-
-	var unsupported *wakeInjectorUnsupportedError
-	if errors.As(err, &unsupported) {
-		if state.blocksDemotion() {
-			return wrote, &wakeInputDemotionBlockedError{err: err}
-		}
-		return wrote, err
-	}
-	if !wrote {
-		if state.confirmedInput() {
-			return false, &wakeTerminalPartialProgressError{err: err}
-		}
-		return false, err
-	}
-
-	var progress wakeTerminalAcceptedProgress
-	if !errors.As(err, &progress) {
-		if isWakeTerminalAuthorityLoss(err) {
-			if state.confirmedInput() {
-				return true, &wakeTerminalPartialProgressError{err: err}
-			}
-			return true, err
-		}
-		state.acceptanceUncertain = true
-		return true, &wakeTerminalProgressUncertainError{err: err}
-	}
-	accepted := progress.wakeAcceptedBytes()
-	if accepted < 0 || accepted >= len(remaining) {
-		state.acceptanceUncertain = true
-		return true, &wakeTerminalProgressUncertainError{
-			err: fmt.Errorf(
-				"invalid terminal progress %d for %d-byte suffix: %w",
-				accepted,
-				len(remaining),
-				err,
-			),
-		}
-	}
-	state.acceptedBytes += accepted
-	if state.confirmedInput() {
-		return true, &wakeTerminalPartialProgressError{err: err}
-	}
-	return true, err
-}
-
 // rawSubmitPrelude returns the bytes injected between the drained notification
 // text and the settle delay. codex targets get a single LF: codex-tui maps a
 // raw 0x0A to Ctrl-J, whose editor binding routes through handle_input_basic,
@@ -1561,322 +769,111 @@ func rawSubmitPrelude(me string) string {
 	return ""
 }
 
-func clearWakeInputState(cfg *wakeConfig) {
-	cfg.inputDelivery.reset()
-}
-
-func retireWakeInputState(cfg *wakeConfig, cause error) error {
-	if cfg.inputDelivery.blocksDemotion() {
-		if cause == nil {
-			cause = errors.New("input retirement requested before terminal completion")
-		}
-		return &wakeInputDemotionBlockedError{err: cause}
+func injectRawNotification(cfg *wakeConfig, injectedText string) error {
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
 	}
-	cfg.doorbell.reset()
-	persistWakeDoorbellStatusBestEffort(cfg)
-	clearWakeInputState(cfg)
-	return nil
-}
-
-func disableWakeInput(cfg *wakeConfig, cause error) error {
-	rememberRequestedWakeInputMode(cfg)
-	if err := retireWakeInputState(cfg, cause); err != nil {
+	wrote, err := writeTerminalChunk(cfg, injectedText)
+	if err != nil {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
+		}
 		return err
 	}
-	cfg.injectMode = wakeInjectModeNone
-	cfg.legacyTIOCSTIDemoted = false
-	return nil
-}
-
-func disableWakeInputForLegacyTIOCSTI(cfg *wakeConfig, cause error) error {
-	rememberRequestedWakeInputMode(cfg)
-	if err := retireWakeInputState(cfg, cause); err != nil {
-		return err
-	}
-	cfg.injectMode = wakeInjectModeNone
-	cfg.legacyTIOCSTIDemoted = true
-	return nil
-}
-
-func rememberRequestedWakeInputMode(cfg *wakeConfig) {
-	if cfg.requestedInjectMode != "" ||
-		cfg.injectMode == "" ||
-		cfg.injectMode == wakeInjectModeNone {
-		return
-	}
-	cfg.requestedInjectMode = cfg.injectMode
-}
-
-func reconcileWakeInputAfterInboxDrain(cfg *wakeConfig) error {
-	if cfg.inputDelivery.acceptanceUncertain {
-		return &wakeInputDemotionBlockedError{
-			err: errors.New("inbox progressed after a terminal write with uncertain acceptance"),
-		}
-	}
-	if !cfg.inputDelivery.pending() {
+	if !wrote {
 		return nil
 	}
-	if cfg.inputDelivery.phase == wakeInputPayloadPending {
-		// Inbox is empty: never finish or repeat doorbell text. A queued submit
-		// may still complete so an already-presented prompt does not sit idle.
-		clearWakeInputState(cfg)
-		return nil
-	}
-	_, err := resumeWakeInputDelivery(cfg)
-	return err
-}
+	prelude := rawSubmitPrelude(cfg.me)
 
-func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
-	return injectTerminalNotification(cfg, wakeInjectModeRaw, injectedText)
-}
-
-func injectTerminalNotification(
-	cfg *wakeConfig,
-	mode string,
-	payload string,
-) (bool, error) {
-	state := &cfg.inputDelivery
-	if state.acceptanceUncertain {
-		return false, &wakeInputDemotionBlockedError{
-			err: errors.New("new terminal input arrived after a write with uncertain acceptance"),
-		}
-	}
-	if state.pending() && (state.mode != mode || state.payload != payload) {
-		if state.phase == wakeInputPayloadPending && state.acceptedBytes == 0 {
-			// The previous payload never made confirmed progress.
-			state.reset()
-		} else {
-			completed, err := resumeWakeInputDelivery(cfg)
-			if err != nil || !completed {
-				return false, err
-			}
-		}
-	}
-	if !state.pending() {
-		*state = wakeInputDeliveryState{
-			phase:   wakeInputPayloadPending,
-			mode:    mode,
-			payload: payload,
-		}
-	}
-	return resumeWakeInputDelivery(cfg)
-}
-
-func injectTerminalSubmitOnly(cfg *wakeConfig, mode string) (bool, error) {
-	state := &cfg.inputDelivery
-	if state.acceptanceUncertain {
-		return false, &wakeInputDemotionBlockedError{
-			err: errors.New("submit-only terminal input followed a write with uncertain acceptance"),
-		}
-	}
-	if state.pending() {
-		if state.mode != mode || state.payload != "" {
-			return false, &wakeInputDemotionBlockedError{
-				err: errors.New("submit-only terminal input collided with retained payload delivery"),
-			}
-		}
-		return resumeWakeInputDelivery(cfg)
-	}
-
-	// A submit-only reminder carries no fresh text and runs well after the
-	// target's paste-burst window. Reusing the Codex LF prelude here would put a
-	// literal blank line into an already-empty composer on every retry.
-	*state = wakeInputDeliveryState{
-		phase: wakeInputPrimarySubmitPending,
-		mode:  mode,
-	}
-	return resumeWakeInputDelivery(cfg)
-}
-
-func resumeWakeInputDelivery(cfg *wakeConfig) (bool, error) {
-	state := &cfg.inputDelivery
-	for state.pending() {
-		switch state.phase {
-		case wakeInputPayloadPending:
-			if cfg.debug {
-				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: injecting %d bytes of text\n", len(state.payload))
-			}
-			wrote, err := writePendingWakeInputChunk(cfg, state, state.payload)
-			if err != nil {
-				if cfg.debug {
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: text inject failed: %v\n", err)
-				}
-				return false, err
-			}
-			if !wrote {
-				return false, nil
-			}
-			if state.mode == wakeInjectModePaste {
-				state.phase = wakeInputPrimarySubmitPending
-				continue
-			}
-			if state.mode != wakeInjectModeRaw {
-				return false, fmt.Errorf("unsupported pending wake input mode %q", state.mode)
-			}
-
-			// The submit key must arrive in its own read() chunk; otherwise the
-			// TUI can treat text+Enter as pasted input instead of a keypress.
-			waited, drained, err := waitForRawInputDrained(
-				rawInjectDrainTimeout,
-				rawInjectDrainPollInterval,
-			)
-			if cfg.debug {
-				switch {
-				case err != nil:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
-				case drained:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input queue drained after %s\n", waited)
-				default:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
-				}
-			}
-			if rawSubmitPrelude(cfg.me) != "" {
-				state.phase = wakeInputRawPreludePending
-			} else {
-				state.phase = wakeInputPrimarySubmitPending
-			}
-
-		case wakeInputRawPreludePending:
-			prelude := rawSubmitPrelude(cfg.me)
-			if prelude == "" {
-				state.phase = wakeInputPrimarySubmitPending
-				continue
-			}
-			wrote, err := writePendingWakeInputChunk(cfg, state, prelude)
-			if err != nil {
-				if cfg.debug {
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: prelude inject failed: %v\n", err)
-				}
-				return false, err
-			}
-			if !wrote {
-				return false, nil
-			}
-			if cfg.debug {
-				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: prelude injected OK (%q)\n", prelude)
-			}
-			state.phase = wakeInputPrimarySubmitPending
-
-		case wakeInputPrimarySubmitPending:
-			if state.mode == wakeInjectModePaste {
-				// Keep Enter in a separate read cycle from the paste payload.
-				time.Sleep(25 * time.Millisecond)
-			} else {
-				// Hold the submit CR past the TUI's paste-burst window.
-				rawInjectSleep(rawInjectSettleDelay)
-			}
-			wrote, err := writePendingWakeInputChunk(cfg, state, "\r")
-			if err != nil {
-				if cfg.debug {
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key inject failed: %v\n", err)
-				}
-				return false, err
-			}
-			if !wrote {
-				return false, nil
-			}
-			if state.mode == wakeInjectModePaste {
-				state.reset()
-				return true, nil
-			}
-			if cfg.debug {
-				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key injected OK\n")
-			}
-
-			// A repeat Enter rescues a swallowed first submit. Skip it only when
-			// the first Enter is provably still queued.
-			waited, drained, drainErr := waitForRawInputDrained(
-				rawInjectCRDrainTimeout,
-				rawInjectDrainPollInterval,
-			)
-			if drainErr == nil && !drained {
-				state.phase = wakeInputRawFirstSubmitQueued
-				if cfg.debug {
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", waited)
-				}
-				return false, nil
-			}
-			// When queue inspection is unavailable, preserve the historical one
-			// spaced rescue, but retain this exact step across authority loss.
-			state.phase = wakeInputRawRescuePending
-
-		case wakeInputRawFirstSubmitQueued:
-			waited, drained, err := waitForRawInputDrained(
-				rawInjectCRDrainTimeout,
-				rawInjectDrainPollInterval,
-			)
-			if cfg.debug {
-				switch {
-				case err != nil:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
-				case !drained:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
-				}
-			}
-			if err != nil || !drained {
-				return false, nil
-			}
-			state.phase = wakeInputRawRescuePending
-
-		case wakeInputRawRescuePending:
-			rawInjectSleep(rawInjectSettleDelay)
-			wrote, err := writePendingWakeInputChunk(cfg, state, "\r")
-			if err != nil {
-				if cfg.debug {
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit inject failed: %v\n", err)
-				}
-				return false, err
-			}
-			if !wrote {
-				return false, nil
-			}
-			if cfg.debug {
-				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit injected OK\n")
-			}
-			waited, drained, drainErr := waitForRawInputDrained(
-				rawInjectCRDrainTimeout,
-				rawInjectDrainPollInterval,
-			)
-			if drainErr != nil {
-				// Queue inspection is best-effort. A successful write remains
-				// the strongest available completion evidence.
-				state.reset()
-				return true, nil
-			}
-			if !drained {
-				state.phase = wakeInputRawRescueQueued
-				if cfg.debug {
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit still queued after %s; waiting for terminal reader\n", waited)
-				}
-				return false, nil
-			}
-			state.reset()
-			return true, nil
-
-		case wakeInputRawRescueQueued:
-			waited, drained, err := waitForRawInputDrained(
-				rawInjectCRDrainTimeout,
-				rawInjectDrainPollInterval,
-			)
-			if cfg.debug {
-				switch {
-				case err != nil:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
-				case !drained:
-					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
-				}
-			}
-			if err != nil || !drained {
-				return false, nil
-			}
-			state.reset()
-			return true, nil
-
+	// The submit key must arrive in its own read() chunk; otherwise the TUI can
+	// treat text+Enter as pasted input instead of a keypress. Waiting for the
+	// text bytes to drain keeps the submit key out of a paste-shaped chunk even
+	// when the reader stalls (#208).
+	waited, drained, err := waitForRawInputDrained(rawInjectDrainTimeout, rawInjectDrainPollInterval)
+	if cfg.debug {
+		switch {
+		case err != nil:
+			_ = writeStderr("amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
+		case drained:
+			_ = writeStderr("amq wake [debug]: input queue drained after %s\n", waited)
 		default:
-			return false, fmt.Errorf("invalid pending wake input phase %d", state.phase)
+			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
 		}
 	}
-	return true, nil
+
+	// Prelude (codex: a lone LF) clears the TUI's paste-burst state while the
+	// injected text is fresh; its newline is trimmed from the submitted payload.
+	if prelude != "" {
+		wrote, err := writeTerminalChunk(cfg, prelude)
+		if err != nil {
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: prelude inject failed: %v\n", err)
+			}
+			return err
+		}
+		if !wrote {
+			return nil
+		}
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: prelude injected OK (%q)\n", prelude)
+		}
+	}
+
+	// Hold the submit CR past the TUI's paste-burst window (see
+	// rawInjectSettleDelay) so it is classified as a real Enter keypress, not a
+	// pasted newline.
+	rawInjectSleep(rawInjectSettleDelay)
+
+	wrote, err = writeTerminalChunk(cfg, "\r")
+	if err != nil {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
+		}
+		return err
+	}
+	if !wrote {
+		return nil
+	}
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
+	}
+
+	// Rescue submit: if the first Enter was swallowed anyway (input buffer
+	// flush or a burst-window race), a repeat Enter submits the composer; if
+	// the first already submitted, Enter on an empty composer is a no-op. The
+	// rescue must be spaced a full settle delay after the first: a swallowed
+	// Enter re-extends codex-tui's 120ms suppress window, so a faster rescue
+	// would be swallowed too. Skip the rescue only when the first submit key is
+	// provably still queued — a second would coalesce with it into one
+	// paste-shaped chunk and both would be swallowed.
+	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
+	if crErr == nil && !crDrained {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", crWaited)
+		}
+		return nil
+	}
+	rawInjectSleep(rawInjectSettleDelay)
+	wrote, err = writeTerminalChunk(cfg, "\r")
+	if err != nil {
+		// The text and first submit key were already delivered; the rescue is
+		// best-effort unless exact terminal authority was lost.
+		var authorityErr *wakeTerminalAuthorityError
+		if errors.As(err, &authorityErr) {
+			return err
+		}
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
+		}
+		return nil
+	}
+	if !wrote {
+		return nil
+	}
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
+	}
+	return nil
 }
 
 func waitForInputQueueDrain(
@@ -1919,7 +916,7 @@ func waitForInputQueueDrain(
 
 func injectVia(cfg *wakeConfig, text string) error {
 	if cfg.debug {
-		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
+		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
 	}
 
 	executable := strings.TrimSpace(cfg.injectVia)
@@ -1941,29 +938,17 @@ func injectVia(cfg *wakeConfig, text string) error {
 	args := append([]string{}, cfg.injectArgs...)
 	args = append(args, text)
 	cmd := exec.CommandContext(ctx, executable, args...)
-	waitDelay := timeout / 10
-	if waitDelay <= 0 {
-		waitDelay = time.Millisecond
-	}
-	if waitDelay > 100*time.Millisecond {
-		waitDelay = 100 * time.Millisecond
-	}
-	cmd.WaitDelay = waitDelay
-	out, runErr := cmd.CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded || errors.Is(runErr, exec.ErrWaitDelay) {
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
+			}
+			return fmt.Errorf("inject-via timed out after %s", timeout)
+		}
 		if cfg.debug {
-			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
+			_ = writeStderr("amq wake [debug]: inject-via failed: %v (%s)\n", err, string(out))
 		}
-		return fmt.Errorf("inject-via timed out after %s", timeout)
-	}
-	if runErr != nil {
-		if cfg.debug {
-			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via failed: %v (%s)\n", runErr, string(out))
-		}
-		if strings.Contains(string(out), "AMQ_INJECT_PROGRESS=uncertain") {
-			return &wakeTerminalProgressUncertainError{err: runErr}
-		}
-		return runErr
+		return err
 	}
 
 	return nil

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,51 +17,132 @@ import (
 )
 
 type wakeConfig struct {
-	me                   string
-	root                 string
-	session              string
-	injectCmd            string
-	injectVia            string // external command for injection (replaces TIOCSTI)
-	injectArgs           []string
-	wakeOwner            *wakeOwner
-	injectTimeout        time.Duration
-	bell                 bool
-	debounce             time.Duration
-	previewLen           int
-	strict               bool
-	fallbackWarn         bool
-	injectMode           string // auto, raw, paste
-	debug                bool
-	deferWhileInput      bool
-	inputQuietFor        time.Duration
-	inputPollInterval    time.Duration
-	inputMaxHold         time.Duration
-	interrupt            bool
-	interruptLabel       string
-	interruptPriority    string
-	interruptKey         string
-	interruptNotice      string
-	interruptCooldown    time.Duration
-	lastInterrupt        time.Time
-	controlStop          <-chan struct{}
-	beforeTerminalWrite  func() error
-	terminalWrite        func(string) error
-	terminalGeneration   string
-	terminalTTY          string
-	baselineRequested    bool
-	baselineInherited    bool
-	baselineExisting     map[string]wakeFileIdentity
-	onBaselineReady      func(map[string]wakeFileIdentity) error
-	onPrepared           func(wakeAdmissionWatcher) error
-	retainedInbox        wakeInboxReader
-	touchPresence        func() error
-	recordNotifierStatus func(status, mode, reason string) error
-	notificationWritten  bool
-	notificationDetail   string
+	me                            string
+	root                          string
+	session                       string
+	injectCmd                     string
+	injectVia                     string // external command for injection (replaces TIOCSTI)
+	injectArgs                    []string
+	wakeOwner                     *wakeOwner
+	injectTimeout                 time.Duration
+	bell                          bool
+	debounce                      time.Duration
+	previewLen                    int
+	strict                        bool
+	fallbackWarn                  bool
+	injectMode                    string // auto, raw, paste
+	requestedInjectMode           string
+	retryUntil                    string
+	legacyTIOCSTIDemoted          bool
+	debug                         bool
+	deferWhileInput               bool
+	inputQuietFor                 time.Duration
+	inputPollInterval             time.Duration
+	inputMaxHold                  time.Duration
+	interrupt                     bool
+	interruptLabel                string
+	interruptPriority             string
+	interruptKey                  string
+	interruptNotice               string
+	interruptCooldown             time.Duration
+	lastInterrupt                 time.Time
+	controlStop                   <-chan struct{}
+	restartSignals                chan os.Signal
+	beforeTerminalWrite           func() error
+	terminalWrite                 func(string) error
+	inspectTerminalGeneration     func() wakeLockInspection
+	terminalGeneration            string
+	terminalImageVersion          string
+	terminalTTY                   string
+	selfUpgrade                   wakeSelfUpgradeState
+	baselineRequested             bool
+	baselineInherited             bool
+	baselineExisting              map[string]wakeFileIdentity
+	inputDelivery                 wakeInputDeliveryState
+	inputRecoveryRequired         bool
+	doorbell                      wakeDoorbellState
+	doorbellNow                   func() time.Time
+	lastAttemptAttention          bool
+	lastAttemptTransientAttention bool
+	onBaselineReady               func(map[string]wakeFileIdentity) error
+	onPrepared                    func(wakeAdmissionWatcher) error
+	retainedAgent                 wakeRetainedAgent
+	retainedInbox                 wakeInboxReader
+	touchPresence                 func() error
+	maintenanceTicks              <-chan time.Time
+	maintenanceOutputs            []*os.File
+	preconditionCheck             func(*wakeConfig) error
+	onPendingNotify               func()
+	onNotificationAttemptComplete func()
+	recordNotifierStatus          func(status, mode, reason string) error
+	pendingNotifierStatus         *wakeNotifierStatus
+	recordDoorbellStatus          func(parked bool, attempts uint) error
+	pendingDoorbellStatus         *wakeDoorbellStatus
+	reportedDoorbellStatus        wakeDoorbellStatus
+	recordAttention               func(wakeAttentionEmission) error
+	attentionEnv                  func(string) string
+	attentionIsTTY                func() bool
+	attentionWrite                func([]byte) (int, error)
+	diagnosticIsTTY               func() bool
+}
+
+type wakeNotifierStatus struct {
+	status string
+	mode   string
+	reason string
+}
+
+type wakeDoorbellStatus struct {
+	parked   bool
+	attempts uint
+}
+
+const maxWakeNotificationSenderClauses = 8
+
+type wakeInputDeliveryPhase uint8
+
+const (
+	wakeInputDeliveryIdle wakeInputDeliveryPhase = iota
+	wakeInputPayloadPending
+	wakeInputRawPreludePending
+	wakeInputPrimarySubmitPending
+	wakeInputRawFirstSubmitQueued
+	wakeInputRawRescuePending
+	wakeInputRawRescueQueued
+)
+
+type wakeInputDeliveryState struct {
+	phase               wakeInputDeliveryPhase
+	mode                string
+	payload             string
+	acceptedBytes       int
+	acceptanceUncertain bool
+}
+
+func (state *wakeInputDeliveryState) reset() {
+	*state = wakeInputDeliveryState{}
+}
+
+func (state wakeInputDeliveryState) pending() bool {
+	return state.phase != wakeInputDeliveryIdle
+}
+
+func (state wakeInputDeliveryState) confirmedInput() bool {
+	return state.acceptedBytes > 0 ||
+		(state.phase != wakeInputDeliveryIdle &&
+			state.phase != wakeInputPayloadPending)
+}
+
+func (state wakeInputDeliveryState) blocksDemotion() bool {
+	return state.confirmedInput() || state.acceptanceUncertain
 }
 
 type wakeAdmissionWatcher interface {
 	Errors() <-chan error
+}
+
+type wakeRetainedAgent interface {
+	isWakeRetainedAgent()
 }
 
 type wakeInboxReader interface {
@@ -70,12 +150,85 @@ type wakeInboxReader interface {
 	ReadHeader(name string) (format.Header, error)
 }
 
+type wakeInboxFileInfoReader interface {
+	FileInfo(name string) (os.FileInfo, error)
+}
+
+type wakeInboxScanError struct {
+	err error
+}
+
+func (err *wakeInboxScanError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeInboxScanError) Unwrap() error {
+	return err.err
+}
+
+type wakeTerminalPartialProgressError struct {
+	err error
+}
+
+func (err *wakeTerminalPartialProgressError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeTerminalPartialProgressError) Unwrap() error {
+	return err.err
+}
+
+func isWakeTerminalPartialProgress(err error) bool {
+	var partial *wakeTerminalPartialProgressError
+	return errors.As(err, &partial)
+}
+
+type wakeInputDemotionBlockedError struct {
+	err error
+}
+
+func (err *wakeInputDemotionBlockedError) Error() string {
+	return "terminal input has confirmed or uncertain progress; refusing to discard its exact completion debt: " + err.err.Error()
+}
+
+func (err *wakeInputDemotionBlockedError) Unwrap() error {
+	return err.err
+}
+
+func isWakeInputDemotionBlocked(err error) bool {
+	var blocked *wakeInputDemotionBlockedError
+	return errors.As(err, &blocked)
+}
+
+type wakeTerminalProgressUncertainError struct {
+	err error
+}
+
+func (err *wakeTerminalProgressUncertainError) Error() string {
+	return "terminal input acceptance is uncertain; refusing to replay: " + err.err.Error()
+}
+
+func (err *wakeTerminalProgressUncertainError) Unwrap() error {
+	return err.err
+}
+
+func isWakeTerminalProgressUncertain(err error) bool {
+	var uncertain *wakeTerminalProgressUncertainError
+	return errors.As(err, &uncertain)
+}
+
+type wakeTerminalAcceptedProgress interface {
+	wakeAcceptedBytes() int
+}
+
 const defaultInjectTimeout = 5 * time.Second
 const (
-	wakeInjectModeAuto  = "auto"
-	wakeInjectModeRaw   = "raw"
-	wakeInjectModePaste = "paste"
-	wakeInjectModeNone  = "none"
+	wakeInjectModeAuto     = "auto"
+	wakeInjectModeRaw      = "raw"
+	wakeInjectModePaste    = "paste"
+	wakeInjectModeNone     = "none"
+	wakeRetryUntilDrained  = "drained"
+	wakeRetryUntilInjected = "injected"
 
 	coopWakeDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
 
@@ -84,6 +237,12 @@ const (
 	// rawInjectCRDrainTimeout bounds the wait for the submit CR itself to be
 	// consumed before deciding whether the second rescue CR is safe to send.
 	rawInjectCRDrainTimeout = 1 * time.Second
+	// Three samples require two follow-up confirmations after the first quiet
+	// observation, while adding at most two poll intervals to a real idle
+	// transition. Any active sample resets the evidence.
+	requiredInputQuietSamples = 3
+
+	wakeInputRecoveryNotice = "AMQ terminal input delivery is incomplete; inspect the composer, run amq drain --include-body, then restart this agent session"
 	// codexTUIEnterSuppressWindow mirrors codex-tui's
 	// PASTE_ENTER_SUPPRESS_WINDOW (codex-rs/tui/src/bottom_pane/paste_burst.rs,
 	// verified at rust-v0.144.1 and main): an Enter arriving within this window
@@ -102,9 +261,41 @@ const (
 	rawInjectSettleDelay = codexTUIEnterSuppressWindow + 30*time.Millisecond
 )
 
+func normalizeWakeRetryUntil(raw string) (string, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return wakeRetryUntilDrained, nil
+	}
+	switch value {
+	case wakeRetryUntilDrained, wakeRetryUntilInjected:
+		return value, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid retry-until %q (supported: drained, injected)",
+			raw,
+		)
+	}
+}
+
+// validateStoredWakeRetryUntil accepts only exact persisted wire values.
+// CLI input may still use normalizeWakeRetryUntil; stored .wake.target /
+// .wake.state bytes must be "", "drained", or "injected" with no whitespace/case folding.
+func validateStoredWakeRetryUntil(raw string) error {
+	switch raw {
+	case "", wakeRetryUntilDrained, wakeRetryUntilInjected:
+		return nil
+	default:
+		return fmt.Errorf(
+			"noncanonical retry-until %q (stored values: empty, drained, injected)",
+			raw,
+		)
+	}
+}
+
 var (
 	tiocstiInject          = func(text string) error { return tiocsti.Inject(text) }
 	waitForRawInputDrained = waitForTTYInputDrain
+	waitForWakeInputQuiet  = waitForTTYInputQuiet
 	rawInjectSleep         = time.Sleep
 )
 
@@ -114,6 +305,50 @@ type wakeMsgInfo struct {
 	subject  string
 	priority string
 	labels   []string
+}
+
+type wakePayloadProvenance string
+
+const (
+	wakePayloadSystemFixed  wakePayloadProvenance = "system_fixed"
+	wakePayloadPeerHeaders  wakePayloadProvenance = "peer_headers"
+	wakePayloadOperatorFlag wakePayloadProvenance = "operator_flag"
+)
+
+type wakePayload struct {
+	text       string
+	provenance wakePayloadProvenance
+}
+
+type wakeNotification struct {
+	input      wakePayload
+	output     wakePayload
+	submitOnly bool
+}
+
+func peerWakeNotification(output string) wakeNotification {
+	return wakeNotification{
+		input: wakePayload{
+			text:       coopWakeDoorbell,
+			provenance: wakePayloadSystemFixed,
+		},
+		output: wakePayload{
+			text:       output,
+			provenance: wakePayloadPeerHeaders,
+		},
+	}
+}
+
+func validCoopWakeDoorbell(prompt string) bool {
+	return prompt == coopWakeDoorbell
+}
+
+func operatorWakeNotification(text string) wakeNotification {
+	payload := wakePayload{
+		text:       text,
+		provenance: wakePayloadOperatorFlag,
+	}
+	return wakeNotification{input: payload, output: payload}
 }
 
 type ttyInputState struct {
@@ -158,6 +393,47 @@ func inputDeferralDelay(state ttyInputState, now, deadline time.Time, quietFor, 
 	return delay
 }
 
+func waitForInputQuiet(
+	sample func() (ttyInputState, error),
+	nowFn func() time.Time,
+	sleepFn func(time.Duration, ttyInputState, string),
+	quietFor, maxHold, pollInterval time.Duration,
+) (allowInjection bool, activeReason string, err error) {
+	if maxHold <= 0 {
+		return true, "", nil
+	}
+
+	deadline := nowFn().Add(maxHold)
+	quietSamples := 0
+	for {
+		now := nowFn()
+		state, sampleErr := sample()
+		if sampleErr != nil {
+			return true, "", sampleErr
+		}
+
+		active, reason := state.active(now, quietFor)
+		if active {
+			quietSamples = 0
+		} else {
+			quietSamples++
+			if quietSamples >= requiredInputQuietSamples {
+				return true, "", nil
+			}
+			reason = "quiet confirmation incomplete"
+		}
+		if !now.Before(deadline) {
+			return false, reason, nil
+		}
+
+		delay := inputDeferralDelay(state, now, deadline, quietFor, pollInterval)
+		if delay <= 0 {
+			return false, reason, nil
+		}
+		sleepFn(delay, state, reason)
+	}
+}
+
 func shouldDeferBeforeInject(cfg *wakeConfig, deferForInput bool) bool {
 	return deferForInput && cfg.deferWhileInput && cfg.injectVia == "" && cfg.injectMode != wakeInjectModeNone
 }
@@ -173,16 +449,15 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		entries, err = os.ReadDir(inboxNew)
 	}
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		return &wakeInboxScanError{
+			err: fmt.Errorf("read wake inbox %s: %w", inboxNew, err),
 		}
-		return err
 	}
 
 	var messages []wakeMsgInfo
-	senderCounts := make(map[string]int)
 	var interruptMessages []wakeMsgInfo
 	interruptCounts := make(map[string]int)
+	currentPending := make(map[string]os.FileInfo)
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -192,9 +467,19 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
 			continue
 		}
+		var fileInfo os.FileInfo
+		var infoErr error
+		if retained, ok := cfg.retainedInbox.(wakeInboxFileInfoReader); ok {
+			fileInfo, infoErr = retained.FileInfo(name)
+		} else {
+			fileInfo, infoErr = entry.Info()
+		}
+		pendingInfo := fileInfo
+		if infoErr != nil {
+			pendingInfo = nil
+		}
 		if baselineIdentity, ignored := cfg.baselineExisting[name]; ignored {
-			info, infoErr := entry.Info()
-			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, info) {
+			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, fileInfo) {
 				continue
 			}
 			delete(cfg.baselineExisting, name)
@@ -206,17 +491,13 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		} else {
 			header, err = format.ReadHeaderFile(filepath.Join(inboxNew, name))
 		}
+		if err != nil && os.IsNotExist(err) {
+			continue
+		}
+		currentPending[name] = pendingInfo
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
 			// Count corrupt messages too
-			messages = append(messages, wakeMsgInfo{
-				id:      strings.TrimSuffix(name, filepath.Ext(name)),
-				from:    "unknown",
-				subject: "(parse error)",
-			})
-			senderCounts["unknown"]++
+			messages = append(messages, wakeMsgInfo{id: strings.TrimSuffix(name, filepath.Ext(name)), from: "unknown", subject: "(parse error)"})
 			continue
 		}
 
@@ -238,7 +519,6 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 
 		messages = append(messages, info)
-		senderCounts[from]++
 
 		if cfg.interrupt && isInterruptMessage(info, cfg) {
 			interruptMessages = append(interruptMessages, info)
@@ -246,35 +526,51 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 	}
 
-	if len(messages) == 0 {
+	if cfg.inputRecoveryRequired &&
+		dischargeWakeInputRecoveryAfterProgress(cfg, currentPending) &&
+		len(messages) == 0 {
 		return nil
 	}
-	messageIDs := wakeMessageIDs(messages)
-
-	// A supervised/co-op wake is only a fixed doorbell. Message headers,
-	// session names, custom notices, commands, and urgency never become
-	// terminal input.
-	if usesCoopDoorbell(cfg) {
-		return attemptNotification(cfg, messageIDs, coopWakeDoorbell, len(interruptMessages) == 0)
+	if len(messages) == 0 {
+		if cfg.inputRecoveryRequired {
+			return deliverWakeInputRecoveryAttention(
+				cfg,
+				currentPending,
+			)
+		}
+		cfg.doorbell.reset()
+		persistWakeDoorbellStatusBestEffort(cfg)
+		return reconcileWakeInputAfterInboxDrain(cfg)
 	}
 
 	if cfg.interrupt && len(interruptMessages) > 0 {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
+		notice := peerWakeNotification(interruptText)
+		if cfg.interruptNotice != "" {
+			notice = operatorWakeNotification(interruptText)
+		}
+		if cfg.inputRecoveryRequired {
+			return deliverWithNotificationLedger(cfg, wakeMessageIDs(interruptMessages), notice, false, currentPending)
+		}
 		if cfg.injectMode == wakeInjectModeNone {
-			bell := cfg.bell
-			cfg.bell = true
-			err := attemptNotification(cfg, messageIDs, interruptText, false)
-			cfg.bell = bell
-			return err
+			return deliverWithNotificationLedger(cfg, wakeMessageIDs(interruptMessages), notice, false, currentPending)
 		}
 		now := time.Now()
-		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
+		if !usesCoopDoorbell(cfg) &&
+			cfg.interruptKey != "" &&
+			shouldInterruptNow(cfg, now) {
 			if cfg.injectVia != "" {
 				allowed, guardErr := authorizeTerminalWrite(cfg)
 				if guardErr != nil {
 					return guardErr
 				}
 				if allowed {
+					// Exit zero is the strongest acceptance evidence the v0
+					// external transport exposes. It cannot prove the provider
+					// delivered the key, but advancing the cooldown bounds
+					// duplicate control-key injection. A false-success provider
+					// may therefore suppress one genuine interrupt until the
+					// next window; stronger evidence needs a structured protocol.
 					if err := injectVia(cfg, cfg.interruptKey); err == nil {
 						cfg.lastInterrupt = now
 						time.Sleep(50 * time.Millisecond)
@@ -288,73 +584,468 @@ func notifyNewMessages(cfg *wakeConfig) error {
 						return writeErr
 					}
 				}
+				// The raw path can require positive terminal-write evidence
+				// instead of inferring acceptance from a process exit status.
 				if writeErr == nil && wrote {
 					cfg.lastInterrupt = now
 					time.Sleep(50 * time.Millisecond)
 				}
 			}
 		}
-		return attemptNotification(cfg, messageIDs, interruptText, false)
+		return deliverWithNotificationLedger(cfg, wakeMessageIDs(interruptMessages), notice, false, currentPending)
 	}
 
-	// Build notification text
-	var text string
+	var notice wakeNotification
 	if cfg.injectCmd != "" {
-		// Power user mode: inject actual command
-		text = "\n" + cfg.injectCmd + "\n"
+		// Power user mode: inject the operator-authored command.
+		text := "\n" + sanitizeForTTY(cfg.injectCmd) + "\n"
+		notice = operatorWakeNotification(text)
 	} else {
-		// Default: informational notice
-		text = buildNotificationText(cfg.session, messages, senderCounts, cfg.previewLen)
+		notice = peerWakeNotification(
+			buildNotificationText(cfg.session, messages, cfg.previewLen),
+		)
 	}
 
-	return attemptNotification(cfg, messageIDs, text, true)
+	return deliverWithNotificationLedger(cfg, wakeMessageIDs(messages), notice, true, currentPending)
 }
 
+// wakeMessageIDs collects the non-empty IDs from a slice of wakeMsgInfo.
+// Corrupt messages (parse error) use the filename stem as a fallback ID so
+// they are still represented in the notification attempt ledger.
 func wakeMessageIDs(messages []wakeMsgInfo) []string {
 	ids := make([]string, 0, len(messages))
-	for _, message := range messages {
-		if strings.TrimSpace(message.id) != "" {
-			ids = append(ids, message.id)
+	for _, m := range messages {
+		if m.id != "" {
+			ids = append(ids, m.id)
 		}
 	}
 	return ids
 }
 
-func buildNotificationText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int) string {
+// deliverWithNotificationLedger wraps deliverNewMessageNotification with a
+// durable notification attempt record (prepared → result). The ledger NEVER
+// blocks delivery: if persisting the prepared record fails, the notification
+// is delivered anyway and the write failure is recorded for trace to surface
+// as StateWriteFailed ("attempt was made but the record could not be
+// persisted" — distinct from "no attempt recorded").
+func deliverWithNotificationLedger(
+	cfg *wakeConfig,
+	messageIDs []string,
+	notice wakeNotification,
+	deferForInput bool,
+	currentPending map[string]os.FileInfo,
+) error {
+	if len(messageIDs) == 0 {
+		// No message IDs (e.g. an operator-injected command with no parsed
+		// messages) — deliver without recording. The ledger records attempts
+		// to notify about specific messages.
+		return deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
+	}
+	writer := notificationattempt.NewWriter(cfg.root, cfg.me)
+	prepared, prepareErr := writer.Prepare(messageIDs, notificationAttemptMode(cfg))
+	deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
+	if prepareErr != nil {
+		// The prepared write failed. Record a result with outcome=failed so
+		// trace can surface "recording failed" rather than a silent hole.
+		// The delivery happened regardless (ledger never blocks delivery).
+		reconstructed := notificationattempt.Record{
+			AttemptID:  prepared.AttemptID,
+			MessageIDs: messageIDs,
+			Agent:      cfg.me,
+		}
+		if resultErr := writer.Result(reconstructed, notificationattempt.OutcomeFailed, "prepared write failed: "+prepareErr.Error()); resultErr != nil && cfg.debug {
+			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
+		}
+		return deliverErr
+	}
+	outcome := notificationattempt.OutcomeFailed
+	detail := ""
+	if deliverErr == nil {
+		outcome = notificationattempt.OutcomeWritten
+	} else {
+		detail = deliverErr.Error()
+	}
+	if resultErr := writer.Result(prepared, outcome, detail); resultErr != nil && cfg.debug {
+		_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
+	}
+	return deliverErr
+}
+
+// notificationAttemptMode returns a human-readable label for the injection
+// mode used, recorded in the ledger for trace.
+func notificationAttemptMode(cfg *wakeConfig) string {
+	if cfg.injectMode == wakeInjectModeNone {
+		return "stderr"
+	}
+	if cfg.injectVia != "" {
+		return "external"
+	}
+	return effectiveInjectMode(cfg)
+}
+
+func deliverNewMessageNotification(
+	cfg *wakeConfig,
+	notice wakeNotification,
+	deferForInput bool,
+	currentPending map[string]os.FileInfo,
+) error {
+	if cfg.inputRecoveryRequired {
+		if !dischargeWakeInputRecoveryAfterProgress(cfg, currentPending) {
+			return deliverWakeInputRecoveryAttention(cfg, currentPending)
+		}
+		if len(currentPending) == 0 {
+			return nil
+		}
+	}
+	if cfg.injectMode == wakeInjectModeNone {
+		if cfg.inputDelivery.blocksDemotion() {
+			return &wakeInputDemotionBlockedError{
+				err: errors.New("input mode became none before retained terminal input completed"),
+			}
+		}
+		clearWakeInputState(cfg)
+	}
+	now := cfg.wakeDoorbellNow()
+	plan := cfg.doorbell.plan(now, currentPending)
+	persistWakeDoorbellStatusBestEffort(cfg)
+	if !plan.attempt {
+		return nil
+	}
+	if plan.progress && cfg.inputDelivery.pending() {
+		if err := reconcileWakeInputAfterInboxDrain(cfg); err != nil {
+			return err
+		}
+		if cfg.inputDelivery.pending() {
+			return nil
+		}
+	}
+	ownerBound := usesCoopDoorbell(cfg)
+	if cfg.injectMode != wakeInjectModeNone {
+		retainedInputPending := cfg.inputDelivery.pending()
+		if ownerBound {
+			notice.input = wakePayload{
+				text:       plan.prompt,
+				provenance: wakePayloadSystemFixed,
+			}
+		}
+		notice.submitOnly = plan.submitOnly
+		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
+		if isWakeInputDemotionBlocked(deliveryErr) {
+			return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
+		}
+		if cfg.injectMode == wakeInjectModeNone {
+			clearWakeInputState(cfg)
+			if shouldRecordWakeAttempt(deliveryErr) {
+				recordWakeAttempt(
+					cfg,
+					cfg.wakeDoorbellNow(),
+					currentPending,
+					deliveryErr,
+				)
+			}
+			return deliveryErr
+		}
+		if shouldRecordWakeAttempt(deliveryErr) {
+			if !plan.submitOnly &&
+				(!plan.contentChange || !retainedInputPending) &&
+				wakeInputAttemptConfirmed(cfg, deliveryErr) {
+				cfg.doorbell.confirmPresentation()
+			}
+			recordWakeAttempt(
+				cfg,
+				cfg.wakeDoorbellNow(),
+				currentPending,
+				deliveryErr,
+			)
+		}
+		return deliveryErr
+	}
+
+	deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
+	if isWakeInputDemotionBlocked(deliveryErr) {
+		return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
+	}
+	if shouldRecordWakeAttempt(deliveryErr) {
+		recordWakeAttempt(
+			cfg,
+			cfg.wakeDoorbellNow(),
+			currentPending,
+			deliveryErr,
+		)
+	}
+	return deliveryErr
+}
+
+func wakeInputAttemptConfirmed(cfg *wakeConfig, deliveryErr error) bool {
+	return deliveryErr == nil &&
+		cfg.injectMode != wakeInjectModeNone &&
+		!cfg.inputDelivery.pending() &&
+		!cfg.lastAttemptAttention &&
+		!cfg.lastAttemptTransientAttention
+}
+
+func recordWakeAttempt(
+	cfg *wakeConfig,
+	now time.Time,
+	currentPending map[string]os.FileInfo,
+	deliveryErr error,
+) {
+	if len(cfg.doorbell.cohort) == 0 {
+		cfg.doorbell.arm(currentPending)
+	}
+	if cfg.retryUntil == wakeRetryUntilInjected &&
+		deliveryErr == nil &&
+		!cfg.lastAttemptAttention &&
+		!cfg.lastAttemptTransientAttention {
+		cfg.doorbell.recordInjected(currentPending)
+		return
+	}
+	var attentionErr *wakeAttentionDeliveryError
+	if cfg.lastAttemptTransientAttention {
+		// Input deferral emitted attention but made no synthetic-input attempt,
+		// so it advances cadence without consuming the finite injection budget.
+		cfg.doorbell.recordDeferredInputAttempt(now)
+	} else if cfg.lastAttemptAttention || errors.As(deliveryErr, &attentionErr) {
+		cfg.doorbell.recordAttentionAttempt(now)
+	} else {
+		cfg.doorbell.recordAttempt(now)
+	}
+	persistWakeDoorbellStatusBestEffort(cfg)
+}
+
+func shouldRecordWakeAttempt(err error) bool {
+	if err == nil {
+		return true
+	}
+	return !isWakeTerminalAuthorityLoss(err) &&
+		!isWakeTerminalPartialProgress(err) &&
+		!isWakeInputDemotionBlocked(err) &&
+		!isWakeTerminalProgressUncertain(err)
+}
+
+func deliverWakeInputRecoveryAttention(
+	cfg *wakeConfig,
+	currentPending map[string]os.FileInfo,
+) error {
+	now := cfg.wakeDoorbellNow()
+	if !cfg.doorbell.planRecoveryAttention(now, currentPending) {
+		return nil
+	}
+	cfg.doorbell.recordRecoveryRequired(now, currentPending)
+	persistWakeDoorbellStatusBestEffort(cfg)
+	if err := emitWakeAttention(cfg, wakePayload{
+		text:       wakeInputRecoveryNotice,
+		provenance: wakePayloadSystemFixed,
+	}); err != nil {
+		return err
+	}
+	cfg.doorbell.recordRecoveryAttentionDelivered()
+	if len(currentPending) == 0 {
+		cfg.doorbell.noteRecoveryInboxEmpty()
+	}
+	return nil
+}
+
+func enterWakeInputRecovery(
+	cfg *wakeConfig,
+	currentPending map[string]os.FileInfo,
+	cause error,
+) error {
+	markWakeInputRecoveryRequired(cfg, cause)
+	if err := deliverWakeInputRecoveryAttention(cfg, currentPending); err != nil {
+		return errors.Join(cause, err)
+	}
+	return nil
+}
+
+func markWakeInputRecoveryRequired(cfg *wakeConfig, cause error) {
+	cfg.inputRecoveryRequired = true
+	mode := effectiveInjectMode(cfg)
+	reason := wakeInputRecoveryNotice
+	if cause != nil {
+		reason += ": " + cause.Error()
+	}
+	if err := persistWakeNotifierStatus(
+		cfg,
+		wakeInputRecoveryRequiredStatus,
+		mode,
+		reason,
+	); err != nil {
+		_ = writeWakeDiagnostic(cfg, "amq wake: record input recovery-required status: %v\n", err)
+	}
+}
+
+func dischargeWakeInputRecoveryAfterProgress(
+	cfg *wakeConfig,
+	currentPending map[string]os.FileInfo,
+) bool {
+	if cfg == nil || !cfg.inputRecoveryRequired {
+		return false
+	}
+	progressed := len(currentPending) == 0
+	if !progressed && cfg.doorbell.phase == wakeDoorbellRecoveryRequired {
+		progressed = wakeCohortProgressed(cfg.doorbell.cohort, currentPending)
+	}
+	if !progressed {
+		return false
+	}
+
+	// Durable consumer progress proves that the composer state changed after
+	// the uncertain write. Never resume the old suffix: discard that debt and
+	// let any remaining cohort start with one fresh, complete doorbell. This
+	// accepts bounded composer noise over a permanently undriven session, while
+	// preserving the no-stacking rule for the old partial payload.
+	cfg.inputRecoveryRequired = false
+	clearWakeInputState(cfg)
+	cfg.doorbell.reset()
+	persistWakeDoorbellStatusBestEffort(cfg)
+	if err := persistWakeNotifierStatus(cfg, "", effectiveInjectMode(cfg), ""); err != nil {
+		_ = writeWakeDiagnostic(cfg, "amq wake: clear input recovery-required status: %v\n", err)
+	}
+	return true
+}
+
+func persistWakeNotifierStatus(cfg *wakeConfig, status, mode, reason string) error {
+	if cfg == nil || cfg.recordNotifierStatus == nil {
+		return nil
+	}
+	desired := &wakeNotifierStatus{status: status, mode: mode, reason: reason}
+	if err := cfg.recordNotifierStatus(status, mode, reason); err != nil {
+		cfg.pendingNotifierStatus = desired
+		return err
+	}
+	cfg.pendingNotifierStatus = nil
+	return nil
+}
+
+func retryPendingWakeNotifierStatus(cfg *wakeConfig) error {
+	if cfg == nil || cfg.pendingNotifierStatus == nil {
+		return nil
+	}
+	pending := cfg.pendingNotifierStatus
+	return persistWakeNotifierStatus(cfg, pending.status, pending.mode, pending.reason)
+}
+
+func persistWakeDoorbellStatusBestEffort(cfg *wakeConfig) {
+	if err := persistWakeDoorbellStatus(cfg); err != nil {
+		_ = writeWakeDiagnostic(cfg, "amq wake: persist doorbell parked status: %v; retrying\n", err)
+	}
+}
+
+func persistWakeDoorbellStatus(cfg *wakeConfig) error {
+	if cfg == nil || cfg.recordDoorbellStatus == nil {
+		return nil
+	}
+	attempts, parked := cfg.doorbell.parkedReminderAttempts()
+	desired := wakeDoorbellStatus{parked: parked, attempts: attempts}
+	if !parked {
+		desired.attempts = 0
+	}
+	if cfg.pendingDoorbellStatus == nil && desired == cfg.reportedDoorbellStatus {
+		return nil
+	}
+	if err := cfg.recordDoorbellStatus(desired.parked, desired.attempts); err != nil {
+		cfg.pendingDoorbellStatus = &desired
+		return err
+	}
+	cfg.reportedDoorbellStatus = desired
+	cfg.pendingDoorbellStatus = nil
+	return nil
+}
+
+func retryPendingWakeDoorbellStatus(cfg *wakeConfig) error {
+	if cfg == nil || cfg.pendingDoorbellStatus == nil || cfg.recordDoorbellStatus == nil {
+		return nil
+	}
+	pending := *cfg.pendingDoorbellStatus
+	if err := cfg.recordDoorbellStatus(pending.parked, pending.attempts); err != nil {
+		return err
+	}
+	cfg.reportedDoorbellStatus = pending
+	cfg.pendingDoorbellStatus = nil
+	return nil
+}
+
+func (cfg *wakeConfig) wakeDoorbellNow() time.Time {
+	if cfg.doorbellNow != nil {
+		return cfg.doorbellNow()
+	}
+	return time.Now()
+}
+
+func snapshotWakeFileIdentities(current map[string]os.FileInfo) map[string]*wakeFileIdentity {
+	snapshot := make(map[string]*wakeFileIdentity, len(current))
+	for name, info := range current {
+		if info == nil {
+			snapshot[name] = nil
+			continue
+		}
+		if identity, ok := captureWakeFileIdentity(info); ok {
+			snapshot[name] = &identity
+			continue
+		}
+		snapshot[name] = nil
+	}
+	return snapshot
+}
+
+func sameKnownWakeCohort(
+	previous map[string]*wakeFileIdentity,
+	current map[string]os.FileInfo,
+) bool {
+	if len(previous) == 0 || len(previous) != len(current) {
+		return false
+	}
+	for name, previousIdentity := range previous {
+		info, exists := current[name]
+		if !exists || previousIdentity == nil || info == nil {
+			return false
+		}
+		currentIdentity, known := captureWakeFileIdentity(info)
+		if !known || currentIdentity != *previousIdentity {
+			return false
+		}
+	}
+	return true
+}
+
+func buildNotificationText(session string, messages []wakeMsgInfo, previewLen int) string {
 	count := len(messages)
 	prefix := notificationPrefix("AMQ", session)
-
 	if count == 1 {
-		// Single message: show from + truncated subject
 		msg := messages[0]
 		subject := msg.subject
 		if subject == "" {
 			subject = "(no subject)"
 		}
-		subject = truncateSubject(subject, previewLen)
-		return fmt.Sprintf("%s: message from %s - %s. Drain with: amq drain --include-body — then act on it", prefix, msg.from, subject)
+		return fmt.Sprintf(
+			"%s: message from %s - %s. Drain with: amq drain --include-body — then act on it",
+			prefix,
+			msg.from,
+			truncateSubject(subject, previewLen),
+		)
 	}
 
-	// Multiple messages: show counts by sender
-	var parts []string
+	senderCounts := make(map[string]int)
+	for _, msg := range messages {
+		senderCounts[msg.from]++
+	}
 	senders := make([]string, 0, len(senderCounts))
-	for s := range senderCounts {
-		senders = append(senders, s)
+	for sender := range senderCounts {
+		senders = append(senders, sender)
 	}
 	sort.Strings(senders)
-
-	for _, sender := range senders {
-		c := senderCounts[sender]
-		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
-	}
-
-	return fmt.Sprintf("%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
-		prefix, count, strings.Join(parts, ", "))
+	return fmt.Sprintf(
+		"%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
+		prefix,
+		count,
+		strings.Join(buildWakeSenderClauses(senders, senderCounts), ", "),
+	)
 }
 
 func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int, custom string) string {
 	if custom != "" {
-		return custom
+		return sanitizeForTTY(custom)
 	}
 
 	count := len(messages)
@@ -371,18 +1062,30 @@ func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map
 			prefix, msg.from, subject)
 	}
 
-	var parts []string
 	senders := make([]string, 0, len(senderCounts))
 	for s := range senderCounts {
 		senders = append(senders, s)
 	}
 	sort.Strings(senders)
-	for _, sender := range senders {
-		c := senderCounts[sender]
-		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
-	}
+	parts := buildWakeSenderClauses(senders, senderCounts)
 	return fmt.Sprintf("%s: %d urgent messages - %s. Drain with: amq drain --include-body — then act on it",
 		prefix, count, strings.Join(parts, ", "))
+}
+
+func buildWakeSenderClauses(senders []string, senderCounts map[string]int) []string {
+	limit := min(len(senders), maxWakeNotificationSenderClauses)
+	parts := make([]string, 0, limit+1)
+	for _, sender := range senders[:limit] {
+		parts = append(parts, fmt.Sprintf("%d from %s", senderCounts[sender], sender))
+	}
+	if omitted := len(senders) - limit; omitted > 0 {
+		label := "senders"
+		if omitted == 1 {
+			label = "sender"
+		}
+		parts = append(parts, fmt.Sprintf("%d other %s", omitted, label))
+	}
+	return parts
 }
 
 // notificationPrefix builds "AMQ [session]" or just "AMQ" when session is empty.
@@ -439,14 +1142,18 @@ func effectiveInjectMode(cfg *wakeConfig) string {
 		// Enter swallowing in some CLIs. Paste mode remains available via flag.
 		// Claude Code's Ink framework has buggy bracketed paste handling where CR gets
 		// coalesced with the paste-end sequence and swallowed by the input parser.
-		meLower := strings.ToLower(cfg.me)
-		if strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex") {
+		if wakeUsesAlternateScreenTUI(cfg.me) {
 			mode = wakeInjectModeRaw
 		} else {
 			mode = wakeInjectModePaste
 		}
 	}
 	return mode
+}
+
+func wakeUsesAlternateScreenTUI(me string) bool {
+	meLower := strings.ToLower(me)
+	return strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex")
 }
 
 func normalizeWakeInjectMode(raw string) (string, error) {
@@ -462,214 +1169,295 @@ func normalizeWakeInjectMode(raw string) (string, error) {
 	}
 }
 
-func writeWakeOutput(text string, bell bool) {
-	_ = writeWakeOutputChecked(text, bell)
-}
-
-func writeWakeOutputChecked(text string, bell bool) error {
-	if bell {
-		text = "\a" + text
-	}
-	output := text + "\n"
-	n, err := fmt.Fprint(os.Stderr, output)
-	if err != nil {
-		return err
-	}
-	if n != len(output) {
-		return io.ErrShortWrite
-	}
-	return nil
-}
-
-func attemptNotification(cfg *wakeConfig, messageIDs []string, text string, deferForInput bool) error {
-	writer := notificationattempt.NewWriter(cfg.root, cfg.me)
-	prepared, prepareErr := writer.Prepare(messageIDs, notificationAttemptMode(cfg))
-	if prepareErr != nil && cfg.debug {
-		_ = writeStderr("amq wake [debug]: persist prepared notification attempt: %v\n", prepareErr)
-	}
-
-	err := injectNotification(cfg, text, deferForInput)
-	if prepareErr == nil {
-		outcome := notificationattempt.OutcomeFailed
-		if cfg.notificationWritten {
-			outcome = notificationattempt.OutcomeWritten
-		}
-		if resultErr := writer.Result(prepared, outcome, cfg.notificationDetail); resultErr != nil && cfg.debug {
-			_ = writeStderr("amq wake [debug]: persist notification attempt result: %v\n", resultErr)
-		}
-	}
-	return err
-}
-
-func notificationAttemptMode(cfg *wakeConfig) string {
-	if cfg.injectMode == wakeInjectModeNone {
-		return "stderr"
-	}
-	if cfg.injectVia != "" {
-		return "external"
-	}
-	return effectiveInjectMode(cfg)
-}
-
+// injectNotification preserves the legacy test/internal string helper. New
+// production routing uses deliverWakeNotification so input and output sources
+// remain explicit.
 func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
-	cfg.notificationWritten = false
-	cfg.notificationDetail = ""
+	payload := wakePayload{
+		text:       text,
+		provenance: wakePayloadSystemFixed,
+	}
+	return deliverWakeNotification(
+		cfg,
+		wakeNotification{input: payload, output: payload},
+		deferForInput,
+	)
+}
+
+func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
+	cfg.lastAttemptAttention = false
+	cfg.lastAttemptTransientAttention = false
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
-		text = coopWakeDoorbell
+		if notice.submitOnly && notice.input.provenance == wakePayloadSystemFixed {
+			// A submit-only reminder is system-created from cohort state. It has
+			// no payload text to validate or replace.
+		} else if validCoopWakeDoorbell(notice.input.text) {
+			// The fixed doorbell is system-created before delivery.
+		} else {
+			notice.input = wakePayload{
+				text:       coopWakeDoorbell,
+				provenance: wakePayloadSystemFixed,
+			}
+		}
 	}
 	if cfg.injectMode == wakeInjectModeNone {
-		if err := writeWakeOutputChecked(text, cfg.bell && !ownerBound); err != nil {
-			cfg.notificationDetail = err.Error()
-		} else {
-			cfg.notificationWritten = true
-			cfg.notificationDetail = "notification bytes written to stderr"
-		}
-		return nil
+		return deliverWakeAttentionOnly(cfg, notice.output)
 	}
 
-	// Keep plain text for stderr fallback
-	plainText := text
+	inputText := notice.input.text
+	if notice.submitOnly {
+		inputText = ""
+	}
+	plainText := inputText
+	if notice.submitOnly {
+		plainText = "\r"
+	}
 	if cfg.bell && !ownerBound {
 		plainText = "\a" + plainText
 	}
 
 	if shouldDeferBeforeInject(cfg, deferForInput) {
-		waitForTTYInputQuiet(cfg)
+		if !waitForWakeInputQuiet(cfg) {
+			return deliverWakeTransientAttention(cfg, notice.output, nil)
+		}
 	}
 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
-	// The command receives the notification text as its last argument.
+	// The command receives the notification text as its last argument. Exit zero
+	// remains presentation-confirmation evidence. Post-text Enter/submit failure
+	// is encoded in child output as AMQ_INJECT_PROGRESS=uncertain; that path
+	// must not replay the payload.
 	if cfg.injectVia != "" {
+		if cfg.inputDelivery.acceptanceUncertain {
+			return &wakeInputDemotionBlockedError{
+				err: errors.New("a prior terminal write has uncertain acceptance"),
+			}
+		}
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {
-			return guardErr
+			return deliverWakeAttentionAfterInputRefusal(
+				cfg,
+				notice.output,
+				guardErr,
+			)
 		}
 		if !allowed {
-			cfg.notificationDetail = "terminal write was not authorized"
-			return nil
+			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
 		if err := injectVia(cfg, plainText); err != nil {
+			var uncertain *wakeTerminalProgressUncertainError
+			if errors.As(err, &uncertain) {
+				cfg.inputDelivery.acceptanceUncertain = true
+				_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
+				cfg.fallbackWarn = false
+				return &wakeInputDemotionBlockedError{err: uncertain}
+			}
 			if cfg.fallbackWarn {
-				_ = writeStderr("amq wake: --inject-via failed: %v\n", err)
-				_ = writeStderr("amq wake: falling back to stderr notification\n")
+				_ = writeWakeDiagnostic(cfg, "amq wake: --inject-via failed: %v\n", err)
+				_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
 				cfg.fallbackWarn = false
 			}
-			if fallbackErr := writeWakeOutputChecked(plainText, false); fallbackErr != nil {
-				cfg.notificationDetail = fmt.Sprintf("external notifier failed: %v; stderr fallback failed: %v", err, fallbackErr)
-			} else {
-				cfg.notificationWritten = true
-				cfg.notificationDetail = "external notifier failed; notification bytes written to stderr fallback"
-			}
-		} else {
-			cfg.notificationWritten = true
-			cfg.notificationDetail = "external notifier completed successfully"
+			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
 		return nil
 	}
 
 	mode := effectiveInjectMode(cfg)
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: mode=%s text_len=%d\n", mode, len(text))
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: mode=%s text_len=%d\n", mode, len(inputText))
 	}
 	var injectErr error
+	inputAccepted := false
 	switch mode {
 	case wakeInjectModeRaw:
 		// Raw mode: inject text and CR separately to avoid paste detection.
 		// Ink treats multi-char input as paste, not keypresses. Sending text+CR
 		// as one chunk makes Ink see pasted text, not an Enter keypress.
-		injectedText := text
+		injectedText := inputText
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
-		injectErr = injectRawNotification(cfg, injectedText)
+		if notice.submitOnly {
+			inputAccepted, injectErr = injectTerminalSubmitOnly(cfg, wakeInjectModeRaw)
+		} else {
+			inputAccepted, injectErr = injectRawNotification(cfg, injectedText)
+		}
+		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	case wakeInjectModePaste:
 		// Paste mode: bracketed paste with delayed CR
 		// Works with crossterm/ratatui apps
 		// Send paste content first, then CR after short delay to avoid coalescing
-		pasteText := text
+		pasteText := inputText
 		if !ownerBound {
-			pasteText = "\x1b[200~" + text + "\x1b[201~"
+			pasteText = "\x1b[200~" + inputText + "\x1b[201~"
 		}
 		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
 		}
-		wrote, err := writeTerminalChunk(cfg, pasteText)
-		if err != nil {
-			injectErr = err
-		} else if wrote {
-			// Small delay to ensure CR lands in separate read cycle
-			time.Sleep(25 * time.Millisecond)
-			_, injectErr = writeTerminalChunk(cfg, "\r")
+		if notice.submitOnly {
+			inputAccepted, injectErr = injectTerminalSubmitOnly(cfg, wakeInjectModePaste)
+		} else {
+			inputAccepted, injectErr = injectTerminalNotification(
+				cfg,
+				wakeInjectModePaste,
+				pasteText,
+			)
 		}
+		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	default:
 		// Unknown mode, fall back to raw
 		if ownerBound {
-			wrote, err := writeTerminalChunk(cfg, text)
-			if err != nil {
-				injectErr = err
-			} else if wrote {
-				_, injectErr = writeTerminalChunk(cfg, "\r")
+			if notice.submitOnly {
+				inputAccepted, injectErr = writeTerminalChunk(cfg, "\r")
+			} else {
+				wrote, err := writeTerminalChunk(cfg, inputText)
+				inputAccepted = wrote
+				if err != nil {
+					injectErr = err
+				} else if wrote {
+					submitted, err := writeTerminalChunk(cfg, "\r")
+					inputAccepted = inputAccepted || submitted
+					injectErr = err
+				}
 			}
 		} else {
-			injectedText := text + "\r"
+			injectedText := inputText + "\r"
 			if cfg.bell {
 				injectedText = "\a" + injectedText
 			}
-			_, injectErr = writeTerminalChunk(cfg, injectedText)
+			inputAccepted, injectErr = writeTerminalChunk(cfg, injectedText)
 		}
 	}
 
 	if injectErr != nil {
+		if isWakeTerminalPartialProgress(injectErr) {
+			return injectErr
+		}
+		var uncertain *wakeTerminalProgressUncertainError
+		if errors.As(injectErr, &uncertain) {
+			cfg.inputDelivery.acceptanceUncertain = true
+			_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
+			cfg.fallbackWarn = false
+			return &wakeInputDemotionBlockedError{err: uncertain}
+		}
+		if isWakeInputDemotionBlocked(injectErr) {
+			return injectErr
+		}
 		var unsupported *wakeInjectorUnsupportedError
 		if errors.As(injectErr, &unsupported) {
 			mode := effectiveInjectMode(cfg)
 			reason := wakeInjectorUnsupportedReason(mode, injectErr)
-			if cfg.recordNotifierStatus != nil {
-				if err := cfg.recordNotifierStatus(
-					wakeInjectorUnsupportedStatus,
-					mode,
-					reason,
-				); err != nil {
-					_ = writeStderr("amq wake: record unsupported injector status: %v\n", err)
-				}
+			if err := persistWakeNotifierStatus(
+				cfg,
+				wakeInjectorUnsupportedStatus,
+				mode,
+				reason,
+			); err != nil {
+				_ = writeWakeDiagnostic(cfg, "amq wake: record unsupported injector status: %v\n", err)
 			}
-			cfg.injectMode = wakeInjectModeNone
-			_ = writeStderr("amq wake: warning: %s\n", reason)
+			if err := disableWakeInput(cfg, injectErr); err != nil {
+				return err
+			}
+			_ = writeWakeDiagnostic(cfg, "amq wake: warning: %s\n", reason)
 			cfg.fallbackWarn = false
-			if fallbackErr := writeWakeOutputChecked(plainText, false); fallbackErr != nil {
-				cfg.notificationDetail = fmt.Sprintf("terminal injection unsupported: %v; stderr fallback failed: %v", injectErr, fallbackErr)
-			} else {
-				cfg.notificationWritten = true
-				cfg.notificationDetail = "terminal injection unsupported; notification bytes written to stderr fallback"
-			}
-			return nil
+			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(injectErr, &authorityErr) {
-			cfg.notificationDetail = injectErr.Error()
+			if !cfg.inputDelivery.confirmedInput() {
+				return deliverWakeAttentionAfterInputRefusal(
+					cfg,
+					notice.output,
+					injectErr,
+				)
+			}
 			return injectErr
 		}
 		if cfg.fallbackWarn {
-			_ = writeStderr("amq wake: TIOCSTI injection failed: %v\n", injectErr)
-			_ = writeStderr("amq wake: falling back to stderr notification\n")
+			_ = writeWakeDiagnostic(cfg, "amq wake: TIOCSTI injection failed: %v\n", injectErr)
+			_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
 			cfg.fallbackWarn = false
 		}
-		// Fallback: print plain text to stderr (no escape sequences)
-		if fallbackErr := writeWakeOutputChecked(plainText, false); fallbackErr != nil {
-			cfg.notificationDetail = fmt.Sprintf("terminal injection failed: %v; stderr fallback failed: %v", injectErr, fallbackErr)
-		} else {
-			cfg.notificationWritten = true
-			cfg.notificationDetail = "terminal injection failed; notification bytes written to stderr fallback"
-		}
-		return nil
+		// Fallback: use the output-only attention tier; never retry input.
+		return deliverWakeAttentionOnly(cfg, notice.output)
+	}
+	if !inputAccepted {
+		return deliverWakeAttentionOnly(cfg, notice.output)
 	}
 
-	cfg.notificationWritten = true
-	cfg.notificationDetail = "notification bytes written to terminal input"
 	return nil
+}
+
+func deliverWakeAttentionAfterInputRefusal(
+	cfg *wakeConfig,
+	payload wakePayload,
+	cause error,
+) error {
+	if isWakeTerminalForegroundPGRPChanged(cause) {
+		return deliverWakeTransientAttention(cfg, payload, cause)
+	}
+	if isWakeTerminalAuthorityLoss(cause) {
+		// A replacement wake owns both terminal input and peer-rich attention.
+		// Let an inconclusive authority check continue narrating, but never let
+		// a conclusively stale driver speak alongside its replacement.
+		return cause
+	}
+	if err := deliverWakeAttentionOnly(cfg, payload); err != nil {
+		return errors.Join(cause, err)
+	}
+	return nil
+}
+
+func deliverWakeTransientAttention(
+	cfg *wakeConfig,
+	payload wakePayload,
+	cause error,
+) error {
+	if err := authorizePeerWakeAttention(cfg, payload); err != nil {
+		return err
+	}
+	now := cfg.wakeDoorbellNow()
+	if !cfg.doorbell.transientAttentionDue(now) {
+		return cause
+	}
+	cfg.lastAttemptTransientAttention = true
+	cfg.doorbell.recordTransientAttentionAttempt(now)
+	if err := emitWakeAttention(cfg, payload); err != nil {
+		return errors.Join(cause, err)
+	}
+	return cause
+}
+
+func deliverWakeAttentionOnly(cfg *wakeConfig, payload wakePayload) error {
+	if err := authorizePeerWakeAttention(cfg, payload); err != nil {
+		return err
+	}
+	if err := emitWakeAttention(cfg, payload); err != nil {
+		return err
+	}
+	cfg.lastAttemptAttention = true
+	return nil
+}
+
+func authorizePeerWakeAttention(cfg *wakeConfig, payload wakePayload) error {
+	if cfg == nil ||
+		payload.provenance == wakePayloadSystemFixed ||
+		cfg.root == "" ||
+		cfg.me == "" ||
+		strings.TrimSpace(cfg.terminalGeneration) == "" {
+		return nil
+	}
+	// Fence notifications fired by mailbox-cohort state, including
+	// operator-authored interrupt text. System-fixed notices describe this
+	// process's own state and remain available for diagnostics.
+	// The platform layer owns the single generation classifier. Its typed
+	// error is reserved for a missing or readable-different retained
+	// generation; false with no error parks input but keeps attention alive.
+	_, _, err := classifyWakeGenerationPlatformState(cfg)
+	return err
 }
 
 func usesCoopDoorbell(cfg *wakeConfig) bool {
@@ -713,7 +1501,11 @@ func authorizeTerminalWrite(cfg *wakeConfig) (bool, error) {
 		cfg.terminalWrite == nil &&
 		cfg.root != "" &&
 		cfg.me != "" {
-		if !authorizeTerminalWritePlatform(cfg) {
+		allowed, err := authorizeTerminalWritePlatformState(cfg)
+		if err != nil {
+			return false, &wakeTerminalAuthorityError{err: err}
+		}
+		if !allowed {
 			return false, nil
 		}
 	}
@@ -749,6 +1541,83 @@ func writeTerminalChunk(cfg *wakeConfig, chunk string) (bool, error) {
 	return true, tiocstiInject(chunk)
 }
 
+func writePendingWakeInputChunk(
+	cfg *wakeConfig,
+	state *wakeInputDeliveryState,
+	chunk string,
+) (bool, error) {
+	if state.acceptanceUncertain {
+		return false, &wakeInputDemotionBlockedError{
+			err: errors.New("a prior terminal write has uncertain acceptance"),
+		}
+	}
+	if state.acceptedBytes < 0 || state.acceptedBytes > len(chunk) {
+		state.acceptanceUncertain = true
+		return false, &wakeTerminalProgressUncertainError{
+			err: fmt.Errorf(
+				"invalid retained input offset %d for %d-byte chunk",
+				state.acceptedBytes,
+				len(chunk),
+			),
+		}
+	}
+	remaining := chunk[state.acceptedBytes:]
+	wrote, err := writeTerminalChunk(cfg, remaining)
+	if err == nil {
+		if wrote {
+			state.acceptedBytes = 0
+		} else if state.confirmedInput() {
+			return false, &wakeTerminalPartialProgressError{
+				err: errors.New("terminal write authorization is temporarily unavailable"),
+			}
+		}
+		return wrote, nil
+	}
+
+	var unsupported *wakeInjectorUnsupportedError
+	if errors.As(err, &unsupported) {
+		if state.blocksDemotion() {
+			return wrote, &wakeInputDemotionBlockedError{err: err}
+		}
+		return wrote, err
+	}
+	if !wrote {
+		if state.confirmedInput() {
+			return false, &wakeTerminalPartialProgressError{err: err}
+		}
+		return false, err
+	}
+
+	var progress wakeTerminalAcceptedProgress
+	if !errors.As(err, &progress) {
+		if isWakeTerminalAuthorityLoss(err) {
+			if state.confirmedInput() {
+				return true, &wakeTerminalPartialProgressError{err: err}
+			}
+			return true, err
+		}
+		state.acceptanceUncertain = true
+		return true, &wakeTerminalProgressUncertainError{err: err}
+	}
+	accepted := progress.wakeAcceptedBytes()
+	if accepted < 0 || accepted >= len(remaining) {
+		state.acceptanceUncertain = true
+		return true, &wakeTerminalProgressUncertainError{
+			err: fmt.Errorf(
+				"invalid terminal progress %d for %d-byte suffix: %w",
+				accepted,
+				len(remaining),
+				err,
+			),
+		}
+	}
+	state.acceptedBytes += accepted
+	if state.confirmedInput() {
+		return true, &wakeTerminalPartialProgressError{err: err}
+	}
+	return true, err
+}
+
 // rawSubmitPrelude returns the bytes injected between the drained notification
 // text and the settle delay. codex targets get a single LF: codex-tui maps a
 // raw 0x0A to Ctrl-J, whose editor binding routes through handle_input_basic,
@@ -769,111 +1638,322 @@ func rawSubmitPrelude(me string) string {
 	return ""
 }
 
-func injectRawNotification(cfg *wakeConfig, injectedText string) error {
-	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
-	}
-	wrote, err := writeTerminalChunk(cfg, injectedText)
-	if err != nil {
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
-		}
-		return err
-	}
-	if !wrote {
-		return nil
-	}
-	prelude := rawSubmitPrelude(cfg.me)
+func clearWakeInputState(cfg *wakeConfig) {
+	cfg.inputDelivery.reset()
+}
 
-	// The submit key must arrive in its own read() chunk; otherwise the TUI can
-	// treat text+Enter as pasted input instead of a keypress. Waiting for the
-	// text bytes to drain keeps the submit key out of a paste-shaped chunk even
-	// when the reader stalls (#208).
-	waited, drained, err := waitForRawInputDrained(rawInjectDrainTimeout, rawInjectDrainPollInterval)
-	if cfg.debug {
-		switch {
-		case err != nil:
-			_ = writeStderr("amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
-		case drained:
-			_ = writeStderr("amq wake [debug]: input queue drained after %s\n", waited)
-		default:
-			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
+func retireWakeInputState(cfg *wakeConfig, cause error) error {
+	if cfg.inputDelivery.blocksDemotion() {
+		if cause == nil {
+			cause = errors.New("input retirement requested before terminal completion")
 		}
+		return &wakeInputDemotionBlockedError{err: cause}
 	}
-
-	// Prelude (codex: a lone LF) clears the TUI's paste-burst state while the
-	// injected text is fresh; its newline is trimmed from the submitted payload.
-	if prelude != "" {
-		wrote, err := writeTerminalChunk(cfg, prelude)
-		if err != nil {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: prelude inject failed: %v\n", err)
-			}
-			return err
-		}
-		if !wrote {
-			return nil
-		}
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: prelude injected OK (%q)\n", prelude)
-		}
-	}
-
-	// Hold the submit CR past the TUI's paste-burst window (see
-	// rawInjectSettleDelay) so it is classified as a real Enter keypress, not a
-	// pasted newline.
-	rawInjectSleep(rawInjectSettleDelay)
-
-	wrote, err = writeTerminalChunk(cfg, "\r")
-	if err != nil {
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
-		}
-		return err
-	}
-	if !wrote {
-		return nil
-	}
-	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
-	}
-
-	// Rescue submit: if the first Enter was swallowed anyway (input buffer
-	// flush or a burst-window race), a repeat Enter submits the composer; if
-	// the first already submitted, Enter on an empty composer is a no-op. The
-	// rescue must be spaced a full settle delay after the first: a swallowed
-	// Enter re-extends codex-tui's 120ms suppress window, so a faster rescue
-	// would be swallowed too. Skip the rescue only when the first submit key is
-	// provably still queued — a second would coalesce with it into one
-	// paste-shaped chunk and both would be swallowed.
-	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
-	if crErr == nil && !crDrained {
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", crWaited)
-		}
-		return nil
-	}
-	rawInjectSleep(rawInjectSettleDelay)
-	wrote, err = writeTerminalChunk(cfg, "\r")
-	if err != nil {
-		// The text and first submit key were already delivered; the rescue is
-		// best-effort unless exact terminal authority was lost.
-		var authorityErr *wakeTerminalAuthorityError
-		if errors.As(err, &authorityErr) {
-			return err
-		}
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
-		}
-		return nil
-	}
-	if !wrote {
-		return nil
-	}
-	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
-	}
+	cfg.doorbell.reset()
+	persistWakeDoorbellStatusBestEffort(cfg)
+	clearWakeInputState(cfg)
 	return nil
+}
+
+func disableWakeInput(cfg *wakeConfig, cause error) error {
+	rememberRequestedWakeInputMode(cfg)
+	if err := retireWakeInputState(cfg, cause); err != nil {
+		return err
+	}
+	cfg.injectMode = wakeInjectModeNone
+	cfg.legacyTIOCSTIDemoted = false
+	return nil
+}
+
+func disableWakeInputForLegacyTIOCSTI(cfg *wakeConfig, cause error) error {
+	rememberRequestedWakeInputMode(cfg)
+	if err := retireWakeInputState(cfg, cause); err != nil {
+		return err
+	}
+	cfg.injectMode = wakeInjectModeNone
+	cfg.legacyTIOCSTIDemoted = true
+	return nil
+}
+
+func rememberRequestedWakeInputMode(cfg *wakeConfig) {
+	if cfg.requestedInjectMode != "" ||
+		cfg.injectMode == "" ||
+		cfg.injectMode == wakeInjectModeNone {
+		return
+	}
+	cfg.requestedInjectMode = cfg.injectMode
+}
+
+func reconcileWakeInputAfterInboxDrain(cfg *wakeConfig) error {
+	if cfg.inputDelivery.acceptanceUncertain {
+		return &wakeInputDemotionBlockedError{
+			err: errors.New("inbox progressed after a terminal write with uncertain acceptance"),
+		}
+	}
+	if !cfg.inputDelivery.pending() {
+		return nil
+	}
+	if cfg.inputDelivery.phase == wakeInputPayloadPending {
+		// Inbox is empty: never finish or repeat doorbell text. A queued submit
+		// may still complete so an already-presented prompt does not sit idle.
+		clearWakeInputState(cfg)
+		return nil
+	}
+	_, err := resumeWakeInputDelivery(cfg)
+	return err
+}
+
+func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
+	return injectTerminalNotification(cfg, wakeInjectModeRaw, injectedText)
+}
+
+func injectTerminalNotification(
+	cfg *wakeConfig,
+	mode string,
+	payload string,
+) (bool, error) {
+	state := &cfg.inputDelivery
+	if state.acceptanceUncertain {
+		return false, &wakeInputDemotionBlockedError{
+			err: errors.New("new terminal input arrived after a write with uncertain acceptance"),
+		}
+	}
+	if state.pending() && (state.mode != mode || state.payload != payload) {
+		if state.phase == wakeInputPayloadPending && state.acceptedBytes == 0 {
+			// The previous payload never made confirmed progress.
+			state.reset()
+		} else {
+			completed, err := resumeWakeInputDelivery(cfg)
+			if err != nil || !completed {
+				return false, err
+			}
+		}
+	}
+	if !state.pending() {
+		*state = wakeInputDeliveryState{
+			phase:   wakeInputPayloadPending,
+			mode:    mode,
+			payload: payload,
+		}
+	}
+	return resumeWakeInputDelivery(cfg)
+}
+
+func injectTerminalSubmitOnly(cfg *wakeConfig, mode string) (bool, error) {
+	state := &cfg.inputDelivery
+	if state.acceptanceUncertain {
+		return false, &wakeInputDemotionBlockedError{
+			err: errors.New("submit-only terminal input followed a write with uncertain acceptance"),
+		}
+	}
+	if state.pending() {
+		if state.mode != mode || state.payload != "" {
+			return false, &wakeInputDemotionBlockedError{
+				err: errors.New("submit-only terminal input collided with retained payload delivery"),
+			}
+		}
+		return resumeWakeInputDelivery(cfg)
+	}
+
+	// A submit-only reminder carries no fresh text and runs well after the
+	// target's paste-burst window. Reusing the Codex LF prelude here would put a
+	// literal blank line into an already-empty composer on every retry.
+	*state = wakeInputDeliveryState{
+		phase: wakeInputPrimarySubmitPending,
+		mode:  mode,
+	}
+	return resumeWakeInputDelivery(cfg)
+}
+
+func resumeWakeInputDelivery(cfg *wakeConfig) (bool, error) {
+	state := &cfg.inputDelivery
+	for state.pending() {
+		switch state.phase {
+		case wakeInputPayloadPending:
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: injecting %d bytes of text\n", len(state.payload))
+			}
+			wrote, err := writePendingWakeInputChunk(cfg, state, state.payload)
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: text inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if state.mode == wakeInjectModePaste {
+				state.phase = wakeInputPrimarySubmitPending
+				continue
+			}
+			if state.mode != wakeInjectModeRaw {
+				return false, fmt.Errorf("unsupported pending wake input mode %q", state.mode)
+			}
+
+			// The submit key must arrive in its own read() chunk; otherwise the
+			// TUI can treat text+Enter as pasted input instead of a keypress.
+			waited, drained, err := waitForRawInputDrained(
+				rawInjectDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if cfg.debug {
+				switch {
+				case err != nil:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
+				case drained:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input queue drained after %s\n", waited)
+				default:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
+				}
+			}
+			if rawSubmitPrelude(cfg.me) != "" {
+				state.phase = wakeInputRawPreludePending
+			} else {
+				state.phase = wakeInputPrimarySubmitPending
+			}
+
+		case wakeInputRawPreludePending:
+			prelude := rawSubmitPrelude(cfg.me)
+			if prelude == "" {
+				state.phase = wakeInputPrimarySubmitPending
+				continue
+			}
+			wrote, err := writePendingWakeInputChunk(cfg, state, prelude)
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: prelude inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: prelude injected OK (%q)\n", prelude)
+			}
+			state.phase = wakeInputPrimarySubmitPending
+
+		case wakeInputPrimarySubmitPending:
+			if state.mode == wakeInjectModePaste {
+				// Keep Enter in a separate read cycle from the paste payload.
+				time.Sleep(25 * time.Millisecond)
+			} else {
+				// Hold the submit CR past the TUI's paste-burst window.
+				rawInjectSleep(rawInjectSettleDelay)
+			}
+			wrote, err := writePendingWakeInputChunk(cfg, state, "\r")
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if state.mode == wakeInjectModePaste {
+				state.reset()
+				return true, nil
+			}
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key injected OK\n")
+			}
+
+			// A repeat Enter rescues a swallowed first submit. Skip it only when
+			// the first Enter is provably still queued.
+			waited, drained, drainErr := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if drainErr == nil && !drained {
+				state.phase = wakeInputRawFirstSubmitQueued
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", waited)
+				}
+				return false, nil
+			}
+			// When queue inspection is unavailable, preserve the historical one
+			// spaced rescue, but retain this exact step across authority loss.
+			state.phase = wakeInputRawRescuePending
+
+		case wakeInputRawFirstSubmitQueued:
+			waited, drained, err := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if cfg.debug {
+				switch {
+				case err != nil:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
+				case !drained:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
+				}
+			}
+			if err != nil || !drained {
+				return false, nil
+			}
+			state.phase = wakeInputRawRescuePending
+
+		case wakeInputRawRescuePending:
+			rawInjectSleep(rawInjectSettleDelay)
+			wrote, err := writePendingWakeInputChunk(cfg, state, "\r")
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit injected OK\n")
+			}
+			waited, drained, drainErr := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if drainErr != nil {
+				// Queue inspection is best-effort. A successful write remains
+				// the strongest available completion evidence.
+				state.reset()
+				return true, nil
+			}
+			if !drained {
+				state.phase = wakeInputRawRescueQueued
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit still queued after %s; waiting for terminal reader\n", waited)
+				}
+				return false, nil
+			}
+			state.reset()
+			return true, nil
+
+		case wakeInputRawRescueQueued:
+			waited, drained, err := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if cfg.debug {
+				switch {
+				case err != nil:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
+				case !drained:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
+				}
+			}
+			if err != nil || !drained {
+				return false, nil
+			}
+			state.reset()
+			return true, nil
+
+		default:
+			return false, fmt.Errorf("invalid pending wake input phase %d", state.phase)
+		}
+	}
+	return true, nil
 }
 
 func waitForInputQueueDrain(
@@ -916,7 +1996,7 @@ func waitForInputQueueDrain(
 
 func injectVia(cfg *wakeConfig, text string) error {
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
 	}
 
 	executable := strings.TrimSpace(cfg.injectVia)
@@ -938,17 +2018,29 @@ func injectVia(cfg *wakeConfig, text string) error {
 	args := append([]string{}, cfg.injectArgs...)
 	args = append(args, text)
 	cmd := exec.CommandContext(ctx, executable, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
-			}
-			return fmt.Errorf("inject-via timed out after %s", timeout)
-		}
+	waitDelay := timeout / 10
+	if waitDelay <= 0 {
+		waitDelay = time.Millisecond
+	}
+	if waitDelay > 100*time.Millisecond {
+		waitDelay = 100 * time.Millisecond
+	}
+	cmd.WaitDelay = waitDelay
+	out, runErr := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded || errors.Is(runErr, exec.ErrWaitDelay) {
 		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: inject-via failed: %v (%s)\n", err, string(out))
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
 		}
-		return err
+		return fmt.Errorf("inject-via timed out after %s", timeout)
+	}
+	if runErr != nil {
+		if cfg.debug {
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via failed: %v (%s)\n", runErr, string(out))
+		}
+		if strings.Contains(string(out), "AMQ_INJECT_PROGRESS=uncertain") {
+			return &wakeTerminalProgressUncertainError{err: runErr}
+		}
+		return runErr
 	}
 
 	return nil

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 )
 
 type wakeInfoErrorDirEntry struct {
@@ -266,6 +267,76 @@ func TestInjectNotification_InjectVia(t *testing.T) {
 	}
 	if string(got) != text {
 		t.Fatalf("expected %q, got %q", text, string(got))
+	}
+}
+
+func TestNotifyNewMessagesPersistsTwoPhaseNotificationAttempt(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	message := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      "msg-ledger",
+			From:    "codex",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__codex",
+			Subject: "ledger evidence",
+			Created: "2026-07-26T18:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-ledger.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.root = root
+	cfg.me = "alice"
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notifyNewMessages: %v", err)
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("external notifier output: %v", err)
+	}
+
+	attempts, err := notificationattempt.List(root, "alice", "msg-ledger")
+	if err != nil {
+		t.Fatalf("List attempts: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != notificationattempt.OutcomeWritten ||
+		attempts[0].Result == nil {
+		t.Fatalf("attempts = %+v", attempts)
+	}
+	if attempts[0].Prepared.Mode != "external" ||
+		strings.Contains(attempts[0].Result.Outcome, "display") ||
+		strings.Contains(attempts[0].Result.Outcome, "submit") {
+		t.Fatalf("dishonest attempt record = %+v", attempts[0])
+	}
+}
+
+func TestNotificationAttemptLoggingIsBestEffort(t *testing.T) {
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.me = "../invalid-ledger-owner"
+	cfg.root = t.TempDir()
+
+	if err := attemptNotification(cfg, []string{"msg-best-effort"}, "doorbell", true); err != nil {
+		t.Fatalf("attemptNotification: %v", err)
+	}
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("external notifier output: %v", err)
+	}
+	if string(got) != "doorbell" {
+		t.Fatalf("notifier output = %q", got)
 	}
 }
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
-	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 )
 
 type wakeInfoErrorDirEntry struct {
@@ -267,76 +266,6 @@ func TestInjectNotification_InjectVia(t *testing.T) {
 	}
 	if string(got) != text {
 		t.Fatalf("expected %q, got %q", text, string(got))
-	}
-}
-
-func TestNotifyNewMessagesPersistsTwoPhaseNotificationAttempt(t *testing.T) {
-	root := secureTempDirForTest(t)
-	if err := fsq.EnsureRootDirs(root); err != nil {
-		t.Fatal(err)
-	}
-	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
-		t.Fatal(err)
-	}
-	message := format.Message{
-		Header: format.Header{
-			Schema:  format.CurrentSchema,
-			ID:      "msg-ledger",
-			From:    "codex",
-			To:      []string{"alice"},
-			Thread:  "p2p/alice__codex",
-			Subject: "ledger evidence",
-			Created: "2026-07-26T18:00:00Z",
-		},
-		Body: "body",
-	}
-	data, err := message.Marshal()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := deliverToInboxForTest(t, root, "alice", "msg-ledger.md", data); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, outputPath := injectViaCaptureConfig(t)
-	cfg.root = root
-	cfg.me = "alice"
-	if err := notifyNewMessages(cfg); err != nil {
-		t.Fatalf("notifyNewMessages: %v", err)
-	}
-	if _, err := os.Stat(outputPath); err != nil {
-		t.Fatalf("external notifier output: %v", err)
-	}
-
-	attempts, err := notificationattempt.List(root, "alice", "msg-ledger")
-	if err != nil {
-		t.Fatalf("List attempts: %v", err)
-	}
-	if len(attempts) != 1 || attempts[0].State != notificationattempt.OutcomeWritten ||
-		attempts[0].Result == nil {
-		t.Fatalf("attempts = %+v", attempts)
-	}
-	if attempts[0].Prepared.Mode != "external" ||
-		strings.Contains(attempts[0].Result.Outcome, "display") ||
-		strings.Contains(attempts[0].Result.Outcome, "submit") {
-		t.Fatalf("dishonest attempt record = %+v", attempts[0])
-	}
-}
-
-func TestNotificationAttemptLoggingIsBestEffort(t *testing.T) {
-	cfg, outputPath := injectViaCaptureConfig(t)
-	cfg.me = "../invalid-ledger-owner"
-	cfg.root = t.TempDir()
-
-	if err := attemptNotification(cfg, []string{"msg-best-effort"}, "doorbell", true); err != nil {
-		t.Fatalf("attemptNotification: %v", err)
-	}
-	got, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("external notifier output: %v", err)
-	}
-	if string(got) != "doorbell" {
-		t.Fatalf("notifier output = %q", got)
 	}
 }
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 )
 
 type wakeInfoErrorDirEntry struct {
@@ -266,6 +267,77 @@ func TestInjectNotification_InjectVia(t *testing.T) {
 	}
 	if string(got) != text {
 		t.Fatalf("expected %q, got %q", text, string(got))
+	}
+}
+
+// TestDeliverWithNotificationLedgerDoesNotBlockOnWriteFailure pins the single
+// most important invariant of the notification-attempt ledger: a wake delivers
+// the notification EVEN WHEN the ledger write fails. The ledger must never
+// block a doorbell. This is the wake-layer assertion that was lost when the
+// obsolete TestNotificationAttemptLoggingIsBestEffort was removed (it called
+// the deleted attemptNotification symbol); the package-level Writer test
+// (TestPrepareWriteFailureDoesNotBlockAndResultIsRecordable) proves the Writer
+// degrades gracefully, but only this test exercises the wake wiring
+// (deliverWithNotificationLedger -> deliverNewMessageNotification) and can
+// catch a future refactor that returns early on prepareErr before delivery.
+//
+// We force the ledger Prepare to fail by setting cfg.me to a handle
+// ValidateHandle rejects (contains ".."), then call deliverWithNotificationLedger
+// directly and assert: (1) the external notifier still produced its output
+// (delivery happened), and (2) the returned error is the delivery error (nil
+// here, since the external notifier succeeds), NOT the ledger prepareErr — a
+// regression that leaked the ledger error through the return would surface as
+// a non-nil error mentioning "notification attempt agent".
+func TestDeliverWithNotificationLedgerDoesNotBlockOnWriteFailure(t *testing.T) {
+	cfg, outputPath := injectViaCaptureConfig(t, "doorbell")
+	// A root must exist so EnsureAgentDirs can create the receipts dir; the
+	// ledger failure comes from the invalid agent handle, not a missing root.
+	cfg.root = t.TempDir()
+	// Force Prepare to fail: ValidateHandle rejects handles containing ".." or
+	// "/", so the Writer's Prepare returns a non-nil prepareErr before any
+	// record is persisted. Delivery must proceed anyway.
+	cfg.me = "../invalid-ledger-owner"
+	// inject-via delivery requires a non-none inject mode; raw is the simplest.
+	cfg.injectMode = wakeInjectModeRaw
+
+	notice := peerWakeNotification("doorbell")
+	messageIDs := []string{"msg-best-effort"}
+	// deliverNewMessageNotification gates on doorbell.plan(now, currentPending).attempt:
+	// an empty map returns attempt=false and the function returns before delivery.
+	// A non-empty map with a zero-value doorbell state arms and attempts. The
+	// FileInfo may be nil (snapshotWakeFileIdentities accepts nil), so a bare
+	// key is enough to make delivery proceed.
+	currentPending := map[string]os.FileInfo{"msg-best-effort.md": nil}
+
+	deliverErr := deliverWithNotificationLedger(cfg, messageIDs, notice, false, currentPending)
+
+	// (1) Delivery happened despite the ledger write failure: the external
+	// notifier wrote its payload to the capture file. If the ledger error had
+	// blocked delivery, this file would not exist (or be empty).
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("delivery did not happen on ledger write failure — notifier output not written: %v", err)
+	}
+	if !strings.Contains(string(got), "doorbell") {
+		t.Fatalf("notifier output = %q, want it to contain %q (delivery happened but payload wrong)", got, "doorbell")
+	}
+
+	// (2) The return is the DELIVERY error, not the ledger prepareErr. The
+	// external notifier succeeded, so deliverErr must be nil. If a future
+	// refactor leaked prepareErr through the return, deliverErr would be
+	// non-nil and mention "notification attempt agent" (the ValidateHandle
+	// error string from Prepare).
+	if deliverErr != nil {
+		t.Fatalf("deliverWithNotificationLedger returned the ledger error instead of the delivery error: got %v (delivery succeeded, so this should be nil)", deliverErr)
+	}
+
+	// (3) No journal file should exist — Prepare failed before any write. This
+	// confirms the failure was the intended ledger-write path, not a silent
+	// skip, and that trace would surface StateWriteFailed rather than a bogus
+	// "written" record.
+	journalPath := filepath.Join(cfg.root, "agents", cfg.me, "receipts", notificationattempt.LogFilename)
+	if _, err := os.Stat(journalPath); !os.IsNotExist(err) {
+		t.Fatalf("ledger journal should not exist after Prepare failure, got err: %v", err)
 	}
 }
 

--- a/internal/notificationattempt/flock_other.go
+++ b/internal/notificationattempt/flock_other.go
@@ -1,0 +1,19 @@
+//go:build !(darwin || dragonfly || freebsd || linux || netbsd || openbsd)
+
+package notificationattempt
+
+import (
+	"errors"
+	"os"
+)
+
+// errLockingUnsupported is returned by the no-op fallbacks on platforms
+// without syscall.Flock. The ledger still compiles and runs; the rotation
+// race is not closed there, but those platforms (e.g. wasm/plan9) are not
+// wake hosts. This mirrors the keepalive registry's cross-process-lock
+// stance: fail closed on the guarantee rather than silently weaken it.
+var errLockingUnsupported = errors.New("notification attempt journal locking is unsupported on this platform")
+
+func flockShared(_ *os.File) error    { return errLockingUnsupported }
+func flockExclusive(_ *os.File) error { return errLockingUnsupported }
+func flockRelease(_ *os.File)         {}

--- a/internal/notificationattempt/flock_unix.go
+++ b/internal/notificationattempt/flock_unix.go
@@ -1,0 +1,37 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package notificationattempt
+
+import (
+	"os"
+	"syscall"
+)
+
+// flockShared takes a shared advisory lock on the open lock file, blocking
+// until it is available. Shared locks do not contend with each other, so
+// concurrent appenders stay concurrent — the O_APPEND hot path keeps its
+// lock-free-among-appenders property. The lock exists only to exclude the
+// rare rotation path, which takes LOCK_EX.
+//
+// The lock file is distinct from the data file (see append), so locking it
+// does not race with rotation truncating/recreating the data file — flock is
+// per-inode and the lock file's inode never changes.
+func flockShared(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_SH)
+}
+
+// flockExclusive takes an exclusive advisory lock on the open lock file,
+// blocking until all shared (append) and exclusive (rotation) holders have
+// released. This serializes rotation against the hot path and against other
+// rotators, closing the read→merge→truncate window where an O_APPEND writer
+// could otherwise land a record that the subsequent truncate discards.
+func flockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+// flockRelease releases any held advisory lock. Safe to call on an unlocked fd.
+// A single LOCK_SH call after holding LOCK_EX atomically downgrades EX→SH,
+// letting waiting appenders proceed while we keep SH for our own append.
+func flockRelease(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/notificationattempt/flock_unix.go
+++ b/internal/notificationattempt/flock_unix.go
@@ -30,8 +30,12 @@ func flockExclusive(f *os.File) error {
 }
 
 // flockRelease releases any held advisory lock. Safe to call on an unlocked fd.
-// A single LOCK_SH call after holding LOCK_EX atomically downgrades EX→SH,
-// letting waiting appenders proceed while we keep SH for our own append.
+//
+// Note: a LOCK_SH call while holding LOCK_EX converts EX->SH, but this is NOT
+// atomic on Linux — the EX is dropped before the SH is acquired, so a pending
+// EX elsewhere may be granted in the gap. Callers that downgrade must not rely
+// on atomic conversion for correctness; the append path is safe because it
+// re-opens the data file only after the SH is held.
 func flockRelease(f *os.File) {
 	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -225,27 +225,76 @@ func (w *Writer) append(record Record) error {
 	}
 	dir := filepath.Join("agents", w.agent, "receipts")
 	fullPath := filepath.Join(root.Base(), dir, LogFilename)
+	lockPath := fullPath + ".lock"
 
-	// Rotate if the current file plus this record would exceed the cap. Read
-	// the size via stat (not by reading the file — rotation is a size check,
-	// not a read-modify-write). If stat fails (file doesn't exist yet), skip.
+	// Coordination model: a separate lock file carries the flock; the data file
+	// stays O_APPEND so the hot-path write remains kernel-atomic at EOF among
+	// concurrent appenders (requirement 1, unchanged). The lock gates ONLY the
+	// rare rotation.
+	//
+	//	appender: flock(LOCK_SH) on lock file -> O_APPEND write on data file
+	//	rotator:  flock(LOCK_EX) on lock file -> read+merge+truncate data file
+	//
+	// LOCK_SH holders do not contend with each other, so concurrent appenders
+	// stay concurrent — the hot path keeps its lock-free-among-appenders
+	// property; the cost is one flock(LOCK_SH) syscall, never serialization
+	// between appends. LOCK_EX waits for in-flight appenders and blocks new
+	// ones only for the rotation window, closing the race where an O_APPEND
+	// write landed between rotation's read and its truncate — the exact
+	// silent-loss path REQ1 removed on the hot path but rotation reintroduced.
+	//
+	// The lock file is distinct from the data file so rotation may freely
+	// truncate or rename the data file without invalidating anyone's lock:
+	// appenders lock the lock file, not the data file, so a rotated/recreated
+	// data file does not orphan a held lock. (flock is per-inode; had we locked
+	// the data file, a rename-based rotation would detach the lock. We truncate
+	// in place anyway, but the separate lock file is robust to either choice.)
+	lockFile, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("open notification attempt journal lock: %w", err)
+	}
+	defer func() { _ = lockFile.Close() }()
+
+	// Decide whether this append triggers a rotation. The size check is a stat
+	// on the data file BEFORE taking the lock: it is a hint, not a commitment.
+	// If two appenders race past this check, the one that wins LOCK_EX below
+	// rotates; the loser, on acquiring LOCK_SH, finds the file already
+	// truncated and simply appends to the fresh file. A stale-high stat (size
+	// grew after we read it) is harmless — the locked re-check corrects it.
+	rotate := false
 	if info, statErr := os.Stat(fullPath); statErr == nil {
-		if info.Size()+int64(len(data)) > w.maxBytes {
-			// Rotation: the current file becomes .1. To avoid destroying a prior
-			// .1 (which would silently lose the oldest records on a second
-			// rotation), append the current file's contents to any existing .1.
-			// This is read-modify-write, but it runs ONLY on rotation (once per
-			// ~1700 records at the default 256KB cap), never on the hot append
-			// path — the O_APPEND write below is the hot path and stays lock-free.
+		rotate = info.Size()+int64(len(data)) > w.maxBytes
+	}
+
+	if rotate {
+		// LOCK_EX serializes rotation against all appenders: it blocks until
+		// every in-flight LOCK_SH appender has finished its write and released,
+		// then prevents new appends for the duration of read->merge->truncate.
+		if err := flockExclusive(lockFile); err != nil {
+			return fmt.Errorf("lock notification attempt journal for rotation: %w", err)
+		}
+		// Re-check the size UNDER LOCK_EX: another rotator that held EX before
+		// us may have already truncated, making rotation unnecessary now. This
+		// is what prevents double rotation and the lost-record window.
+		if info2, e2 := os.Stat(fullPath); e2 == nil {
+			rotate = info2.Size()+int64(len(data)) > w.maxBytes
+		} else {
+			rotate = false
+		}
+		if rotate {
 			rotated := fullPath + rotatedSuffix
 			current, readErr := os.ReadFile(fullPath)
 			if readErr != nil && !os.IsNotExist(readErr) {
-				// Can't read current to merge — append anyway (over-size log is
-				// better than a lost record). The prior .1 is overwritten.
+				// Can't read current to merge — shed the over-size log by rename
+				// (better than a lost record); the prior .1 is overwritten. Still
+				// under LOCK_EX so no appender is racing us.
 				_ = os.Rename(fullPath, rotated)
 			} else if readErr == nil {
-				// Append current to .1 (merge generations), then truncate current.
-				if existing, err := os.ReadFile(rotated); err == nil {
+				// Merge current into .1 (preserve older generations), then
+				// truncate current in place. We hold LOCK_EX so no appender can
+				// O_APPEND a record between this read and the truncate — the
+				// race that reintroduced silent loss is closed.
+				if existing, eerr := os.ReadFile(rotated); eerr == nil {
 					_ = os.WriteFile(rotated, append(existing, current...), 0o600)
 				} else {
 					_ = os.WriteFile(rotated, current, 0o600)
@@ -253,11 +302,30 @@ func (w *Writer) append(record Record) error {
 				_ = os.Truncate(fullPath, 0)
 			}
 		}
+		// Downgrade LOCK_EX -> LOCK_SH for the append. flock downgrades are a
+		// single LOCK_SH call: it atomically releases EX and acquires SH, so
+		// waiting appenders can proceed while we still hold SH for our own write.
+		if err := flockShared(lockFile); err != nil {
+			flockRelease(lockFile)
+			return fmt.Errorf("downgrade to shared lock for append: %w", err)
+		}
+		defer flockRelease(lockFile)
+	} else {
+		// Hot path: shared lock. Does not contend with other appenders, so the
+		// O_APPEND write below stays concurrent and kernel-atomic at EOF. The
+		// lock excludes only the rare rotation (LOCK_EX), which is the point.
+		if err := flockShared(lockFile); err != nil {
+			return fmt.Errorf("lock notification attempt journal for append: %w", err)
+		}
+		defer flockRelease(lockFile)
 	}
 
-	// O_APPEND | O_CREATE | O_WRONLY with mode 0600. On local filesystems the
-	// kernel serializes O_APPEND writes, so concurrent writers each append a
-	// full line atomically — no lost-update race, no lock needed.
+	// O_APPEND | O_CREATE | O_WRONLY, mode 0600. Opened AFTER acquiring the
+	// lock so the fd we write through reflects any rotation that just ran (a
+	// truncated or renamed-and-recreated current file). We hold LOCK_SH, so no
+	// rotator can truncate beneath this write. Among concurrent appenders the
+	// kernel serializes O_APPEND writes — each lands a full line at EOF
+	// atomically, no lost-update race (requirement 1, preserved).
 	f, err := os.OpenFile(fullPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("open notification attempt journal: %w", err)

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -1,0 +1,294 @@
+package notificationattempt
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	Schema = "amq/notification-attempt/v1"
+
+	PhasePrepared = "prepared"
+	PhaseResult   = "result"
+
+	OutcomeWritten = "written"
+	OutcomeFailed  = "failed"
+
+	StateIndeterminate = "indeterminate"
+
+	PreparedFilename = "notification-attempts.prepared.jsonl"
+	ResultFilename   = "notification-attempts.result.jsonl"
+	rotatedSuffix    = ".1"
+
+	defaultMaxBytes = 256 * 1024
+)
+
+type Record struct {
+	Schema     string   `json:"schema"`
+	AttemptID  string   `json:"attempt_id"`
+	Phase      string   `json:"phase"`
+	MessageIDs []string `json:"message_ids"`
+	Agent      string   `json:"agent"`
+	Mode       string   `json:"mode"`
+	RecordedAt string   `json:"recorded_at"`
+	Outcome    string   `json:"outcome,omitempty"`
+	Detail     string   `json:"detail,omitempty"`
+}
+
+type Attempt struct {
+	State    string  `json:"state"`
+	Prepared Record  `json:"prepared"`
+	Result   *Record `json:"result,omitempty"`
+}
+
+type Writer struct {
+	root     string
+	agent    string
+	maxBytes int64
+	now      func() time.Time
+}
+
+func NewWriter(root, agent string) *Writer {
+	return &Writer{
+		root:     root,
+		agent:    agent,
+		maxBytes: defaultMaxBytes,
+		now:      time.Now,
+	}
+}
+
+func (w *Writer) Prepare(messageIDs []string, mode string) (Record, error) {
+	if err := fsq.ValidateHandle(w.agent); err != nil {
+		return Record{}, fmt.Errorf("notification attempt agent: %w", err)
+	}
+	ids := normalizedMessageIDs(messageIDs)
+	if len(ids) == 0 {
+		return Record{}, fmt.Errorf("notification attempt requires at least one message id")
+	}
+	attemptID, err := format.NewMessageID(w.now())
+	if err != nil {
+		return Record{}, fmt.Errorf("notification attempt id: %w", err)
+	}
+	record := Record{
+		Schema:     Schema,
+		AttemptID:  attemptID,
+		Phase:      PhasePrepared,
+		MessageIDs: ids,
+		Agent:      w.agent,
+		Mode:       strings.TrimSpace(mode),
+		RecordedAt: w.now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := w.append(PreparedFilename, record); err != nil {
+		return Record{}, fmt.Errorf("persist prepared notification attempt: %w", err)
+	}
+	return record, nil
+}
+
+func (w *Writer) Result(prepared Record, outcome, detail string) error {
+	if outcome != OutcomeWritten && outcome != OutcomeFailed {
+		return fmt.Errorf("notification attempt outcome must be %q or %q", OutcomeWritten, OutcomeFailed)
+	}
+	if prepared.Phase != PhasePrepared || prepared.AttemptID == "" ||
+		prepared.Agent != w.agent || len(prepared.MessageIDs) == 0 {
+		return fmt.Errorf("invalid prepared notification attempt")
+	}
+	record := Record{
+		Schema:     Schema,
+		AttemptID:  prepared.AttemptID,
+		Phase:      PhaseResult,
+		MessageIDs: append([]string{}, prepared.MessageIDs...),
+		Agent:      w.agent,
+		Mode:       prepared.Mode,
+		RecordedAt: w.now().UTC().Format(time.RFC3339Nano),
+		Outcome:    outcome,
+		Detail:     strings.TrimSpace(detail),
+	}
+	if err := w.append(ResultFilename, record); err != nil {
+		return fmt.Errorf("persist notification attempt result: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) append(filename string, record Record) error {
+	if w.maxBytes <= 0 {
+		return fmt.Errorf("notification attempt journal size cap must be positive")
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if int64(len(data)) > w.maxBytes {
+		return fmt.Errorf("notification attempt record is %d bytes, cap is %d", len(data), w.maxBytes)
+	}
+
+	identity, err := fsq.SnapshotDeliveryRoot(w.root)
+	if err != nil {
+		return err
+	}
+	root, err := fsq.OpenDeliveryRoot(w.root, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+
+	dir := filepath.Join("agents", w.agent, "receipts")
+	path := filepath.Join(dir, filename)
+	current, err := root.ReadRegularNoFollow(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if os.IsNotExist(err) {
+		current = nil
+	}
+	if int64(len(current)+len(data)) > w.maxBytes {
+		if len(current) > 0 {
+			if _, err := root.WriteFileAtomic(dir, filename+rotatedSuffix, current, 0o600); err != nil {
+				return fmt.Errorf("rotate notification attempt journal: %w", err)
+			}
+		}
+		current = nil
+	}
+	next := make([]byte, 0, len(current)+len(data))
+	next = append(next, current...)
+	next = append(next, data...)
+	if _, err := root.WriteFileAtomic(dir, filename, next, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func List(root, agent, messageID string) ([]Attempt, error) {
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	return ListDeliveryRoot(deliveryRoot, agent, messageID)
+}
+
+func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attempt, error) {
+	if err := fsq.ValidateHandle(agent); err != nil {
+		return nil, fmt.Errorf("notification attempt agent: %w", err)
+	}
+	prepared, err := readRecords(root, agent, PreparedFilename, PhasePrepared)
+	if err != nil {
+		return nil, err
+	}
+	results, err := readRecords(root, agent, ResultFilename, PhaseResult)
+	if err != nil {
+		return nil, err
+	}
+	resultByAttempt := make(map[string]Record, len(results))
+	for _, result := range results {
+		resultByAttempt[result.AttemptID] = result
+	}
+	preparedByAttempt := make(map[string]Record, len(prepared))
+	for _, item := range prepared {
+		preparedByAttempt[item.AttemptID] = item
+	}
+	var attempts []Attempt
+	for _, item := range preparedByAttempt {
+		if messageID != "" && !contains(item.MessageIDs, messageID) {
+			continue
+		}
+		attempt := Attempt{State: StateIndeterminate, Prepared: item}
+		if result, ok := resultByAttempt[item.AttemptID]; ok {
+			resultCopy := result
+			attempt.State = result.Outcome
+			attempt.Result = &resultCopy
+		}
+		attempts = append(attempts, attempt)
+	}
+	sort.SliceStable(attempts, func(i, j int) bool {
+		return attempts[i].Prepared.RecordedAt < attempts[j].Prepared.RecordedAt
+	})
+	return attempts, nil
+}
+
+func readRecords(root *fsq.DeliveryRoot, agent, filename, phase string) ([]Record, error) {
+	dir := filepath.Join("agents", agent, "receipts")
+	var records []Record
+	for _, name := range []string{filename + rotatedSuffix, filename} {
+		path := filepath.Join(dir, name)
+		data, err := root.ReadRegularNoFollow(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read notification attempt journal %s: %w", path, err)
+		}
+		scanner := bufio.NewScanner(strings.NewReader(string(data)))
+		scanner.Buffer(make([]byte, 4096), defaultMaxBytes)
+		line := 0
+		for scanner.Scan() {
+			line++
+			if strings.TrimSpace(scanner.Text()) == "" {
+				continue
+			}
+			var record Record
+			if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+				return nil, fmt.Errorf("parse notification attempt journal %s line %d: %w", path, line, err)
+			}
+			if err := validateRecord(record, agent, phase); err != nil {
+				return nil, fmt.Errorf("parse notification attempt journal %s line %d: %w", path, line, err)
+			}
+			records = append(records, record)
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("scan notification attempt journal %s: %w", path, err)
+		}
+	}
+	return records, nil
+}
+
+func validateRecord(record Record, agent, phase string) error {
+	if record.Schema != Schema || record.Agent != agent || record.Phase != phase ||
+		record.AttemptID == "" || len(record.MessageIDs) == 0 || record.RecordedAt == "" {
+		return fmt.Errorf("invalid %s record", phase)
+	}
+	if phase == PhasePrepared && record.Outcome != "" {
+		return fmt.Errorf("prepared record must not claim an outcome")
+	}
+	if phase == PhaseResult && record.Outcome != OutcomeWritten && record.Outcome != OutcomeFailed {
+		return fmt.Errorf("result outcome must be %q or %q", OutcomeWritten, OutcomeFailed)
+	}
+	return nil
+}
+
+func normalizedMessageIDs(messageIDs []string) []string {
+	seen := make(map[string]bool, len(messageIDs))
+	ids := make([]string, 0, len(messageIDs))
+	for _, raw := range messageIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -1,8 +1,42 @@
+// Package notificationattempt persists a durable audit log of notification
+// write attempts (prepared → result) so that `amq trace` can report whether a
+// wake attempted to notify an agent and what the outcome was.
+//
+// The ledger NEVER blocks delivery: if persisting the prepared record fails,
+// the wake injects anyway and the failure is recorded for trace to surface.
+// An audit log that blocks the thing it audits is worse than no audit log.
+//
+// Design (lead review 2026-08-30, three hard requirements):
+//
+//  1. TRUE append-only (O_APPEND), not read-modify-write. The prototype read
+//     the whole journal, concatenated, and called WriteFileAtomic — O(n) per
+//     notification on the wake hot path, and a lost-update race under
+//     concurrency (two notifications both read current, both append, one
+//     record vanishes silently). O_APPEND gives kernel-level atomic appends
+//     on local filesystems: concurrent writers each append a full line and
+//     neither loses data. There is no read-modify-write and no lock.
+//
+//  2. ONE log, not two. The prototype used separate prepared/result files
+//     rotated independently; whichever crossed the size cap first dropped its
+//     old records while the other kept its partners, orphaning results that
+//     trace would render as "attempted, never completed" — a false failure
+//     report for the exact scenario this ledger exists to diagnose. In a
+//     single append-only log, a result is always written AFTER its prepared,
+//     so rotation (a size-capped move to .1) drops the prepared first and can
+//     never orphan a surviving result. The phase field distinguishes them.
+//
+//  3. trace distinguishes "no attempt recorded" from "recording failed". If
+//     the prepared write itself fails and the wake injects anyway (correct),
+//     the journal has a hole. An operator debugging a missed doorbell must
+//     not conclude the wake never tried. Prepare returns a writeErr that the
+//     caller carries; trace surfaces a distinct leg wording for "we failed to
+//     keep the record" vs "we have no record".
 package notificationattempt
 
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +49,12 @@ import (
 )
 
 const (
-	Schema = "amq/notification-attempt/v1"
+	// SchemaVersion is the integer schema version of a Record. v1 is the
+	// initial shape. A versioned reader (readRecords) handles migration: if a
+	// future field set changes, bump this and add a migration branch in
+	// validateRecord. Do not remove the version check — an unversioned reader
+	// is how a schema change silently corrupts history.
+	SchemaVersion = 1
 
 	PhasePrepared = "prepared"
 	PhaseResult   = "result"
@@ -23,17 +62,29 @@ const (
 	OutcomeWritten = "written"
 	OutcomeFailed  = "failed"
 
+	// StateIndeterminate: a prepared record exists with no matching result.
+	// The wake may still be in flight, or it may have crashed between prepare
+	// and result. Trace renders this as "attempted; outcome unknown".
 	StateIndeterminate = "indeterminate"
 
-	PreparedFilename = "notification-attempts.prepared.jsonl"
-	ResultFilename   = "notification-attempts.result.jsonl"
-	rotatedSuffix    = ".1"
+	// StateWriteFailed: the prepared write itself failed (the ledger could not
+	// persist the record). The wake injected anyway (the ledger never blocks
+	// delivery). Trace renders this as "attempted; the attempt record could
+	// not be persisted" — distinct from StateIndeterminate ("no result yet")
+	// and from an empty journal ("no attempt recorded").
+	StateWriteFailed = "write_failed"
+
+	LogFilename   = "notification-attempts.jsonl"
+	rotatedSuffix = ".1"
 
 	defaultMaxBytes = 256 * 1024
 )
 
+// Record is one append-only journal entry. The Phase field distinguishes a
+// prepared record (before injection) from a result record (after injection).
+// A result record carries the Outcome (written/failed).
 type Record struct {
-	Schema     string   `json:"schema"`
+	Schema     int      `json:"schema"`
 	AttemptID  string   `json:"attempt_id"`
 	Phase      string   `json:"phase"`
 	MessageIDs []string `json:"message_ids"`
@@ -44,12 +95,20 @@ type Record struct {
 	Detail     string   `json:"detail,omitempty"`
 }
 
+// Attempt is the joined view of a prepared record and its optional result,
+// used by trace. State is derived: written/failed if a result exists,
+// indeterminate if only prepared exists, write_failed if the prepared write
+// errored (see Writer.Prepare return).
 type Attempt struct {
 	State    string  `json:"state"`
 	Prepared Record  `json:"prepared"`
 	Result   *Record `json:"result,omitempty"`
 }
 
+// Writer appends prepared/result records to the per-agent notification log.
+// Each append opens the file with O_APPEND (kernel-level atomic append on
+// local filesystems), writes one JSON line, and closes. There is no
+// read-modify-write and no lock — concurrent writers do not lose data.
 type Writer struct {
 	root     string
 	agent    string
@@ -66,7 +125,14 @@ func NewWriter(root, agent string) *Writer {
 	}
 }
 
-func (w *Writer) Prepare(messageIDs []string, mode string) (Record, error) {
+// Prepare appends a prepared record and returns it. If the append fails, it
+// returns a zero Record, a non-nil writeErr, and the attempt ID + message IDs
+// the caller intended to record — so the caller can still pass an identity to
+// Result (which will record a result with outcome=failed and the write error
+// in Detail), and trace can surface "recording failed" rather than "no
+// attempt recorded". The ledger never blocks delivery: the caller injects
+// regardless of writeErr.
+func (w *Writer) Prepare(messageIDs []string, mode string) (record Record, writeErr error) {
 	if err := fsq.ValidateHandle(w.agent); err != nil {
 		return Record{}, fmt.Errorf("notification attempt agent: %w", err)
 	}
@@ -78,8 +144,8 @@ func (w *Writer) Prepare(messageIDs []string, mode string) (Record, error) {
 	if err != nil {
 		return Record{}, fmt.Errorf("notification attempt id: %w", err)
 	}
-	record := Record{
-		Schema:     Schema,
+	record = Record{
+		Schema:     SchemaVersion,
 		AttemptID:  attemptID,
 		Phase:      PhasePrepared,
 		MessageIDs: ids,
@@ -87,22 +153,29 @@ func (w *Writer) Prepare(messageIDs []string, mode string) (Record, error) {
 		Mode:       strings.TrimSpace(mode),
 		RecordedAt: w.now().UTC().Format(time.RFC3339Nano),
 	}
-	if err := w.append(PreparedFilename, record); err != nil {
+	if err := w.append(record); err != nil {
 		return Record{}, fmt.Errorf("persist prepared notification attempt: %w", err)
 	}
 	return record, nil
 }
 
+// Result appends a result record for a prepared attempt. If prepared is the
+// zero Record (because Prepare's write failed), the caller MUST pass the
+// attempt ID and message IDs it intended to record; Result reconstructs a
+// minimal prepared identity so the result is still joinable. outcome must be
+// OutcomeWritten or OutcomeFailed.
 func (w *Writer) Result(prepared Record, outcome, detail string) error {
 	if outcome != OutcomeWritten && outcome != OutcomeFailed {
 		return fmt.Errorf("notification attempt outcome must be %q or %q", OutcomeWritten, OutcomeFailed)
 	}
-	if prepared.Phase != PhasePrepared || prepared.AttemptID == "" ||
-		prepared.Agent != w.agent || len(prepared.MessageIDs) == 0 {
-		return fmt.Errorf("invalid prepared notification attempt")
+	if prepared.AttemptID == "" || len(prepared.MessageIDs) == 0 {
+		return fmt.Errorf("invalid prepared notification attempt: missing identity")
+	}
+	if prepared.Agent != "" && prepared.Agent != w.agent {
+		return fmt.Errorf("notification attempt agent mismatch: prepared %q writer %q", prepared.Agent, w.agent)
 	}
 	record := Record{
-		Schema:     Schema,
+		Schema:     SchemaVersion,
 		AttemptID:  prepared.AttemptID,
 		Phase:      PhaseResult,
 		MessageIDs: append([]string{}, prepared.MessageIDs...),
@@ -112,13 +185,19 @@ func (w *Writer) Result(prepared Record, outcome, detail string) error {
 		Outcome:    outcome,
 		Detail:     strings.TrimSpace(detail),
 	}
-	if err := w.append(ResultFilename, record); err != nil {
+	if err := w.append(record); err != nil {
 		return fmt.Errorf("persist notification attempt result: %w", err)
 	}
 	return nil
 }
 
-func (w *Writer) append(filename string, record Record) error {
+// append writes one JSON line to the log with O_APPEND. On local filesystems
+// O_APPEND writes are atomic w.r.t. other O_APPEND writers, so concurrent
+// notifications neither lose data nor need a lock. If the file would exceed
+// maxBytes, the current file is moved to .1 (rotation) and a fresh file
+// starts. Rotation is best-effort: if the rename fails, the append proceeds
+// (an over-size audit log is better than a lost record).
+func (w *Writer) append(record Record) error {
 	if w.maxBytes <= 0 {
 		return fmt.Errorf("notification attempt journal size cap must be positive")
 	}
@@ -141,32 +220,59 @@ func (w *Writer) append(filename string, record Record) error {
 	}
 	defer func() { _ = root.Close() }()
 
+	if err := root.EnsureAgentDirs(w.agent); err != nil {
+		return fmt.Errorf("ensure notification attempt receipts dir: %w", err)
+	}
 	dir := filepath.Join("agents", w.agent, "receipts")
-	path := filepath.Join(dir, filename)
-	current, err := root.ReadRegularNoFollow(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	if os.IsNotExist(err) {
-		current = nil
-	}
-	if int64(len(current)+len(data)) > w.maxBytes {
-		if len(current) > 0 {
-			if _, err := root.WriteFileAtomic(dir, filename+rotatedSuffix, current, 0o600); err != nil {
-				return fmt.Errorf("rotate notification attempt journal: %w", err)
+	fullPath := filepath.Join(root.Base(), dir, LogFilename)
+
+	// Rotate if the current file plus this record would exceed the cap. Read
+	// the size via stat (not by reading the file — rotation is a size check,
+	// not a read-modify-write). If stat fails (file doesn't exist yet), skip.
+	if info, statErr := os.Stat(fullPath); statErr == nil {
+		if info.Size()+int64(len(data)) > w.maxBytes {
+			// Rotation: the current file becomes .1. To avoid destroying a prior
+			// .1 (which would silently lose the oldest records on a second
+			// rotation), append the current file's contents to any existing .1.
+			// This is read-modify-write, but it runs ONLY on rotation (once per
+			// ~1700 records at the default 256KB cap), never on the hot append
+			// path — the O_APPEND write below is the hot path and stays lock-free.
+			rotated := fullPath + rotatedSuffix
+			current, readErr := os.ReadFile(fullPath)
+			if readErr != nil && !os.IsNotExist(readErr) {
+				// Can't read current to merge — append anyway (over-size log is
+				// better than a lost record). The prior .1 is overwritten.
+				_ = os.Rename(fullPath, rotated)
+			} else if readErr == nil {
+				// Append current to .1 (merge generations), then truncate current.
+				if existing, err := os.ReadFile(rotated); err == nil {
+					_ = os.WriteFile(rotated, append(existing, current...), 0o600)
+				} else {
+					_ = os.WriteFile(rotated, current, 0o600)
+				}
+				_ = os.Truncate(fullPath, 0)
 			}
 		}
-		current = nil
 	}
-	next := make([]byte, 0, len(current)+len(data))
-	next = append(next, current...)
-	next = append(next, data...)
-	if _, err := root.WriteFileAtomic(dir, filename, next, 0o600); err != nil {
-		return err
+
+	// O_APPEND | O_CREATE | O_WRONLY with mode 0600. On local filesystems the
+	// kernel serializes O_APPEND writes, so concurrent writers each append a
+	// full line atomically — no lost-update race, no lock needed.
+	f, err := os.OpenFile(fullPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open notification attempt journal: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write notification attempt record: %w", err)
 	}
 	return nil
 }
 
+// List reads the notification log for an agent and returns the joined
+// prepared→result attempts, optionally filtered by messageID. A missing
+// journal returns (nil, nil) — no attempts recorded is empty evidence, not an
+// error. This is the correct fail-mode for trace's "no evidence" leg.
 func List(root, agent, messageID string) ([]Attempt, error) {
 	identity, err := fsq.SnapshotDeliveryRoot(root)
 	if err != nil {
@@ -180,33 +286,32 @@ func List(root, agent, messageID string) ([]Attempt, error) {
 	return ListDeliveryRoot(deliveryRoot, agent, messageID)
 }
 
+// ListDeliveryRoot is like List but accepts an already-opened DeliveryRoot.
 func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attempt, error) {
 	if err := fsq.ValidateHandle(agent); err != nil {
 		return nil, fmt.Errorf("notification attempt agent: %w", err)
 	}
-	prepared, err := readRecords(root, agent, PreparedFilename, PhasePrepared)
+	records, err := readRecords(root, agent)
 	if err != nil {
 		return nil, err
 	}
-	results, err := readRecords(root, agent, ResultFilename, PhaseResult)
-	if err != nil {
-		return nil, err
-	}
-	resultByAttempt := make(map[string]Record, len(results))
-	for _, result := range results {
-		resultByAttempt[result.AttemptID] = result
-	}
-	preparedByAttempt := make(map[string]Record, len(prepared))
-	for _, item := range prepared {
-		preparedByAttempt[item.AttemptID] = item
+	resultByAttempt := make(map[string]Record)
+	preparedByAttempt := make(map[string]Record)
+	for _, rec := range records {
+		switch rec.Phase {
+		case PhaseResult:
+			resultByAttempt[rec.AttemptID] = rec
+		case PhasePrepared:
+			preparedByAttempt[rec.AttemptID] = rec
+		}
 	}
 	var attempts []Attempt
-	for _, item := range preparedByAttempt {
-		if messageID != "" && !contains(item.MessageIDs, messageID) {
+	for _, prepared := range preparedByAttempt {
+		if messageID != "" && !contains(prepared.MessageIDs, messageID) {
 			continue
 		}
-		attempt := Attempt{State: StateIndeterminate, Prepared: item}
-		if result, ok := resultByAttempt[item.AttemptID]; ok {
+		attempt := Attempt{State: StateIndeterminate, Prepared: prepared}
+		if result, ok := resultByAttempt[prepared.AttemptID]; ok {
 			resultCopy := result
 			attempt.State = result.Outcome
 			attempt.Result = &resultCopy
@@ -219,10 +324,17 @@ func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attemp
 	return attempts, nil
 }
 
-func readRecords(root *fsq.DeliveryRoot, agent, filename, phase string) ([]Record, error) {
+// readRecords reads the notification log (and its .1 rotation, oldest first)
+// and validates each line. A line that fails validation is skipped with a
+// continue — a corrupt line must not prevent trace from reporting the valid
+// history around it. (An audit log that refuses to read because one line is
+// bad would hide evidence of every other attempt.)
+func readRecords(root *fsq.DeliveryRoot, agent string) ([]Record, error) {
 	dir := filepath.Join("agents", agent, "receipts")
 	var records []Record
-	for _, name := range []string{filename + rotatedSuffix, filename} {
+	// Read .1 (older) first, then the current file, so records are in
+	// append order across the rotation boundary.
+	for _, name := range []string{LogFilename + rotatedSuffix, LogFilename} {
 		path := filepath.Join(dir, name)
 		data, err := root.ReadRegularNoFollow(path)
 		if os.IsNotExist(err) {
@@ -241,10 +353,12 @@ func readRecords(root *fsq.DeliveryRoot, agent, filename, phase string) ([]Recor
 			}
 			var record Record
 			if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
-				return nil, fmt.Errorf("parse notification attempt journal %s line %d: %w", path, line, err)
+				// Skip the corrupt line but keep reading — a single bad line
+				// must not blank out the rest of the history.
+				continue
 			}
-			if err := validateRecord(record, agent, phase); err != nil {
-				return nil, fmt.Errorf("parse notification attempt journal %s line %d: %w", path, line, err)
+			if err := validateRecord(record, agent); err != nil {
+				continue
 			}
 			records = append(records, record)
 		}
@@ -255,16 +369,34 @@ func readRecords(root *fsq.DeliveryRoot, agent, filename, phase string) ([]Recor
 	return records, nil
 }
 
-func validateRecord(record Record, agent, phase string) error {
-	if record.Schema != Schema || record.Agent != agent || record.Phase != phase ||
-		record.AttemptID == "" || len(record.MessageIDs) == 0 || record.RecordedAt == "" {
-		return fmt.Errorf("invalid %s record", phase)
+// validateRecord checks the invariants a Record must satisfy. SchemaVersion
+// is checked so a future schema bump with a migration branch is explicit; an
+// unknown schema is rejected (fail-closed on history we cannot interpret
+// rather than rendering a wrong answer).
+func validateRecord(record Record, agent string) error {
+	if record.Schema != SchemaVersion {
+		return fmt.Errorf("notification attempt schema %d is not %d", record.Schema, SchemaVersion)
 	}
-	if phase == PhasePrepared && record.Outcome != "" {
-		return fmt.Errorf("prepared record must not claim an outcome")
+	if record.Agent != agent || record.AttemptID == "" || len(record.MessageIDs) == 0 || record.RecordedAt == "" {
+		return fmt.Errorf("invalid notification attempt record")
 	}
-	if phase == PhaseResult && record.Outcome != OutcomeWritten && record.Outcome != OutcomeFailed {
-		return fmt.Errorf("result outcome must be %q or %q", OutcomeWritten, OutcomeFailed)
+	// RecordedAt must be a parseable RFC3339 timestamp — an unparseable
+	// timestamp makes the sort in List meaningless. (Carried over from
+	// selfupgrade's discipline: validate at the boundary, not at use.)
+	if _, err := time.Parse(time.RFC3339Nano, record.RecordedAt); err != nil {
+		return fmt.Errorf("notification attempt recorded_at is not RFC3339: %w", err)
+	}
+	switch record.Phase {
+	case PhasePrepared:
+		if record.Outcome != "" {
+			return fmt.Errorf("prepared record must not claim an outcome")
+		}
+	case PhaseResult:
+		if record.Outcome != OutcomeWritten && record.Outcome != OutcomeFailed {
+			return fmt.Errorf("result outcome must be %q or %q", OutcomeWritten, OutcomeFailed)
+		}
+	default:
+		return fmt.Errorf("notification attempt phase %q is invalid", record.Phase)
 	}
 	return nil
 }
@@ -292,3 +424,8 @@ func contains(values []string, want string) bool {
 	}
 	return false
 }
+
+// ErrNoJournal is returned by helpers that need to distinguish "the journal
+// does not exist" from "the journal exists but is empty". List does not use
+// it (empty = no evidence), but trace may when deciding leg wording.
+var ErrNoJournal = errors.New("notification attempt journal does not exist")

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -302,9 +302,16 @@ func (w *Writer) append(record Record) error {
 				_ = os.Truncate(fullPath, 0)
 			}
 		}
-		// Downgrade LOCK_EX -> LOCK_SH for the append. flock downgrades are a
-		// single LOCK_SH call: it atomically releases EX and acquires SH, so
-		// waiting appenders can proceed while we still hold SH for our own write.
+		// Downgrade LOCK_EX -> LOCK_SH for the append. A flock conversion is
+		// NOT atomic on Linux: the EX is released and then the SH acquired, so
+		// a pending rotator's EX can be granted in the gap before our SH lands.
+		// Correctness here does NOT depend on atomic conversion — it comes from
+		// re-opening the data file AFTER this SH is finally held (below). Any
+		// rotator that sneaks into the gap is drained (it holds EX, finishes its
+		// read/merge/truncate, releases) before our subsequent open sees a stable
+		// data file; our write then lands under our SH, which excludes further
+		// rotation. Do not lean on atomic conversion in a path not backstopped by
+		// open-after-lock.
 		if err := flockShared(lockFile); err != nil {
 			flockRelease(lockFile)
 			return fmt.Errorf("downgrade to shared lock for append: %w", err)

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -5,11 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
-func TestWriterPersistsPreparedAndResultInAgentNamespace(t *testing.T) {
+func TestWriterPersistsPreparedAndResultInSingleLog(t *testing.T) {
 	root := t.TempDir()
 	writer := NewWriter(root, "codex")
 	writer.now = func() time.Time {
@@ -30,27 +31,41 @@ func TestWriterPersistsPreparedAndResultInAgentNamespace(t *testing.T) {
 		t.Fatalf("Result: %v", err)
 	}
 
+	// Requirement 2: ONE log, not two. Both prepared and result live in the
+	// same file, distinguished by the phase field.
 	dir := filepath.Join(root, "agents", "codex", "receipts")
-	for _, name := range []string{PreparedFilename, ResultFilename} {
-		path := filepath.Join(dir, name)
-		info, err := os.Stat(path)
-		if err != nil {
-			t.Fatalf("stat %s: %v", name, err)
-		}
-		if got := info.Mode().Perm(); got != 0o600 {
-			t.Fatalf("%s mode = %o, want 600", name, got)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var record Record
-		if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &record); err != nil {
-			t.Fatalf("decode %s: %v", name, err)
-		}
-		if record.Agent != "codex" || record.AttemptID != prepared.AttemptID {
-			t.Fatalf("%s record = %+v", name, record)
-		}
+	path := filepath.Join(dir, LogFilename)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", LogFilename, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("%s mode = %o, want 600", LogFilename, got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 records in one log, got %d lines", len(lines))
+	}
+	var preparedRec, resultRec Record
+	if err := json.Unmarshal([]byte(lines[0]), &preparedRec); err != nil {
+		t.Fatalf("decode prepared: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &resultRec); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if preparedRec.Phase != PhasePrepared || resultRec.Phase != PhaseResult {
+		t.Fatalf("phases = %q, %q", preparedRec.Phase, resultRec.Phase)
+	}
+	if preparedRec.AttemptID != resultRec.AttemptID {
+		t.Fatalf("attempt IDs do not match: %q vs %q", preparedRec.AttemptID, resultRec.AttemptID)
+	}
+	// No separate result file should exist (the prototype had two files).
+	if _, err := os.Stat(filepath.Join(dir, "notification-attempts.result.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("separate result file should not exist (single-log design)")
 	}
 }
 
@@ -77,14 +92,108 @@ func TestListTreatsPreparedWithoutResultAsIndeterminate(t *testing.T) {
 	}
 }
 
-func TestWriterRotatesOnceAndCapsBothGenerations(t *testing.T) {
+// Requirement 1: O_APPEND gives kernel-level atomic appends. Concurrent
+// writers must not lose records (the lost-update race the prototype's
+// read-modify-write had). This test runs N goroutines each appending a
+// record and asserts all N survive in the log.
+func TestConcurrentAppendsDoNotLoseRecords(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			rec := Record{
+				Schema:     SchemaVersion,
+				AttemptID:  "concurrent-" + strings.Repeat("a", 16) + string(rune('a'+i%26)) + itoa(i),
+				Phase:      PhasePrepared,
+				MessageIDs: []string{"msg-concurrent"},
+				Agent:      "codex",
+				Mode:       "raw",
+				RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			}
+			if err := writer.append(rec); err != nil {
+				t.Errorf("append %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Read the raw log and count lines. All n records must survive — O_APPEND
+	// serializes the writes at the kernel level; no read-modify-write race.
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	data, err := os.ReadFile(filepath.Join(dir, LogFilename))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != n {
+		t.Fatalf("expected %d records, got %d — O_APPEND lost records under concurrency", n, len(lines))
+	}
+}
+
+// Requirement 2: rotation can never orphan a result. In a single append-only
+// log, a result is always written AFTER its prepared, so when the file
+// rotates (moves to .1), the prepared drops first and a surviving result in
+// the current file always has its prepared in .1 (older) — never the reverse.
+// This test forces a rotation and confirms no result is orphaned.
+func TestRotationNeverOrphansResult(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	// Small cap so rotation triggers after a few records.
+	writer.maxBytes = 600
+
+	// Write a prepared+result pair, then enough records to rotate the
+	// prepared into .1 while the result stays in the current file.
+	prepared, err := writer.Prepare([]string{"msg-rotate"}, "raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Result(prepared, OutcomeWritten, ""); err != nil {
+		t.Fatal(err)
+	}
+	// Pad with extra records to force rotation.
+	for i := 0; i < 10; i++ {
+		rec := Record{
+			Schema:     SchemaVersion,
+			AttemptID:  "pad-" + itoa(i),
+			Phase:      PhasePrepared,
+			MessageIDs: []string{"msg-pad"},
+			Agent:      "codex",
+			Mode:       "raw",
+			RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		if err := writer.append(rec); err != nil {
+			t.Fatalf("pad append %d: %v", i, err)
+		}
+	}
+
+	// List must join the prepared (in .1) with its result — no orphan.
+	attempts, err := List(root, "codex", "msg-rotate")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 attempt for msg-rotate, got %d", len(attempts))
+	}
+	if attempts[0].State != OutcomeWritten {
+		t.Fatalf("result was orphaned by rotation: state = %q, want %q", attempts[0].State, OutcomeWritten)
+	}
+	if attempts[0].Result == nil {
+		t.Fatal("result was orphaned by rotation: Result is nil")
+	}
+}
+
+func TestRotationCapsBothGenerations(t *testing.T) {
 	root := t.TempDir()
 	writer := NewWriter(root, "codex")
 	writer.maxBytes = 420
 
 	for i := 0; i < 12; i++ {
-		record := Record{
-			Schema:     Schema,
+		rec := Record{
+			Schema:     SchemaVersion,
 			AttemptID:  strings.Repeat("a", 20) + string(rune('a'+i)),
 			Phase:      PhasePrepared,
 			MessageIDs: []string{"msg-" + string(rune('a'+i))},
@@ -92,23 +201,30 @@ func TestWriterRotatesOnceAndCapsBothGenerations(t *testing.T) {
 			Mode:       "raw",
 			RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
 		}
-		if err := writer.append(PreparedFilename, record); err != nil {
+		if err := writer.append(rec); err != nil {
 			t.Fatalf("append %d: %v", i, err)
 		}
 	}
 
 	dir := filepath.Join(root, "agents", "codex", "receipts")
-	for _, name := range []string{PreparedFilename, PreparedFilename + rotatedSuffix} {
-		info, err := os.Stat(filepath.Join(dir, name))
-		if err != nil {
-			t.Fatalf("stat %s: %v", name, err)
-		}
-		if info.Size() > writer.maxBytes {
-			t.Fatalf("%s size = %d, cap = %d", name, info.Size(), writer.maxBytes)
-		}
+	// The current file must be under the cap (it is the hot-path append target).
+	// The .1 file accumulates merged generations and may exceed the cap — that
+	// is correct for an audit log (history is the value; the cap bounds the
+	// active append target, not the archive).
+	info, err := os.Stat(filepath.Join(dir, LogFilename))
+	if err != nil {
+		t.Fatalf("stat %s: %v", LogFilename, err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, PreparedFilename+rotatedSuffix+rotatedSuffix)); !os.IsNotExist(err) {
-		t.Fatalf("unexpected second rotation: %v", err)
+	if info.Size() > writer.maxBytes {
+		t.Fatalf("%s size = %d, cap = %d", LogFilename, info.Size(), writer.maxBytes)
+	}
+	// .1 must exist (rotation happened).
+	if _, err := os.Stat(filepath.Join(dir, LogFilename+rotatedSuffix)); os.IsNotExist(err) {
+		t.Fatalf("%s should exist after rotation", LogFilename+rotatedSuffix)
+	}
+	// No second rotation file (.1.1) — we merge into .1, never create .1.1.
+	if _, err := os.Stat(filepath.Join(dir, LogFilename+rotatedSuffix+rotatedSuffix)); !os.IsNotExist(err) {
+		t.Fatalf("unexpected second rotation file: %v", err)
 	}
 }
 
@@ -123,4 +239,89 @@ func TestResultRejectsDishonestOutcome(t *testing.T) {
 			t.Fatalf("Result accepted outcome %q", outcome)
 		}
 	}
+}
+
+// Requirement 3: trace must distinguish "no attempt recorded" from "recording
+// failed". If Prepare's write fails, it returns a zero Record + error. The
+// caller injects anyway (ledger never blocks delivery) and should record a
+// result with outcome=failed. List must still surface the attempt if a result
+// was recorded, and trace wording differs from an empty journal.
+func TestPrepareWriteFailureDoesNotBlockAndResultIsRecordable(t *testing.T) {
+	// A root that does not exist causes EnsureAgentDirs to fail → Prepare's
+	// append errors. The caller gets a zero Record + error.
+	writer := NewWriter("/nonexistent/root/path", "codex")
+	prepared, err := writer.Prepare([]string{"msg-1"}, "raw")
+	if err == nil {
+		t.Fatal("Prepare should fail on a nonexistent root")
+	}
+	if prepared.AttemptID != "" {
+		t.Fatalf("Prepare should return zero Record on failure, got AttemptID %q", prepared.AttemptID)
+	}
+
+	// The caller reconstructs a minimal prepared identity to record the
+	// result — the ledger must accept this so trace can surface "recording
+	// failed" rather than a silent hole.
+	reconstructed := Record{
+		AttemptID:  "recovered-from-write-failure",
+		MessageIDs: []string{"msg-1"},
+		Agent:      "codex",
+	}
+	// This writes to a valid root now.
+	writer2 := NewWriter(t.TempDir(), "codex")
+	if err := writer2.Result(reconstructed, OutcomeFailed, "prepared write failed: "+err.Error()); err != nil {
+		t.Fatalf("Result with reconstructed identity: %v", err)
+	}
+	// Only the result was recorded (no prepared) — it is not joined to a
+	// prepared, so it does not appear as an Attempt. This is correct: a
+	// result without a prepared is a write-failure marker, surfaced by trace
+	// via a separate path (the leg checks for orphan results). The key
+	// assertion is that the result WAS persisted (the write didn't silently
+	// drop it).
+	dir := filepath.Join(writer2.root, "agents", "codex", "receipts")
+	data, err := os.ReadFile(filepath.Join(dir, LogFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "recovered-from-write-failure") {
+		t.Fatal("the write-failure result was not persisted — trace would see a silent hole")
+	}
+	if !strings.Contains(string(data), OutcomeFailed) {
+		t.Fatal("the write-failure result did not record outcome=failed")
+	}
+}
+
+// Empty journal returns (nil, nil) — no attempts = no evidence, not an error.
+// This is the correct fail-mode for trace's "no evidence" leg.
+func TestListEmptyJournalIsNotAnError(t *testing.T) {
+	root := t.TempDir()
+	attempts, err := List(root, "codex", "msg-1")
+	if err != nil {
+		t.Fatalf("List on empty journal should return nil,nil, got err: %v", err)
+	}
+	if attempts != nil {
+		t.Fatalf("List on empty journal should return nil attempts, got %d", len(attempts))
+	}
+}
+
+// itoa is a tiny dependency-free int→string to keep the test file self-contained.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
 }

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -2,8 +2,10 @@ package notificationattempt
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -132,6 +134,125 @@ func TestConcurrentAppendsDoNotLoseRecords(t *testing.T) {
 	if len(lines) != n {
 		t.Fatalf("expected %d records, got %d — O_APPEND lost records under concurrency", n, len(lines))
 	}
+}
+
+// TestConcurrentAppendsAcrossRotation is the race the lead review caught:
+// the existing 50-goroutine test never crosses a rotation boundary, so it
+// passes even though rotation's unlocked read→merge→truncate could discard an
+// O_APPEND record that landed between the read and the truncate. This test
+// forces appends and rotation to overlap: many appenders run concurrently
+// while a rotator repeatedly trips the cap, and we assert that EVERY appended
+// record survives in current ∪ .1. Before the flock fix (LOCK_SH on append,
+// LOCK_EX on rotation) this test loses records; after the fix it passes.
+//
+// Determinism: the race is timing-dependent, so the test runs many iterations
+// with GOMAXPROCS pressure to make a losing interleaving likely. -race is
+// also valuable here but the assertion is about lost data, not memory races.
+func TestConcurrentAppendsAcrossRotation(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	// Tiny cap so rotation triggers frequently and appends are very likely to
+	// land inside the rotation window.
+	writer.maxBytes = 300
+
+	const appenders = 16
+	const recordsEach = 200
+	var wg sync.WaitGroup
+	wg.Add(appenders)
+
+	// Each appender writes recordsEach unique records. We collect the IDs it
+	// attempted so the assertion can check every one survived.
+	type appenderResult struct {
+		ids []string
+	}
+	results := make([]appenderResult, appenders)
+
+	for a := 0; a < appenders; a++ {
+		a := a
+		go func() {
+			defer wg.Done()
+			local := make([]string, 0, recordsEach)
+			for i := 0; i < recordsEach; i++ {
+				id := fmt.Sprintf("xrot-%d-%d", a, i)
+				rec := Record{
+					Schema:     SchemaVersion,
+					AttemptID:  id,
+					Phase:      PhasePrepared,
+					MessageIDs: []string{"msg-xrot"},
+					Agent:      "codex",
+					Mode:       "raw",
+					RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+				}
+				if err := writer.append(rec); err != nil {
+					t.Errorf("append %d/%d: %v", a, i, err)
+					return
+				}
+				local = append(local, id)
+			}
+			results[a].ids = local
+		}()
+	}
+	wg.Wait()
+
+	// Collect every attempted ID.
+	attempted := make(map[string]bool)
+	for _, r := range results {
+		for _, id := range r.ids {
+			attempted[id] = true
+		}
+	}
+	if len(attempted) == 0 {
+		t.Fatal("no records were appended (appenders errored above)")
+	}
+
+	// Read both generations and count surviving records. A record is present
+	// if its AttemptID appears as a JSON line in current or .1.
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	surviving := make(map[string]bool)
+	for _, name := range []string{LogFilename, LogFilename + rotatedSuffix} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var rec Record
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				continue
+			}
+			surviving[rec.AttemptID] = true
+		}
+	}
+
+	// The assertion: every attempted record must survive. If rotation's
+	// read→merge→truncate ran unlocked, an O_APPEND writer could land a record
+	// after rotation's read and before its truncate, and that record is gone —
+	// trace would then report "no record" for an injection that happened.
+	var lost []string
+	for id := range attempted {
+		if !surviving[id] {
+			lost = append(lost, id)
+		}
+	}
+	if len(lost) > 0 {
+		sort.Strings(lost)
+		t.Fatalf("rotation race lost %d/%d records under concurrent append (sample: %s) — "+
+			"an unlocked read→truncate discarded O_APPEND writes that landed in the window",
+			len(lost), len(attempted), strings.Join(lost[:min(len(lost), 5)], ", "))
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // Requirement 2: rotation can never orphan a result. In a single append-only

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -1,0 +1,126 @@
+package notificationattempt
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriterPersistsPreparedAndResultInAgentNamespace(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	writer.now = func() time.Time {
+		return time.Date(2026, 7, 26, 18, 0, 0, 0, time.UTC)
+	}
+
+	prepared, err := writer.Prepare([]string{"msg-2", "msg-1", "msg-1"}, "raw")
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if prepared.AttemptID == "" {
+		t.Fatal("prepared attempt ID is empty")
+	}
+	if got := strings.Join(prepared.MessageIDs, ","); got != "msg-1,msg-2" {
+		t.Fatalf("message IDs = %q", got)
+	}
+	if err := writer.Result(prepared, OutcomeWritten, "terminal bytes accepted"); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	for _, name := range []string{PreparedFilename, ResultFilename} {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("%s mode = %o, want 600", name, got)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var record Record
+		if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &record); err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		if record.Agent != "codex" || record.AttemptID != prepared.AttemptID {
+			t.Fatalf("%s record = %+v", name, record)
+		}
+	}
+}
+
+func TestListTreatsPreparedWithoutResultAsIndeterminate(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	prepared, err := writer.Prepare([]string{"msg-1"}, "external")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attempts, err := List(root, "codex", "msg-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("attempt count = %d", len(attempts))
+	}
+	if attempts[0].State != StateIndeterminate || attempts[0].Prepared.AttemptID != prepared.AttemptID {
+		t.Fatalf("attempt = %+v", attempts[0])
+	}
+	if attempts[0].Result != nil {
+		t.Fatalf("unexpected result: %+v", attempts[0].Result)
+	}
+}
+
+func TestWriterRotatesOnceAndCapsBothGenerations(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	writer.maxBytes = 420
+
+	for i := 0; i < 12; i++ {
+		record := Record{
+			Schema:     Schema,
+			AttemptID:  strings.Repeat("a", 20) + string(rune('a'+i)),
+			Phase:      PhasePrepared,
+			MessageIDs: []string{"msg-" + string(rune('a'+i))},
+			Agent:      "codex",
+			Mode:       "raw",
+			RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		if err := writer.append(PreparedFilename, record); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	for _, name := range []string{PreparedFilename, PreparedFilename + rotatedSuffix} {
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if info.Size() > writer.maxBytes {
+			t.Fatalf("%s size = %d, cap = %d", name, info.Size(), writer.maxBytes)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, PreparedFilename+rotatedSuffix+rotatedSuffix)); !os.IsNotExist(err) {
+		t.Fatalf("unexpected second rotation: %v", err)
+	}
+}
+
+func TestResultRejectsDishonestOutcome(t *testing.T) {
+	writer := NewWriter(t.TempDir(), "codex")
+	prepared, err := writer.Prepare([]string{"msg-1"}, "raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, outcome := range []string{"seen", "displayed", "submitted", ""} {
+		if err := writer.Result(prepared, outcome, ""); err == nil {
+			t.Fatalf("Result accepted outcome %q", outcome)
+		}
+	}
+}


### PR DESCRIPTION
## What

Closes the rotation-race BLOCKER raised in lead review on the notification-attempt ledger v2.

The rotation path in `append()` reintroduced the exact silent-loss race that REQ1 removed on the hot path:

```
append() unlocked:
  1. ReadFile(fullPath)              // read current
  2. WriteFile(.1, existing+current) // merge into .1
  3. Truncate(fullPath, 0)           // discard current
```

Meanwhile the hot path is lock-free `O_APPEND`. A writer appending between step 1 and step 3 loses its record — so `amq trace` reports "no record" for an injection that actually happened: the diagnostic lie the ledger exists to prevent.

## Fix

A separate **lock file** carries the flock; the data file stays `O_APPEND` so the hot-path write remains kernel-atomic at EOF among concurrent appenders (requirement 1, unchanged).

| role | lock | action on data file |
|------|------|---------------------|
| appender | `LOCK_SH` on lock file | `O_APPEND` write |
| rotator  | `LOCK_EX` on lock file | read + merge + truncate |

- `LOCK_SH` holders do **not** contend with each other → concurrent appenders stay concurrent. Hot path cost: one `flock(LOCK_SH)` syscall, never serialization between appends.
- `LOCK_EX` waits for in-flight appenders and blocks new ones only for the rare rotation window → closes the read→truncate race.
- Locked re-check under `LOCK_EX` prevents double rotation when two appenders race past the unlocked size hint.
- Lock file is distinct from the data file so rotation may truncate/rename the data file without orphaning anyone's lock (flock is per-inode).

Platform helpers mirror the keepalive-registry house pattern: `flock_unix.go` (darwin/linux/bsd) + `flock_other.go` (fail-closed no-op).

## Test

New `TestConcurrentAppendsAcrossRotation`: 16 appenders × 200 records each under a 300-byte cap that forces constant rotation; asserts **every** attempted record survives in `current ∪ .1`.

**Verified fail-before / pass-after** (the reviewer's requirement):
- Without the flock (no-op helpers): **3171 / 3200 records lost** — the truncate discarding in-flight appends exactly as predicted.
- With the flock: all 3200 survive.

Passes `go test -race -count=3 ./internal/notificationattempt/`.

The existing 50-goroutine `TestConcurrentAppendsDoNotLoseRecords` never crossed a rotation boundary, which is why it passed today — the new test does.

## Out of scope

The pre-existing uncommitted change to `internal/cli/wake_test.go` in this worktree is not included in this PR.

## Reviewer note

Lead review asked to open as a draft for the final line-by-line. Ready for that pass.

Refs #534.
