### PR TITLE
feat(wake): add inject-via provider acceptance protocol

### DIFF
--- a/docs/adr-wake-capability-vector.md
+++ b/docs/adr-wake-capability-vector.md
@@ -15,7 +15,10 @@ ChatGPT.app) are real agents. Pretending they are a pty, or silently substitutin
 notify/prefill for inject, lies about delivery.
 
 TTY inject remains defined by [wake operations](wake-operations.md). This ADR
-does not change that path.
+does not change that path. Raw TIOCSTI proves only that AMQ accepted terminal
+bytes; it does not prove provider presentation, submission, or consumption.
+The raw path therefore records `written` evidence and never claims provider
+acceptance.
 
 ## Decision
 
@@ -38,6 +41,16 @@ Unknown apps fail closed. Prompt text must not drive generic `osascript`.
 
 App repair/restart is `operator_only` until identity and generation checks
 match the TTY contract. `notifier_live` is not consumption.
+
+An external `--inject-via` provider must use the AMQ transport protocol. Exit
+zero is accepted only with the exact stderr marker
+`AMQ_INJECT_PROGRESS=accepted`. `AMQ_INJECT_PROGRESS=deferred` means
+pre-dispatch busy/transition and keeps the same unread cohort on the wake retry
+ladder. `AMQ_INJECT_PROGRESS=uncertain` wins over every other marker and enters
+recovery. Other nonzero exits and timeouts are terminal `failed` outcomes for
+the current AttemptID and are not silently replayed. A bare legacy exit zero is
+`written`/uncertain evidence, never an accepted provider dispatch. This
+transport gap is tracked in [#703](https://github.com/avivsinai/agent-message-queue/issues/703).
 
 ## v1 seats (docs + local inspect, 2026-08-20)
 

--- a/docs/trace.md
+++ b/docs/trace.md
@@ -74,4 +74,9 @@ durability as `no_evidence`; do not infer retry safety from current file
 presence.
 
 Notification success is never inferred from wake state, a mailbox file, or a
-delivery receipt. Phase A reports the notification leg as `no_evidence`.
+delivery receipt. Phase A reports the notification leg as `no_evidence` when
+the journal is absent. When present, schema 2 distinguishes `accepted`
+(explicit external-provider dispatch), `deferred`/`retried` (pre-dispatch busy
+with the cohort retained), and terminal `failed`; raw TIOCSTI and legacy
+injectors remain `written` byte evidence only. None of these states proves
+human or agent consumption.

--- a/docs/wake-doorbell-acknowledgement.md
+++ b/docs/wake-doorbell-acknowledgement.md
@@ -7,16 +7,18 @@ implemented by `amq wake`.
 
 ## Problem
 
-An external `--inject-via` process exposes two different delivery facts:
+An external `--inject-via` process exposes separate transport facts:
 
-1. exit zero proves that the injector accepted the complete doorbell; and
+1. an explicit `AMQ_INJECT_PROGRESS=accepted` marker plus exit zero proves
+   that the provider accepted the complete doorbell; and
 2. removal of a message from `inbox/new` proves durable consumer progress.
 
 Those facts are not interchangeable. Exit zero does not prove that an agent
 executed the doorbell, while an unchanged inbox does not prove that a second
-terminal prompt is useful. Integrations that already own receipt-based
-recovery need the first fact to suppress duplicate terminal turns; standalone
-AMQ keeps the second fact as its safer default.
+terminal prompt is useful. A legacy zero exit without the marker is recorded as
+`written`/uncertain and is never provider acceptance. Integrations that already
+own receipt-based recovery need the first fact to suppress duplicate terminal
+turns; standalone AMQ keeps the second fact as its safer default.
 
 ## CLI contract
 
@@ -27,12 +29,19 @@ AMQ keeps the second fact as its safer default.
 ```
 
 - `drained` is the default and preserves the existing retry ladder.
-- `injected` requires `--inject-via`. A zero exit status acknowledges the
-  current physical inbox cohort and suppresses further input retries for that
-  unchanged cohort.
-- A nonzero exit, timeout, authority refusal, partial write, or output-only
-  fallback MUST NOT acknowledge injection. Existing bounded retry and recovery
-  semantics continue to apply.
+- `injected` requires `--inject-via`. Only exit zero with the exact stderr line
+  `AMQ_INJECT_PROGRESS=accepted` acknowledges the current physical inbox
+  cohort and suppresses further input retries for that unchanged cohort.
+- `AMQ_INJECT_PROGRESS=deferred` with a nonzero exit means the provider was
+  busy or transitioning before dispatch. AMQ MUST retain the cohort, emit no
+  terminal or attention fallback, and retry through the existing wake loop.
+- `AMQ_INJECT_PROGRESS=uncertain` wins over every other marker, including a
+  deferred/uncertain pair. AMQ MUST enter existing recovery and MUST NOT
+  replay the payload before durable inbox progress.
+- Any other nonzero exit or timeout is `failed`, is terminal for that
+  AttemptID, and MUST NOT be silently replayed. Timeout wins even if stderr
+  contains a deferred marker. Authority refusal, partial write, and
+  output-only fallback MUST NOT acknowledge injection.
 
 The requested value is part of the retained wake target identity. The optional
 `retry_until` target/state field omits the default `drained` value for byte and
@@ -53,8 +62,9 @@ give-up while the cohort remains unread.
   continue through 4 and 8 minutes to a 15-minute cap, because they alert a
   human rather than act.
 - The delay is measured from when the preceding injector process exits or
-  times out, not from when the attempt was scheduled. Because `--inject-via`
-  runs arbitrary local code, a retry can repeat injector-side effects.
+  times out, not from when the attempt was scheduled. A provider `deferred`
+  result keeps the same durable attempt and retry ladder; a terminal
+  `failed`/`uncertain` result does not silently replay the injector.
 - A new message added to a pending cohort joins it and shares the next
   notification without resetting the ladder. An input-delivery addition may
   pull a decayed deadline forward to a delivery floor 5s after the last input
@@ -101,6 +111,21 @@ idle -> retrying -> announced
   expanded cohort. A successful attempt announces the expanded cohort.
 - An empty inbox resets the state to `idle`.
 
+The external injector ledger records the transport lifecycle in one append-only
+log:
+
+```text
+attempt -> deferred -> retried -> accepted
+                         |-> deferred -> retried
+attempt -----------------> failed
+```
+
+The same AttemptID and message cohort MUST be used across `deferred` and
+`retried` events. A terminal `accepted` or `failed` event closes that ID. A
+later unread re-notification starts a new AttemptID. The raw TIOCSTI path has
+only byte-write evidence (`written`); it never claims provider presentation or
+acceptance. This contract closes P1 issue [#703](https://github.com/avivsinai/agent-message-queue/issues/703).
+
 The announced state is process-local. A wake process replacement MAY produce
 one fresh doorbell for an unread cohort; cross-process exactly-once injection
 would require a separate durable injected-receipt protocol and is outside this
@@ -109,7 +134,7 @@ contract.
 ## Integration rule
 
 Consumers selecting `injected` MUST retain their own durable-consumption
-policy. Injector exit zero MUST NOT be reported as a drained message receipt.
+policy. Injector acceptance MUST NOT be reported as a drained message receipt.
 Orch continues to use the original message's `drained` receipt for task
 delivery status and explicit recovery.
 
@@ -119,8 +144,30 @@ delivery status and explicit recovery.
 2. `injected` mode invokes a successful external injector once for an
    unchanged unread cohort, even after its former retry deadlines.
 3. A new inbox member after acknowledgement produces one new injection.
-4. Injector failure or output-only fallback remains retryable.
+4. A provider failure or output-only fallback is terminal for that injector
+   AttemptID and never silently replays the injector; only `deferred` is
+   replayable, while legacy zero-exit behavior remains compatible.
 5. CLI validation rejects unknown values and `injected` without
    `--inject-via`.
 6. Retained target/state round trips preserve `injected`; omitted values read
    as `drained`.
+
+## Keepalive adapter acceptance
+
+`amq-keepalive inject` emits `AMQ_INJECT_PROGRESS=accepted` only for adapters
+that implement the explicit provider-acceptance reporter contract. The current
+classifications are:
+
+| Adapter | Acceptance evidence |
+| --- | --- |
+| `codex-queue` | The queue command accepts the message for the existing writer. |
+| `claude-print` | The matching `isReplay` user event is observed in the Claude stream. |
+| `file` | Legacy file-write evidence only; no provider marker. |
+| `ghostty` | Legacy terminal text/Enter write evidence only; no provider marker. |
+| `cmux` | Legacy terminal RPC text/Enter evidence only; no provider marker. |
+| `codex-app` | Deep-link dispatch/prefill only; no provider marker. |
+| `claude-desktop` | Deep-link dispatch/prefill only; no provider marker. |
+
+`DeliverySubmitted` in the capability vector does not by itself authorize the
+marker: it describes the seat's delivery shape, not an application-level
+receipt.

--- a/docs/wake-state-invariants.md
+++ b/docs/wake-state-invariants.md
@@ -64,6 +64,34 @@ delete a newer target.
 
 Source anchors: `wake_target.go` and `wake_owner_storage_unix.go`.
 
+## `notification-attempts.jsonl`: durable notifier lifecycle audit
+
+**Owns:** the audit of one AMQ notification attempt for one message cohort.
+It does not own inbox delivery, provider consumption, terminal ownership, or
+the in-memory doorbell schedule. Schema 2 writes one prepared `attempt` event
+followed by ordered result states: `deferred`, `retried`, `accepted`, or
+`failed`. A deferred/retried sequence keeps the same AttemptID and cohort;
+`accepted` and `failed` are terminal. A later unread notification gets a new
+AttemptID. Schema 1 prepared/result records remain readable.
+
+**Commit domain:** each event is one O_APPEND JSON line in the single journal,
+with the existing rotation lock protecting rotation. The ledger is best effort:
+a journal write failure never blocks wake delivery. Readers fold only
+contiguous, valid lifecycle sequences. An out-of-order or contradictory
+sequence is `invalid`, never accepted evidence.
+
+**Transport taxonomy:** an external injector may claim provider dispatch only
+with stderr marker `AMQ_INJECT_PROGRESS=accepted` and exit zero. A deferred
+marker is a pre-dispatch busy result and produces no attention or acceptance
+claim. An uncertain marker wins over every other marker and enters recovery.
+Timeout is failed even when stderr contains deferred. A bare legacy exit zero
+is byte-write/uncertain evidence, not provider acceptance. Raw TIOCSTI remains
+`written` byte evidence only. `amq doctor --ops` projects the same folded state
+and warns for deferred/retried attempts.
+
+Source anchors: `internal/notificationattempt/ledger.go`, `wake.go`, and
+`doctor_ops.go`. The external-injector ambiguity is tracked in [#703](https://github.com/avivsinai/agent-message-queue/issues/703).
+
 Retirement results are exactly `refused`, `retired`, and
 `retired_with_residue`. The last is exit-0 success with a warning: ownership is
 already retired, but target/state cleanup failed or was skipped. The next

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 	"github.com/avivsinai/agent-message-queue/internal/presence"
 )
 
@@ -36,19 +37,31 @@ type opsRoot struct {
 }
 
 type opsAgent struct {
-	Handle                 string  `json:"handle"`
-	UnreadCount            int     `json:"unread_count"`
-	OldestUnreadAgeSeconds float64 `json:"oldest_unread_age_seconds"`
-	DLQCount               int     `json:"dlq_count"`
-	OldestDLQAgeSeconds    float64 `json:"oldest_dlq_age_seconds"`
-	PresenceStatus         string  `json:"presence_status"`
-	PresenceAgeSeconds     float64 `json:"presence_age_seconds"`
-	PresenceSource         string  `json:"presence_source,omitempty"`
-	NotifierStatus         string  `json:"notifier_status,omitempty"`
-	NotifierMode           string  `json:"notifier_mode,omitempty"`
-	NotifierReason         string  `json:"notifier_reason,omitempty"`
-	DoorbellParked         bool    `json:"doorbell_parked,omitempty"`
-	DoorbellAttempts       uint    `json:"doorbell_attempts,omitempty"`
+	Handle                 string                   `json:"handle"`
+	UnreadCount            int                      `json:"unread_count"`
+	OldestUnreadAgeSeconds float64                  `json:"oldest_unread_age_seconds"`
+	DLQCount               int                      `json:"dlq_count"`
+	OldestDLQAgeSeconds    float64                  `json:"oldest_dlq_age_seconds"`
+	PresenceStatus         string                   `json:"presence_status"`
+	PresenceAgeSeconds     float64                  `json:"presence_age_seconds"`
+	PresenceSource         string                   `json:"presence_source,omitempty"`
+	NotifierStatus         string                   `json:"notifier_status,omitempty"`
+	NotifierMode           string                   `json:"notifier_mode,omitempty"`
+	NotifierReason         string                   `json:"notifier_reason,omitempty"`
+	DoorbellParked         bool                     `json:"doorbell_parked,omitempty"`
+	DoorbellAttempts       uint                     `json:"doorbell_attempts,omitempty"`
+	NotificationAttempts   []opsNotificationAttempt `json:"notification_attempts,omitempty"`
+}
+
+type opsNotificationAttempt struct {
+	AttemptID    string   `json:"attempt_id"`
+	State        string   `json:"state"`
+	MessageIDs   []string `json:"message_ids"`
+	Mode         string   `json:"mode"`
+	RecordedAt   string   `json:"recorded_at"`
+	Sequence     uint64   `json:"sequence,omitempty"`
+	Detail       string   `json:"detail,omitempty"`
+	RetryPending bool     `json:"retry_pending,omitempty"`
 }
 
 type opsOperatorGate struct {
@@ -259,6 +272,14 @@ func runOpsChecksWithSchema(
 			agent.PresenceStatus = "unknown"
 		}
 		agent.PresenceSource = resolvePresenceSource(root, handle, recentActivity)
+		agent.NotificationAttempts, err = readOpsNotificationAttempts(root, handle)
+		if err != nil {
+			result.Hints = append(result.Hints, opsHint{
+				Code:    "notification_attempt_ledger_error",
+				Status:  "warn",
+				Message: fmt.Sprintf("Cannot read notification attempt ledger for %s: %v", handle, err),
+			})
+		}
 
 		// Round to reasonable precision
 		agent.OldestUnreadAgeSeconds = math.Round(agent.OldestUnreadAgeSeconds)
@@ -276,6 +297,21 @@ func runOpsChecksWithSchema(
 					agent.Handle,
 					agent.DoorbellAttempts,
 					agent.OldestUnreadAgeSeconds,
+				),
+			})
+		}
+		for _, attempt := range agent.NotificationAttempts {
+			if !attempt.RetryPending {
+				continue
+			}
+			result.Hints = append(result.Hints, opsHint{
+				Code:   "notification_deferred",
+				Status: "warn",
+				Message: fmt.Sprintf(
+					"Agent %s notification attempt %s is %s; the unread cohort is retained and the existing wake retry loop will try again",
+					agent.Handle,
+					attempt.AttemptID,
+					attempt.State,
 				),
 			})
 		}
@@ -303,6 +339,39 @@ func runOpsChecksWithSchema(
 	result.Hints = append(result.Hints, checkSymphonyHint()...)
 
 	return result
+}
+
+func readOpsNotificationAttempts(root, agent string) ([]opsNotificationAttempt, error) {
+	attempts, err := notificationattempt.List(root, agent, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(attempts) == 0 {
+		return nil, nil
+	}
+	result := make([]opsNotificationAttempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		recordedAt := attempt.Prepared.RecordedAt
+		sequence := attempt.Prepared.Sequence
+		detail := ""
+		if attempt.Result != nil {
+			recordedAt = attempt.Result.RecordedAt
+			sequence = attempt.Result.Sequence
+			detail = attempt.Result.Detail
+		}
+		result = append(result, opsNotificationAttempt{
+			AttemptID:  attempt.Prepared.AttemptID,
+			State:      attempt.State,
+			MessageIDs: append([]string{}, attempt.Prepared.MessageIDs...),
+			Mode:       attempt.Prepared.Mode,
+			RecordedAt: recordedAt,
+			Sequence:   sequence,
+			Detail:     detail,
+			RetryPending: attempt.State == notificationattempt.StateDeferred ||
+				attempt.State == notificationattempt.StateRetried,
+		})
+	}
+	return result, nil
 }
 
 func checkUnreadBacklogNoNotifierHints(root string, agents []opsAgent, wakeLocks []opsWakeLock) []opsHint {

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 	"github.com/avivsinai/agent-message-queue/internal/presence"
 )
 
@@ -106,6 +107,49 @@ func TestRunOpsChecks_BasicAgentStats(t *testing.T) {
 		t.Errorf("bob presence = %q, want %q", bob.PresenceStatus, "unknown")
 	}
 
+}
+
+func TestRunOpsChecksProjectsDeferredNotificationAttempt(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("ensure agent dirs: %v", err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"codex"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	writer := notificationattempt.NewWriter(root, "codex")
+	lifecycle, err := writer.Begin([]string{"msg-doctor-deferred"}, "external")
+	if err != nil {
+		t.Fatalf("begin notification attempt: %v", err)
+	}
+	if err := writer.Transition(lifecycle, notificationattempt.StateDeferred, "provider busy"); err != nil {
+		t.Fatalf("defer notification attempt: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.Agents) != 1 || len(result.Agents[0].NotificationAttempts) != 1 {
+		t.Fatalf("ops agents = %#v, want one projected notification attempt", result.Agents)
+	}
+	attempt := result.Agents[0].NotificationAttempts[0]
+	if attempt.State != notificationattempt.StateDeferred || !attempt.RetryPending {
+		t.Fatalf("projected notification attempt = %#v, want deferred retry-pending", attempt)
+	}
+	foundHint := false
+	for _, hint := range result.Hints {
+		if hint.Code == "notification_deferred" {
+			foundHint = true
+			break
+		}
+	}
+	if !foundHint {
+		t.Fatalf("ops hints = %#v, want notification_deferred warning", result.Hints)
+	}
 }
 
 func TestRunOpsChecks_DoorbellParkedHintRequiresUnreadBacklog(t *testing.T) {

--- a/internal/cli/trace.go
+++ b/internal/cli/trace.go
@@ -432,8 +432,14 @@ func notificationAttemptLimitation(state string) string {
 		return "prepared without a durable result is indeterminate; it does not prove that notification bytes were written"
 	case notificationattempt.OutcomeWritten:
 		return "written means only that notifier bytes were accepted; it does not prove seen, displayed, or submitted"
+	case notificationattempt.StateAccepted:
+		return "accepted means the external injector declared provider dispatch; it does not prove that the provider displayed, submitted, or consumed the doorbell"
+	case notificationattempt.StateDeferred, notificationattempt.StateRetried:
+		return "deferred/retried means the provider reported pre-dispatch busy or transition; the unread cohort remains pending and no provider acceptance is claimed"
+	case notificationattempt.StateInvalid:
+		return "invalid lifecycle ordering is ignored for acceptance; inspect the append-only notification journal"
 	default:
-		return "failed records a notifier write failure; it does not establish any terminal or user-visible state"
+		return "failed is terminal injector failure or uncertainty; it does not establish any terminal or user-visible state and is not silently replayed"
 	}
 }
 

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -64,6 +65,12 @@ type wakeConfig struct {
 	doorbellNow                   func() time.Time
 	lastAttemptAttention          bool
 	lastAttemptTransientAttention bool
+	lastInjectorOutcome           wakeInjectorOutcome
+	lastInjectorDetail            string
+	skipExternalInjector          bool
+	terminalInjectorCohort        []string
+	terminalInjectorMode          string
+	notificationAttempt           *notificationattempt.Lifecycle
 	onBaselineReady               func(map[string]wakeFileIdentity) error
 	onPrepared                    func(wakeAdmissionWatcher) error
 	retainedAgent                 wakeRetainedAgent
@@ -73,6 +80,7 @@ type wakeConfig struct {
 	maintenanceOutputs            []*os.File
 	preconditionCheck             func(*wakeConfig) error
 	onPendingNotify               func()
+	onNotificationAttemptStart    func()
 	onNotificationAttemptComplete func()
 	recordNotifierStatus          func(status, mode, reason string) error
 	pendingNotifierStatus         *wakeNotifierStatus
@@ -98,6 +106,17 @@ type wakeDoorbellStatus struct {
 }
 
 const maxWakeNotificationSenderClauses = 8
+
+type wakeInjectorOutcome uint8
+
+const (
+	wakeInjectorOutcomeNone wakeInjectorOutcome = iota
+	wakeInjectorOutcomeAccepted
+	wakeInjectorOutcomeDeferred
+	wakeInjectorOutcomeUncertain
+	wakeInjectorOutcomeFailed
+	wakeInjectorOutcomeLegacy
+)
 
 type wakeInputDeliveryPhase uint8
 
@@ -623,11 +642,10 @@ func wakeMessageIDs(messages []wakeMsgInfo) []string {
 }
 
 // deliverWithNotificationLedger wraps deliverNewMessageNotification with a
-// durable notification attempt record (prepared → result). The ledger NEVER
-// blocks delivery: if persisting the prepared record fails, the notification
-// is delivered anyway and the write failure is recorded for trace to surface
-// as StateWriteFailed ("attempt was made but the record could not be
-// persisted" — distinct from "no attempt recorded").
+// durable notification attempt record. Raw TIOCSTI and attention-only paths
+// retain the v1 byte-write record. External injectors use the v2 lifecycle so
+// deferred provider dispatch keeps one AttemptID until it is accepted or
+// terminally failed. The ledger NEVER blocks delivery.
 func deliverWithNotificationLedger(
 	cfg *wakeConfig,
 	messageIDs []string,
@@ -641,34 +659,194 @@ func deliverWithNotificationLedger(
 		// to notify about specific messages.
 		return deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
 	}
+	if cfg.inputRecoveryRequired && cfg.notificationAttempt == nil {
+		// Recovery attention is not a new provider attempt. Avoid creating an
+		// orphaned prepared record while the exact terminal-input debt is held.
+		return deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
+	}
+	if terminalInjectorForCohort(cfg, messageIDs) {
+		// A provider failure is terminal for the injector, but the existing
+		// attention cadence may still remind the operator. Suppress only the
+		// provider replay for this unchanged cohort; a new message cohort clears
+		// this latch in ensureNotificationAttempt and can try the provider.
+		previousSkip := cfg.skipExternalInjector
+		cfg.skipExternalInjector = true
+		defer func() { cfg.skipExternalInjector = previousSkip }()
+		return deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
+	}
 	writer := notificationattempt.NewWriter(cfg.root, cfg.me)
-	prepared, prepareErr := writer.Prepare(messageIDs, notificationAttemptMode(cfg))
-	deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
-	if prepareErr != nil {
-		// The prepared write failed. Record a result with outcome=failed so
-		// trace can surface "recording failed" rather than a silent hole.
-		// The delivery happened regardless (ledger never blocks delivery).
-		reconstructed := notificationattempt.Record{
-			AttemptID:  prepared.AttemptID,
-			MessageIDs: messageIDs,
-			Agent:      cfg.me,
+	if cfg.injectVia == "" || cfg.injectMode == wakeInjectModeNone {
+		prepared, prepareErr := writer.Prepare(messageIDs, notificationAttemptMode(cfg))
+		deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
+		if prepareErr != nil {
+			// The prepared write failed. Record a result with outcome=failed so
+			// trace can surface "recording failed" rather than a silent hole.
+			reconstructed := notificationattempt.Record{
+				AttemptID:  prepared.AttemptID,
+				MessageIDs: messageIDs,
+				Agent:      cfg.me,
+			}
+			if resultErr := writer.Result(reconstructed, notificationattempt.OutcomeFailed, "prepared write failed: "+prepareErr.Error()); resultErr != nil && cfg.debug {
+				_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
+			}
+			return deliverErr
 		}
-		if resultErr := writer.Result(reconstructed, notificationattempt.OutcomeFailed, "prepared write failed: "+prepareErr.Error()); resultErr != nil && cfg.debug {
+		outcome := notificationattempt.OutcomeFailed
+		detail := ""
+		if deliverErr == nil {
+			outcome = notificationattempt.OutcomeWritten
+		} else {
+			detail = deliverErr.Error()
+		}
+		if resultErr := writer.Result(prepared, outcome, detail); resultErr != nil && cfg.debug {
 			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
 		}
 		return deliverErr
 	}
-	outcome := notificationattempt.OutcomeFailed
-	detail := ""
-	if deliverErr == nil {
-		outcome = notificationattempt.OutcomeWritten
-	} else {
-		detail = deliverErr.Error()
+
+	cfg.lastInjectorOutcome = wakeInjectorOutcomeNone
+	var lifecycle *notificationattempt.Lifecycle
+	var prepareErr error
+	previousAttemptStart := cfg.onNotificationAttemptStart
+	cfg.onNotificationAttemptStart = func() {
+		if previousAttemptStart != nil {
+			previousAttemptStart()
+		}
+		if lifecycle != nil || prepareErr != nil {
+			return
+		}
+		lifecycle, prepareErr = ensureNotificationAttempt(cfg, writer, messageIDs)
 	}
-	if resultErr := writer.Result(prepared, outcome, detail); resultErr != nil && cfg.debug {
-		_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
+	defer func() { cfg.onNotificationAttemptStart = previousAttemptStart }()
+	deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
+	if isTerminalInjectorOutcome(cfg.lastInjectorOutcome) {
+		cfg.terminalInjectorCohort = append([]string{}, messageIDs...)
+		cfg.terminalInjectorMode = notificationAttemptMode(cfg)
+	}
+	if prepareErr != nil {
+		if cfg.debug {
+			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt: %v\n", prepareErr)
+		}
+		return deliverErr
+	}
+	if lifecycle == nil || cfg.lastInjectorOutcome == wakeInjectorOutcomeNone {
+		return deliverErr
+	}
+
+	if lifecycle.State == notificationattempt.StateDeferred {
+		if err := writer.Transition(lifecycle, notificationattempt.StateRetried, "provider retry attempted"); err != nil && cfg.debug {
+			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification retry: %v\n", err)
+		}
+	}
+	state, detail := notificationAttemptLifecycleResult(cfg, deliverErr)
+	if state == "" {
+		return deliverErr
+	}
+	if state == notificationattempt.OutcomeWritten {
+		// A legacy external injector wrote bytes but did not declare the v2
+		// protocol. Preserve the byte-write taxonomy without claiming provider
+		// acceptance.
+		prepared := notificationattempt.Record{
+			Schema:     notificationattempt.SchemaVersion,
+			AttemptID:  lifecycle.AttemptID,
+			Phase:      notificationattempt.PhasePrepared,
+			MessageIDs: append([]string{}, lifecycle.MessageIDs...),
+			Agent:      lifecycle.Agent,
+			Mode:       lifecycle.Mode,
+			State:      notificationattempt.StateAttempt,
+		}
+		if err := writer.Result(prepared, notificationattempt.OutcomeWritten, detail); err != nil && cfg.debug {
+			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist legacy notification result: %v\n", err)
+		}
+		cfg.notificationAttempt = nil
+		return deliverErr
+	}
+	if err := writer.Transition(lifecycle, state, detail); err != nil && cfg.debug {
+		_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification lifecycle: %v\n", err)
+	}
+	if state != notificationattempt.StateDeferred {
+		cfg.notificationAttempt = nil
 	}
 	return deliverErr
+}
+
+func ensureNotificationAttempt(
+	cfg *wakeConfig,
+	writer *notificationattempt.Writer,
+	messageIDs []string,
+) (*notificationattempt.Lifecycle, error) {
+	mode := notificationAttemptMode(cfg)
+	if cfg.notificationAttempt != nil &&
+		cfg.notificationAttempt.Agent == cfg.me &&
+		cfg.notificationAttempt.Mode == mode &&
+		sameWakeMessageIDs(cfg.notificationAttempt.MessageIDs, messageIDs) &&
+		cfg.notificationAttempt.State != notificationattempt.StateAccepted &&
+		cfg.notificationAttempt.State != notificationattempt.StateFailed {
+		return cfg.notificationAttempt, nil
+	}
+	lifecycle, err := writer.Begin(messageIDs, mode)
+	if err != nil {
+		return nil, err
+	}
+	cfg.notificationAttempt = lifecycle
+	return lifecycle, nil
+}
+
+func terminalInjectorForCohort(cfg *wakeConfig, messageIDs []string) bool {
+	return cfg != nil &&
+		cfg.injectVia != "" &&
+		len(cfg.terminalInjectorCohort) > 0 &&
+		cfg.terminalInjectorMode == notificationAttemptMode(cfg) &&
+		sameWakeMessageIDs(cfg.terminalInjectorCohort, messageIDs)
+}
+
+func isTerminalInjectorOutcome(outcome wakeInjectorOutcome) bool {
+	return outcome == wakeInjectorOutcomeFailed || outcome == wakeInjectorOutcomeUncertain
+}
+
+func sameWakeMessageIDs(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]string{}, left...)
+	rightCopy := append([]string{}, right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	for i := range leftCopy {
+		if strings.TrimSpace(leftCopy[i]) != strings.TrimSpace(rightCopy[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func notificationAttemptLifecycleResult(cfg *wakeConfig, deliveryErr error) (string, string) {
+	detail := ""
+	if deliveryErr != nil {
+		detail = deliveryErr.Error()
+	} else {
+		detail = cfg.lastInjectorDetail
+	}
+	switch cfg.lastInjectorOutcome {
+	case wakeInjectorOutcomeAccepted:
+		return notificationattempt.StateAccepted, detail
+	case wakeInjectorOutcomeDeferred:
+		return notificationattempt.StateDeferred, detail
+	case wakeInjectorOutcomeLegacy:
+		if detail == "" {
+			detail = "injector exited 0 without AMQ_INJECT_PROGRESS=accepted; provider acceptance is uncertain"
+		}
+		return notificationattempt.OutcomeWritten, detail
+	case wakeInjectorOutcomeUncertain:
+		if detail == "" {
+			detail = "provider acceptance is uncertain; replay is prohibited"
+		}
+		return notificationattempt.StateFailed, detail
+	case wakeInjectorOutcomeFailed:
+		return notificationattempt.StateFailed, detail
+	default:
+		return "", detail
+	}
 }
 
 // notificationAttemptMode returns a human-readable label for the injection
@@ -718,6 +896,9 @@ func deliverNewMessageNotification(
 		if cfg.inputDelivery.pending() {
 			return nil
 		}
+	}
+	if cfg.onNotificationAttemptStart != nil {
+		cfg.onNotificationAttemptStart()
 	}
 	ownerBound := usesCoopDoorbell(cfg)
 	if cfg.injectMode != wakeInjectModeNone {
@@ -796,8 +977,19 @@ func recordWakeAttempt(
 	if cfg.retryUntil == wakeRetryUntilInjected &&
 		deliveryErr == nil &&
 		!cfg.lastAttemptAttention &&
-		!cfg.lastAttemptTransientAttention {
+		!cfg.lastAttemptTransientAttention &&
+		(cfg.injectVia == "" ||
+			cfg.lastInjectorOutcome == wakeInjectorOutcomeAccepted ||
+			cfg.lastInjectorOutcome == wakeInjectorOutcomeLegacy) {
 		cfg.doorbell.recordInjected(currentPending)
+		return
+	}
+	if isWakeInjectorDeferred(deliveryErr) {
+		// Provider-side busy/transition is a silent transport deferral. Keep
+		// the existing cohort and its normal input retry ladder; do not spend
+		// the reminder budget or emit attention output.
+		cfg.doorbell.recordDeferredInputAttempt(now)
+		persistWakeDoorbellStatusBestEffort(cfg)
 		return
 	}
 	var attentionErr *wakeAttentionDeliveryError
@@ -1187,6 +1379,8 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
 	cfg.lastAttemptAttention = false
 	cfg.lastAttemptTransientAttention = false
+	cfg.lastInjectorOutcome = wakeInjectorOutcomeNone
+	cfg.lastInjectorDetail = ""
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
 		if notice.submitOnly && notice.input.provenance == wakePayloadSystemFixed {
@@ -1225,11 +1419,16 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
 	// The command receives the notification text as its last argument. Exit zero
-	// remains presentation-confirmation evidence. Post-text Enter/submit failure
-	// is encoded in child output as AMQ_INJECT_PROGRESS=uncertain; that path
-	// must not replay the payload.
+	// is accepted only when the child emits AMQ_INJECT_PROGRESS=accepted.
+	// Provider busy/transition is AMQ_INJECT_PROGRESS=deferred; post-dispatch
+	// ambiguity is AMQ_INJECT_PROGRESS=uncertain. Neither may replay the
+	// payload.
 	if cfg.injectVia != "" {
+		if cfg.skipExternalInjector {
+			return deliverWakeAttentionOnly(cfg, notice.output)
+		}
 		if cfg.inputDelivery.acceptanceUncertain {
+			cfg.lastInjectorOutcome = wakeInjectorOutcomeUncertain
 			return &wakeInputDemotionBlockedError{
 				err: errors.New("a prior terminal write has uncertain acceptance"),
 			}
@@ -1246,13 +1445,30 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
 		if err := injectVia(cfg, plainText); err != nil {
+			cfg.lastInjectorDetail = err.Error()
+			if isWakeInjectorDeferred(err) {
+				cfg.lastInjectorOutcome = wakeInjectorOutcomeDeferred
+				return err
+			}
+			if isWakeInjectorLegacy(err) {
+				cfg.lastInjectorOutcome = wakeInjectorOutcomeLegacy
+				// Preserve the v1 external-injector contract: a marker-less
+				// exit-zero command is a successful transport result. The
+				// lifecycle ledger records it as written/uncertain, while the
+				// wake loop keeps its existing retry-until policy.
+				return nil
+			}
 			var uncertain *wakeTerminalProgressUncertainError
 			if errors.As(err, &uncertain) {
+				if cfg.lastInjectorOutcome == wakeInjectorOutcomeNone {
+					cfg.lastInjectorOutcome = wakeInjectorOutcomeUncertain
+				}
 				cfg.inputDelivery.acceptanceUncertain = true
 				_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
 				cfg.fallbackWarn = false
 				return &wakeInputDemotionBlockedError{err: uncertain}
 			}
+			cfg.lastInjectorOutcome = wakeInjectorOutcomeFailed
 			if cfg.fallbackWarn {
 				_ = writeWakeDiagnostic(cfg, "amq wake: --inject-via failed: %v\n", err)
 				_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
@@ -1260,6 +1476,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			}
 			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
+		cfg.lastInjectorOutcome = wakeInjectorOutcomeAccepted
 		return nil
 	}
 
@@ -2026,24 +2243,49 @@ func injectVia(cfg *wakeConfig, text string) error {
 		waitDelay = 100 * time.Millisecond
 	}
 	cmd.WaitDelay = waitDelay
-	out, runErr := cmd.CombinedOutput()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	output := stdout.String() + stderr.String()
 	if ctx.Err() == context.DeadlineExceeded || errors.Is(runErr, exec.ErrWaitDelay) {
 		if cfg.debug {
-			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, output)
 		}
 		return fmt.Errorf("inject-via timed out after %s", timeout)
 	}
+	progress := parseWakeInjectorProgress(stderr.String())
 	if runErr != nil {
 		if cfg.debug {
-			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via failed: %v (%s)\n", runErr, string(out))
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via failed: %v (%s)\n", runErr, output)
 		}
-		if strings.Contains(string(out), "AMQ_INJECT_PROGRESS=uncertain") {
+		if progress == wakeInjectorProgressUncertain {
 			return &wakeTerminalProgressUncertainError{err: runErr}
+		}
+		if progress == wakeInjectorProgressDeferred {
+			return &wakeInjectorDeferredError{err: runErr}
 		}
 		return runErr
 	}
 
-	return nil
+	switch progress {
+	case wakeInjectorProgressAccepted:
+		return nil
+	case wakeInjectorProgressUncertain:
+		return &wakeTerminalProgressUncertainError{
+			err: errors.New("inject-via declared uncertain progress"),
+		}
+	case wakeInjectorProgressDeferred:
+		return &wakeTerminalProgressUncertainError{
+			err: errors.New("inject-via declared deferred progress with exit status 0"),
+		}
+	default:
+		return &wakeInjectorLegacyError{
+			err: &wakeTerminalProgressUncertainError{
+				err: errors.New("inject-via exited 0 without AMQ_INJECT_PROGRESS=accepted"),
+			},
+		}
+	}
 }
 
 func sanitizeForTTY(s string) string {

--- a/internal/cli/wake_injector_status.go
+++ b/internal/cli/wake_injector_status.go
@@ -1,14 +1,90 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
 	wakeInjectorUnsupportedStatus   = "injector_unsupported"
 	wakeInputRecoveryRequiredStatus = "input_recovery_required"
 	tiocstiLegacySysctlPath         = "/proc/sys/dev/tty/legacy_tiocsti"
+	wakeInjectorProgressPrefix      = "AMQ_INJECT_PROGRESS="
 )
+
+type wakeInjectorProgress string
+
+const (
+	wakeInjectorProgressAccepted  wakeInjectorProgress = "accepted"
+	wakeInjectorProgressDeferred  wakeInjectorProgress = "deferred"
+	wakeInjectorProgressUncertain wakeInjectorProgress = "uncertain"
+)
+
+// parseWakeInjectorProgress accepts only complete marker lines. Uncertain has
+// precedence over every other marker so a contradictory provider response can
+// never be treated as a successful or replayable delivery.
+func parseWakeInjectorProgress(stderr string) wakeInjectorProgress {
+	if strings.Contains(stderr, wakeInjectorProgressPrefix+string(wakeInjectorProgressUncertain)) {
+		return wakeInjectorProgressUncertain
+	}
+	var progress wakeInjectorProgress
+	accepted := false
+	deferred := false
+	for _, rawLine := range strings.Split(stderr, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if !strings.HasPrefix(line, wakeInjectorProgressPrefix) {
+			continue
+		}
+		candidate := wakeInjectorProgress(strings.TrimSpace(strings.TrimPrefix(line, wakeInjectorProgressPrefix)))
+		switch candidate {
+		case wakeInjectorProgressDeferred:
+			deferred = true
+			progress = candidate
+		case wakeInjectorProgressAccepted:
+			accepted = true
+			progress = candidate
+		}
+	}
+	if accepted && deferred {
+		return wakeInjectorProgressUncertain
+	}
+	return progress
+}
+
+type wakeInjectorDeferredError struct {
+	err error
+}
+
+func (err *wakeInjectorDeferredError) Error() string {
+	return fmt.Sprintf("inject-via deferred before provider dispatch: %v", err.err)
+}
+
+func (err *wakeInjectorDeferredError) Unwrap() error {
+	return err.err
+}
+
+func isWakeInjectorDeferred(err error) bool {
+	var deferred *wakeInjectorDeferredError
+	return errors.As(err, &deferred)
+}
+
+type wakeInjectorLegacyError struct {
+	err error
+}
+
+func (err *wakeInjectorLegacyError) Error() string {
+	return fmt.Sprintf("inject-via legacy success is not provider acceptance: %v", err.err)
+}
+
+func (err *wakeInjectorLegacyError) Unwrap() error {
+	return err.err
+}
+
+func isWakeInjectorLegacy(err error) bool {
+	var legacy *wakeInjectorLegacyError
+	return errors.As(err, &legacy)
+}
 
 type wakeInjectorUnsupportedError struct {
 	err error

--- a/internal/cli/wake_repair_handoff_unix_test.go
+++ b/internal/cli/wake_repair_handoff_unix_test.go
@@ -1355,6 +1355,7 @@ func TestWakeRepairFDInspectorHelperProcess(t *testing.T) {
 		_, _ = os.Stderr.WriteString("write repair descriptor inspection: " + err.Error() + "\n")
 		os.Exit(3)
 	}
+	_, _ = os.Stderr.WriteString("AMQ_INJECT_PROGRESS=accepted\n")
 	os.Exit(0)
 }
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -250,6 +250,7 @@ func TestInjectViaHelperProcess(t *testing.T) {
 		_, _ = os.Stderr.WriteString("write inject-via helper output: " + err.Error() + "\n")
 		os.Exit(3)
 	}
+	_, _ = os.Stderr.WriteString("AMQ_INJECT_PROGRESS=accepted\n")
 	os.Exit(0)
 }
 
@@ -1703,7 +1704,7 @@ func TestNotifyNewMessages_InjectViaExitZeroAdvancesInterruptCooldown(t *testing
 
 	logPath := filepath.Join(root, "inject.log")
 	scriptPath := filepath.Join(root, "inject.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> "+logPath+"\n"), 0o755); err != nil {
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> "+logPath+"\nprintf 'AMQ_INJECT_PROGRESS=accepted\\n' >&2\n"), 0o755); err != nil {
 		t.Fatalf("write script: %v", err)
 	}
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -3778,6 +3778,18 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 			return nil
 		}
+		if isWakeInjectorDeferred(err) {
+			// The provider refused before dispatch. The transport already
+			// retained the cohort and armed its input retry deadline; keep this
+			// loop silent and let that existing deadline drive the next attempt.
+			pendingNotify = false
+			clearTerminalAuthorityRetry()
+			scheduleDoorbellDeadline()
+			if cfg.debug {
+				_ = writeWakeDiagnostic(&cfg, "amq wake [debug]: provider deferred notification; retaining cohort for retry: %v\n", err)
+			}
+			return nil
+		}
 		var attentionErr *wakeAttentionDeliveryError
 		if errors.As(err, &attentionErr) &&
 			!isWakeTerminalAuthorityLoss(err) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
 	"github.com/avivsinai/agent-message-queue/internal/presence"
 	"github.com/fsnotify/fsnotify"
 )
@@ -6223,6 +6224,322 @@ exit 1
 	if attentionWrites != 1 {
 		t.Fatalf("ordinary inject-via failure emitted %d attention writes, want one", attentionWrites)
 	}
+}
+
+func TestInjectViaDeferredRetainsCohortWithoutAttentionOrAcceptance(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	injector := writeExecutableScriptForTest(t, "deferred-injector", `#!/bin/sh
+echo AMQ_INJECT_PROGRESS=deferred >&2
+exit 1
+`)
+	attentionWrites := 0
+	cfg := protocolWakeConfigForTest(t, root, injector, &attentionWrites)
+	current := wakeDoorbellTestFiles(t, "pending.md")
+
+	err := deliverWithNotificationLedger(
+		cfg,
+		[]string{"msg-deferred"},
+		peerWakeNotification("pending message"),
+		false,
+		current,
+	)
+	if !isWakeInjectorDeferred(err) {
+		t.Fatalf("delivery error = %v, want deferred", err)
+	}
+	if attentionWrites != 0 {
+		t.Fatalf("deferred provider emitted %d attention writes, want 0", attentionWrites)
+	}
+	if cfg.doorbell.phase != wakeDoorbellRetrying || cfg.doorbell.reminderAttempts != 0 || cfg.doorbell.presentationConfirmed {
+		t.Fatalf("deferred doorbell state = %#v, want retained retrying cohort without acceptance", cfg.doorbell)
+	}
+
+	attempts := listNotificationAttemptsForTest(t, root, "msg-deferred")
+	if len(attempts) != 1 || attempts[0].State != notificationattempt.StateDeferred {
+		t.Fatalf("notification attempts = %#v, want one deferred attempt", attempts)
+	}
+}
+
+func TestInjectViaDeferredThenAcceptedUsesOneAttemptAndNoDuplicate(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	countPath := filepath.Join(secureTempDirForTest(t), "inject-count")
+	injector := writeExecutableScriptForTest(t, "deferred-then-accepted", fmt.Sprintf(`#!/bin/sh
+count=0
+if [ -f %q ]; then count=$(cat %q); fi
+count=$((count + 1))
+printf '%%s' "$count" > %q
+if [ "$count" -eq 1 ]; then
+  echo AMQ_INJECT_PROGRESS=deferred >&2
+  exit 1
+fi
+echo AMQ_INJECT_PROGRESS=accepted >&2
+exit 0
+`, countPath, countPath, countPath))
+	attentionWrites := 0
+	cfg := protocolWakeConfigForTest(t, root, injector, &attentionWrites)
+	cfg.retryUntil = wakeRetryUntilInjected
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	messageIDs := []string{"msg-deferred-accepted"}
+	notice := peerWakeNotification("pending message")
+
+	if err := deliverWithNotificationLedger(cfg, messageIDs, notice, false, current); !isWakeInjectorDeferred(err) {
+		t.Fatalf("first delivery error = %v, want deferred", err)
+	}
+	first := listNotificationAttemptsForTest(t, root, messageIDs[0])
+	if len(first) != 1 || first[0].State != notificationattempt.StateDeferred {
+		t.Fatalf("first notification attempts = %#v, want one deferred attempt", first)
+	}
+	cfg.doorbell.makeDue(cfg.wakeDoorbellNow())
+	if err := deliverWithNotificationLedger(cfg, messageIDs, notice, false, current); err != nil {
+		t.Fatalf("accepted retry error = %v", err)
+	}
+
+	data, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read injector count: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "2" {
+		t.Fatalf("injector calls = %q, want deferred plus one accepted call", got)
+	}
+	if attentionWrites != 0 || cfg.doorbell.phase != wakeDoorbellAnnounced {
+		t.Fatalf("post-accept attention/state = %d/%#v, want 0/announced", attentionWrites, cfg.doorbell)
+	}
+	accepted := listNotificationAttemptsForTest(t, root, messageIDs[0])
+	if len(accepted) != 1 || accepted[0].State != notificationattempt.StateAccepted {
+		t.Fatalf("accepted notification attempts = %#v, want one terminal accepted attempt", accepted)
+	}
+	if accepted[0].Prepared.AttemptID != first[0].Prepared.AttemptID || len(accepted[0].History) != 4 {
+		t.Fatalf("accepted lifecycle = %#v, want same ID and attempt/deferred/retried/accepted history", accepted[0])
+	}
+	if err := deliverWithNotificationLedger(cfg, messageIDs, notice, false, current); err != nil {
+		t.Fatalf("post-accept scan error = %v", err)
+	}
+	data, err = os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read injector count after post-accept scan: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "2" {
+		t.Fatalf("post-accept injector calls = %q, want 2", got)
+	}
+}
+
+func TestInjectViaLegacyExitZeroIsWrittenButNotAccepted(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	countPath := filepath.Join(secureTempDirForTest(t), "inject-count")
+	injector := writeExecutableScriptForTest(t, "legacy-injector", fmt.Sprintf(`#!/bin/sh
+count=0
+if [ -f %q ]; then count=$(cat %q); fi
+count=$((count + 1))
+printf '%%s' "$count" > %q
+exit 0
+`, countPath, countPath, countPath))
+	attentionWrites := 0
+	cfg := protocolWakeConfigForTest(t, root, injector, &attentionWrites)
+	cfg.retryUntil = wakeRetryUntilInjected
+	current := wakeDoorbellTestFiles(t, "pending.md")
+
+	if err := deliverWithNotificationLedger(cfg, []string{"msg-legacy"}, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("legacy delivery error = %v, want legacy success", err)
+	}
+	if attentionWrites != 0 || cfg.inputRecoveryRequired || cfg.doorbell.phase != wakeDoorbellAnnounced {
+		t.Fatalf("legacy loop state = attention %d recovery %v doorbell %#v; want no recovery and announced", attentionWrites, cfg.inputRecoveryRequired, cfg.doorbell)
+	}
+	attempts := listNotificationAttemptsForTest(t, root, "msg-legacy")
+	if len(attempts) != 1 || attempts[0].State != notificationattempt.OutcomeWritten {
+		t.Fatalf("legacy notification attempts = %#v, want written byte evidence", attempts)
+	}
+	if attempts[0].State == notificationattempt.StateAccepted || attempts[0].Result == nil || !strings.Contains(attempts[0].Result.Detail, "uncertain") {
+		t.Fatalf("legacy result = %#v, want uncertain non-accepted detail", attempts[0].Result)
+	}
+	data, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read legacy injector count: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "1" {
+		t.Fatalf("legacy injector calls = %q, want one call under retry-until-injected", got)
+	}
+}
+
+func TestInjectViaDualMarkersIsUncertainAndNeverReplayed(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	countPath := filepath.Join(secureTempDirForTest(t), "inject-count")
+	injector := writeExecutableScriptForTest(t, "dual-marker-injector", fmt.Sprintf(`#!/bin/sh
+count=0
+if [ -f %q ]; then count=$(cat %q); fi
+count=$((count + 1))
+printf '%%s' "$count" > %q
+echo AMQ_INJECT_PROGRESS=deferred >&2
+echo AMQ_INJECT_PROGRESS=uncertain >&2
+exit 1
+`, countPath, countPath, countPath))
+	attentionWrites := 0
+	cfg := protocolWakeConfigForTest(t, root, injector, &attentionWrites)
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	messageIDs := []string{"msg-dual-marker"}
+	notice := peerWakeNotification("pending message")
+	if err := deliverWithNotificationLedger(cfg, messageIDs, notice, false, current); err != nil {
+		t.Fatalf("dual-marker delivery error = %v, want recovery transition", err)
+	}
+	if !cfg.inputRecoveryRequired || attentionWrites != 1 {
+		t.Fatalf("dual-marker recovery = required %v attention %d, want true/1", cfg.inputRecoveryRequired, attentionWrites)
+	}
+	if err := deliverWithNotificationLedger(cfg, messageIDs, notice, false, current); err != nil {
+		t.Fatalf("dual-marker recovery scan error = %v", err)
+	}
+	data, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read injector count: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "1" {
+		t.Fatalf("dual-marker injector calls = %q, want 1", got)
+	}
+	attempts := listNotificationAttemptsForTest(t, root, messageIDs[0])
+	if len(attempts) != 1 || attempts[0].State == notificationattempt.StateAccepted || attempts[0].Result == nil || !strings.Contains(attempts[0].Result.Detail, "uncertain") {
+		t.Fatalf("dual-marker notification attempts = %#v, want terminal non-accepted uncertainty", attempts)
+	}
+}
+
+func TestInjectViaTimeoutWithDeferredMarkerIsFailedAndAttentionOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	countPath := filepath.Join(secureTempDirForTest(t), "inject-count")
+	injector := writeExecutableScriptForTest(t, "timeout-deferred-injector", fmt.Sprintf(`#!/bin/sh
+printf '1' > %q
+echo AMQ_INJECT_PROGRESS=deferred >&2
+sleep 5
+`, countPath))
+	attentionWrites := 0
+	cfg := protocolWakeConfigForTest(t, root, injector, &attentionWrites)
+	cfg.injectTimeout = time.Second
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	if err := deliverWithNotificationLedger(cfg, []string{"msg-timeout"}, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("timeout delivery error = %v, want attention fallback", err)
+	}
+	if attentionWrites != 1 || cfg.inputRecoveryRequired {
+		t.Fatalf("timeout fallback = attention %d recovery %v, want 1/false", attentionWrites, cfg.inputRecoveryRequired)
+	}
+	attempts := listNotificationAttemptsForTest(t, root, "msg-timeout")
+	if len(attempts) != 1 || attempts[0].State != notificationattempt.StateFailed || attempts[0].Result == nil || !strings.Contains(attempts[0].Result.Detail, "timed out") {
+		t.Fatalf("timeout notification attempts = %#v, want terminal failed timeout", attempts)
+	}
+	cfg.doorbell.makeDue(cfg.wakeDoorbellNow())
+	if err := deliverWithNotificationLedger(cfg, []string{"msg-timeout"}, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("timeout due retry error = %v", err)
+	}
+	data, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read timeout injector count: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "1" {
+		t.Fatalf("timeout injector calls = %q, want terminal failure not replayed", got)
+	}
+}
+
+func TestRawTIOCSTIRecordsWrittenWithoutAcceptanceClaim(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	var writes []string
+	cfg := &wakeConfig{
+		me:         "codex",
+		root:       root,
+		wakeOwner:  &wakeOwner{},
+		injectMode: wakeInjectModeRaw,
+		terminalWrite: func(chunk string) error {
+			writes = append(writes, chunk)
+			return nil
+		},
+	}
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	if err := deliverWithNotificationLedger(cfg, []string{"msg-raw"}, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("raw delivery error = %v", err)
+	}
+	if len(writes) == 0 {
+		t.Fatal("raw TIOCSTI test injected no terminal bytes")
+	}
+	attempts := listNotificationAttemptsForTest(t, root, "msg-raw")
+	if len(attempts) != 1 || attempts[0].State != notificationattempt.OutcomeWritten {
+		t.Fatalf("raw notification attempts = %#v, want written byte evidence", attempts)
+	}
+	if attempts[0].State == notificationattempt.StateAccepted || cfg.doorbell.phase == wakeDoorbellAnnounced {
+		t.Fatalf("raw delivery claimed acceptance: attempt=%#v doorbell=%#v", attempts[0], cfg.doorbell)
+	}
+}
+
+func TestRawTIOCSTIRetryUntilInjectedStopsAfterByteWrite(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	writes := 0
+	cfg := &wakeConfig{
+		me:         "codex",
+		root:       root,
+		wakeOwner:  &wakeOwner{},
+		injectMode: wakeInjectModeRaw,
+		retryUntil: wakeRetryUntilInjected,
+		terminalWrite: func(string) error {
+			writes++
+			return nil
+		},
+	}
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	if err := deliverWithNotificationLedger(cfg, []string{"msg-raw-retry"}, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("raw delivery error = %v", err)
+	}
+	if cfg.doorbell.phase != wakeDoorbellAnnounced {
+		t.Fatalf("raw doorbell phase = %v, want announced after byte-write success", cfg.doorbell.phase)
+	}
+	firstWrites := writes
+	cfg.doorbell.makeDue(cfg.wakeDoorbellNow())
+	if err := deliverNewMessageNotification(cfg, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("raw post-ack scan error = %v", err)
+	}
+	if writes != firstWrites {
+		t.Fatalf("raw post-ack writes = %d, want %d", writes, firstWrites)
+	}
+}
+
+func protocolWakeConfigForTest(t *testing.T, root, injector string, attentionWrites *int) *wakeConfig {
+	t.Helper()
+	return &wakeConfig{
+		me:             "codex",
+		root:           root,
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModePaste,
+		injectVia:      injector,
+		injectTimeout:  time.Second,
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			if attentionWrites != nil {
+				(*attentionWrites)++
+			}
+			return len(data), nil
+		},
+	}
+}
+
+func listNotificationAttemptsForTest(t *testing.T, root, messageID string) []notificationattempt.Attempt {
+	t.Helper()
+	attempts, err := notificationattempt.List(root, "codex", messageID)
+	if err != nil {
+		t.Fatalf("List notification attempts: %v", err)
+	}
+	return attempts
 }
 
 func TestRunWakeWithLoopKeepsOldWakeTargetWhenNewTargetIsUnsafe(t *testing.T) {

--- a/internal/keepalive/adapter/adapter.go
+++ b/internal/keepalive/adapter/adapter.go
@@ -28,6 +28,14 @@ type Adapter interface {
 	Inject(ctx context.Context, target string, payload string) error
 }
 
+// ProviderAcceptanceReporter is an opt-in marker for adapters whose Inject
+// implementation observes an application-level acceptance receipt. It is
+// deliberately separate from Capability.DeliverySubmitted: a submitted TTY
+// or file write does not prove that the provider accepted the payload.
+type ProviderAcceptanceReporter interface {
+	ReportsProviderAcceptance()
+}
+
 type Discoverer interface {
 	Discover(ctx context.Context) (string, error)
 }

--- a/internal/keepalive/adapter/claudeprint.go
+++ b/internal/keepalive/adapter/claudeprint.go
@@ -57,6 +57,11 @@ type ClaudePrint struct {
 
 func (ClaudePrint) Name() string { return claudePrintName }
 
+// ReportsProviderAcceptance marks Claude Print as an application-level
+// acceptance reporter. Inject waits for the matching isReplay user event in
+// the Claude stream before returning nil.
+func (ClaudePrint) ReportsProviderAcceptance() {}
+
 func (ClaudePrint) Capability() Capability {
 	return Capability{
 		Activation:    ActivationNone,

--- a/internal/keepalive/adapter/codexqueue.go
+++ b/internal/keepalive/adapter/codexqueue.go
@@ -39,6 +39,11 @@ type CodexQueue struct {
 
 func (CodexQueue) Name() string { return codexQueueName }
 
+// ReportsProviderAcceptance marks Codex Queue as an application-level
+// acceptance reporter. Inject returns nil only after the queue command
+// accepts the message.
+func (CodexQueue) ReportsProviderAcceptance() {}
+
 // Capability is the honest submitted vector. Queue enqueues to the thread's
 // existing writer; it never raises/focuses the app.
 func (CodexQueue) Capability() Capability {

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -1149,7 +1149,13 @@ func (a App) inject(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	return selected.Inject(ctx, args[1], args[2])
+	if err := selected.Inject(ctx, args[1], args[2]); err != nil {
+		return err
+	}
+	if _, ok := selected.(adapter.ProviderAcceptanceReporter); ok {
+		_, _ = fmt.Fprintln(a.Stderr, "AMQ_INJECT_PROGRESS=accepted")
+	}
+	return nil
 }
 
 func (a App) doctor(args []string) error {

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -857,6 +857,57 @@ func (undeclaredAdapter) Name() string                                 { return 
 func (undeclaredAdapter) Probe(context.Context, string) error          { return nil }
 func (undeclaredAdapter) Inject(context.Context, string, string) error { return nil }
 
+type injectProgressAdapter struct {
+	name string
+}
+
+func (a injectProgressAdapter) Name() string                               { return a.name }
+func (injectProgressAdapter) Probe(context.Context, string) error          { return nil }
+func (injectProgressAdapter) Inject(context.Context, string, string) error { return nil }
+
+type acceptedInjectProgressAdapter struct {
+	injectProgressAdapter
+}
+
+func (acceptedInjectProgressAdapter) ReportsProviderAcceptance() {}
+
+func TestInjectReportsProviderAcceptanceOnlyForOptInAdapters(t *testing.T) {
+	tests := []struct {
+		name       string
+		adapter    adapter.Adapter
+		wantMarker bool
+	}{
+		{
+			name:    "transport-only adapter",
+			adapter: injectProgressAdapter{name: "transport-only"},
+		},
+		{
+			name: "provider-ack adapter",
+			adapter: acceptedInjectProgressAdapter{
+				injectProgressAdapter: injectProgressAdapter{name: "provider-ack"},
+			},
+			wantMarker: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapters := adapter.NewRegistry(test.adapter)
+			var stderr bytes.Buffer
+			code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr, Adapters: &adapters}).Run(
+				context.Background(),
+				[]string{"inject", test.adapter.Name(), "target", "payload"},
+			)
+			if code != 0 {
+				t.Fatalf("inject code = %d, stderr = %q", code, stderr.String())
+			}
+			gotMarker := strings.Contains(stderr.String(), "AMQ_INJECT_PROGRESS=accepted")
+			if gotMarker != test.wantMarker {
+				t.Fatalf("accepted marker = %t, want %t; stderr = %q", gotMarker, test.wantMarker, stderr.String())
+			}
+		})
+	}
+}
+
 func TestRegisterCapabilityGateTreatsUndeclaredAdapterAsUnknown(t *testing.T) {
 	// An undeclared adapter is treated as UnknownCapability(): weakest on
 	// every ordered axis and requires a human. It is REFUSED under the default

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -1,6 +1,7 @@
 // Package notificationattempt persists a durable audit log of notification
-// write attempts (prepared → result) so that `amq trace` can report whether a
-// wake attempted to notify an agent and what the outcome was.
+// write attempts and their lifecycle so that `amq trace` and `amq doctor
+// --ops` can report whether a wake attempted to notify an agent and what the
+// outcome was.
 //
 // The ledger NEVER blocks delivery: if persisting the prepared record fails,
 // the wake injects anyway and the failure is recorded for trace to surface.
@@ -49,12 +50,12 @@ import (
 )
 
 const (
-	// SchemaVersion is the integer schema version of a Record. v1 is the
-	// initial shape. A versioned reader (readRecords) handles migration: if a
-	// future field set changes, bump this and add a migration branch in
-	// validateRecord. Do not remove the version check — an unversioned reader
+	// SchemaVersion is the current integer schema version of a Record. Version
+	// 2 adds ordered lifecycle state events while keeping the v1 prepared/result
+	// records readable. Do not remove the version check: an unversioned reader
 	// is how a schema change silently corrupts history.
-	SchemaVersion = 1
+	SchemaVersion       = 2
+	legacySchemaVersion = 1
 
 	PhasePrepared = "prepared"
 	PhaseResult   = "result"
@@ -74,6 +75,15 @@ const (
 	// and from an empty journal ("no attempt recorded").
 	StateWriteFailed = "write_failed"
 
+	// Lifecycle states are deliberately small. They describe AMQ's durable
+	// attempt state, not provider-side presentation or consumption.
+	StateAttempt  = "attempt"
+	StateDeferred = "deferred"
+	StateRetried  = "retried"
+	StateAccepted = "accepted"
+	StateFailed   = "failed"
+	StateInvalid  = "invalid"
+
 	LogFilename   = "notification-attempts.jsonl"
 	rotatedSuffix = ".1"
 
@@ -82,7 +92,8 @@ const (
 
 // Record is one append-only journal entry. The Phase field distinguishes a
 // prepared record (before injection) from a result record (after injection).
-// A result record carries the Outcome (written/failed).
+// Version 1 result records carry Outcome (written/failed). Version 2
+// lifecycle records carry State and Sequence instead.
 type Record struct {
 	Schema     int      `json:"schema"`
 	AttemptID  string   `json:"attempt_id"`
@@ -93,16 +104,30 @@ type Record struct {
 	RecordedAt string   `json:"recorded_at"`
 	Outcome    string   `json:"outcome,omitempty"`
 	Detail     string   `json:"detail,omitempty"`
+	State      string   `json:"state,omitempty"`
+	Sequence   uint64   `json:"sequence,omitempty"`
 }
 
 // Attempt is the joined view of a prepared record and its optional result,
-// used by trace. State is derived: written/failed if a result exists,
-// indeterminate if only prepared exists, write_failed if the prepared write
-// errored (see Writer.Prepare return).
+// used by trace and doctor. State is derived from the ordered lifecycle for a
+// v2 attempt, or from the v1 result outcome for a legacy attempt.
 type Attempt struct {
-	State    string  `json:"state"`
-	Prepared Record  `json:"prepared"`
-	Result   *Record `json:"result,omitempty"`
+	State    string   `json:"state"`
+	Prepared Record   `json:"prepared"`
+	Result   *Record  `json:"result,omitempty"`
+	History  []Record `json:"history,omitempty"`
+}
+
+// Lifecycle is the in-process handle for one durable notification attempt.
+// The handle keeps one AttemptID across deferred/retried delivery and is not
+// itself a source of authority; the append-only journal is.
+type Lifecycle struct {
+	AttemptID  string
+	MessageIDs []string
+	Agent      string
+	Mode       string
+	State      string
+	Sequence   uint64
 }
 
 // Writer appends prepared/result records to the per-agent notification log.
@@ -133,6 +158,64 @@ func NewWriter(root, agent string) *Writer {
 // attempt recorded". The ledger never blocks delivery: the caller injects
 // regardless of writeErr.
 func (w *Writer) Prepare(messageIDs []string, mode string) (record Record, writeErr error) {
+	return w.prepare(messageIDs, mode, "")
+}
+
+// Begin appends the initial v2 lifecycle event for one notification attempt.
+// The returned handle must be used for every later state transition so a
+// deferred attempt keeps the same AttemptID and cohort.
+func (w *Writer) Begin(messageIDs []string, mode string) (*Lifecycle, error) {
+	record, err := w.prepare(messageIDs, mode, StateAttempt)
+	if err != nil {
+		return nil, err
+	}
+	return &Lifecycle{
+		AttemptID:  record.AttemptID,
+		MessageIDs: append([]string{}, record.MessageIDs...),
+		Agent:      record.Agent,
+		Mode:       record.Mode,
+		State:      record.State,
+		Sequence:   record.Sequence,
+	}, nil
+}
+
+// Transition appends one ordered v2 lifecycle state. Invalid transitions are
+// rejected before writing, so a terminal state cannot silently be reopened.
+func (w *Writer) Transition(lifecycle *Lifecycle, state, detail string) error {
+	if lifecycle == nil || lifecycle.AttemptID == "" || len(lifecycle.MessageIDs) == 0 {
+		return fmt.Errorf("invalid notification attempt lifecycle: missing identity")
+	}
+	if lifecycle.Agent != "" && lifecycle.Agent != w.agent {
+		return fmt.Errorf("notification attempt agent mismatch: lifecycle %q writer %q", lifecycle.Agent, w.agent)
+	}
+	state = strings.TrimSpace(state)
+	if !validLifecycleState(state) {
+		return fmt.Errorf("notification attempt lifecycle state %q is invalid", state)
+	}
+	if !validLifecycleTransition(lifecycle.State, state) {
+		return fmt.Errorf("notification attempt lifecycle transition %q -> %q is invalid", lifecycle.State, state)
+	}
+	record := Record{
+		Schema:     SchemaVersion,
+		AttemptID:  lifecycle.AttemptID,
+		Phase:      PhaseResult,
+		MessageIDs: append([]string{}, lifecycle.MessageIDs...),
+		Agent:      w.agent,
+		Mode:       lifecycle.Mode,
+		RecordedAt: w.now().UTC().Format(time.RFC3339Nano),
+		Detail:     strings.TrimSpace(detail),
+		State:      state,
+		Sequence:   lifecycle.Sequence + 1,
+	}
+	if err := w.append(record); err != nil {
+		return fmt.Errorf("persist notification attempt transition: %w", err)
+	}
+	lifecycle.State = state
+	lifecycle.Sequence = record.Sequence
+	return nil
+}
+
+func (w *Writer) prepare(messageIDs []string, mode, state string) (record Record, writeErr error) {
 	if err := fsq.ValidateHandle(w.agent); err != nil {
 		return Record{}, fmt.Errorf("notification attempt agent: %w", err)
 	}
@@ -152,6 +235,7 @@ func (w *Writer) Prepare(messageIDs []string, mode string) (record Record, write
 		Agent:      w.agent,
 		Mode:       strings.TrimSpace(mode),
 		RecordedAt: w.now().UTC().Format(time.RFC3339Nano),
+		State:      strings.TrimSpace(state),
 	}
 	if err := w.append(record); err != nil {
 		return Record{}, fmt.Errorf("persist prepared notification attempt: %w", err)
@@ -370,12 +454,17 @@ func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attemp
 	if err != nil {
 		return nil, err
 	}
-	resultByAttempt := make(map[string]Record)
 	preparedByAttempt := make(map[string]Record)
+	legacyResultByAttempt := make(map[string]Record)
+	lifecycleByAttempt := make(map[string][]Record)
 	for _, rec := range records {
 		switch rec.Phase {
 		case PhaseResult:
-			resultByAttempt[rec.AttemptID] = rec
+			if rec.State != "" {
+				lifecycleByAttempt[rec.AttemptID] = append(lifecycleByAttempt[rec.AttemptID], rec)
+			} else {
+				legacyResultByAttempt[rec.AttemptID] = rec
+			}
 		case PhasePrepared:
 			preparedByAttempt[rec.AttemptID] = rec
 		}
@@ -386,10 +475,22 @@ func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attemp
 			continue
 		}
 		attempt := Attempt{State: StateIndeterminate, Prepared: prepared}
-		if result, ok := resultByAttempt[prepared.AttemptID]; ok {
+		if prepared.State != "" || len(lifecycleByAttempt[prepared.AttemptID]) > 0 {
+			var legacyResult *Record
+			if result, ok := legacyResultByAttempt[prepared.AttemptID]; ok {
+				resultCopy := result
+				legacyResult = &resultCopy
+			}
+			attempt = foldLifecycle(
+				prepared,
+				lifecycleByAttempt[prepared.AttemptID],
+				legacyResult,
+			)
+		} else if result, ok := legacyResultByAttempt[prepared.AttemptID]; ok {
 			resultCopy := result
 			attempt.State = result.Outcome
 			attempt.Result = &resultCopy
+			attempt.History = []Record{prepared, result}
 		}
 		attempts = append(attempts, attempt)
 	}
@@ -397,6 +498,51 @@ func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attemp
 		return attempts[i].Prepared.RecordedAt < attempts[j].Prepared.RecordedAt
 	})
 	return attempts, nil
+}
+
+func foldLifecycle(prepared Record, events []Record, legacyResult *Record) Attempt {
+	attempt := Attempt{
+		State:    StateInvalid,
+		Prepared: prepared,
+		History:  append([]Record{prepared}, events...),
+	}
+	if prepared.State != StateAttempt || prepared.Sequence != 0 || prepared.Outcome != "" {
+		return attempt
+	}
+	if len(events) == 0 && legacyResult != nil {
+		if legacyResult.AttemptID != prepared.AttemptID ||
+			legacyResult.Agent != prepared.Agent ||
+			legacyResult.Mode != prepared.Mode ||
+			!sameStrings(legacyResult.MessageIDs, prepared.MessageIDs) {
+			return attempt
+		}
+		resultCopy := *legacyResult
+		attempt.State = resultCopy.Outcome
+		attempt.Result = &resultCopy
+		attempt.History = append(attempt.History, resultCopy)
+		return attempt
+	}
+	if legacyResult != nil {
+		return attempt
+	}
+	state := prepared.State
+	sequence := prepared.Sequence
+	for _, event := range events {
+		if event.AttemptID != prepared.AttemptID ||
+			event.Agent != prepared.Agent ||
+			event.Mode != prepared.Mode ||
+			!sameStrings(event.MessageIDs, prepared.MessageIDs) ||
+			event.Sequence != sequence+1 ||
+			!validLifecycleTransition(state, event.State) {
+			return attempt
+		}
+		state = event.State
+		sequence = event.Sequence
+		resultCopy := event
+		attempt.Result = &resultCopy
+	}
+	attempt.State = state
+	return attempt
 }
 
 // readRecords reads the notification log (and its .1 rotation, oldest first)
@@ -449,8 +595,8 @@ func readRecords(root *fsq.DeliveryRoot, agent string) ([]Record, error) {
 // unknown schema is rejected (fail-closed on history we cannot interpret
 // rather than rendering a wrong answer).
 func validateRecord(record Record, agent string) error {
-	if record.Schema != SchemaVersion {
-		return fmt.Errorf("notification attempt schema %d is not %d", record.Schema, SchemaVersion)
+	if record.Schema != SchemaVersion && record.Schema != legacySchemaVersion {
+		return fmt.Errorf("notification attempt schema %d is not %d or legacy %d", record.Schema, SchemaVersion, legacySchemaVersion)
 	}
 	if record.Agent != agent || record.AttemptID == "" || len(record.MessageIDs) == 0 || record.RecordedAt == "" {
 		return fmt.Errorf("invalid notification attempt record")
@@ -466,14 +612,45 @@ func validateRecord(record Record, agent string) error {
 		if record.Outcome != "" {
 			return fmt.Errorf("prepared record must not claim an outcome")
 		}
+		if record.State != "" {
+			if record.Schema != SchemaVersion || record.State != StateAttempt || record.Sequence != 0 {
+				return fmt.Errorf("prepared lifecycle record must start at state %q sequence 0", StateAttempt)
+			}
+		}
 	case PhaseResult:
-		if record.Outcome != OutcomeWritten && record.Outcome != OutcomeFailed {
+		if record.State != "" {
+			if record.Schema != SchemaVersion || record.Sequence == 0 || !validLifecycleState(record.State) || record.Outcome != "" {
+				return fmt.Errorf("invalid notification attempt lifecycle result")
+			}
+		} else if record.Outcome != OutcomeWritten && record.Outcome != OutcomeFailed {
 			return fmt.Errorf("result outcome must be %q or %q", OutcomeWritten, OutcomeFailed)
 		}
 	default:
 		return fmt.Errorf("notification attempt phase %q is invalid", record.Phase)
 	}
 	return nil
+}
+
+func validLifecycleState(state string) bool {
+	switch state {
+	case StateAttempt, StateDeferred, StateRetried, StateAccepted, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func validLifecycleTransition(from, to string) bool {
+	switch from {
+	case StateAttempt:
+		return to == StateDeferred || to == StateAccepted || to == StateFailed
+	case StateDeferred:
+		return to == StateRetried
+	case StateRetried:
+		return to == StateDeferred || to == StateAccepted || to == StateFailed
+	default:
+		return false
+	}
 }
 
 func normalizedMessageIDs(messageIDs []string) []string {
@@ -498,6 +675,18 @@ func contains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // ErrNoJournal is returned by helpers that need to distinguish "the journal

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -424,6 +424,66 @@ func TestListEmptyJournalIsNotAnError(t *testing.T) {
 	}
 }
 
+func TestLifecycleRetainsAttemptIDAcrossDeferredRetryAccepted(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	lifecycle, err := writer.Begin([]string{"msg-lifecycle"}, "external")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	attemptID := lifecycle.AttemptID
+	for _, state := range []string{StateDeferred, StateRetried, StateAccepted} {
+		if err := writer.Transition(lifecycle, state, "test"); err != nil {
+			t.Fatalf("Transition(%q): %v", state, err)
+		}
+	}
+
+	attempts, err := List(root, "codex", "msg-lifecycle")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("attempt count = %d, want 1", len(attempts))
+	}
+	attempt := attempts[0]
+	if attempt.State != StateAccepted || attempt.Prepared.AttemptID != attemptID {
+		t.Fatalf("attempt = %+v, want accepted attempt %q", attempt, attemptID)
+	}
+	if len(attempt.History) != 4 {
+		t.Fatalf("history length = %d, want attempt plus three transitions", len(attempt.History))
+	}
+	for index, record := range attempt.History {
+		if record.AttemptID != attemptID {
+			t.Fatalf("history[%d] attempt ID = %q, want %q", index, record.AttemptID, attemptID)
+		}
+		if index > 0 && record.Sequence != uint64(index) {
+			t.Fatalf("history[%d] sequence = %d, want %d", index, record.Sequence, index)
+		}
+	}
+}
+
+func TestLifecycleRejectsTerminalReopen(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	lifecycle, err := writer.Begin([]string{"msg-terminal"}, "external")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := writer.Transition(lifecycle, StateAccepted, "done"); err != nil {
+		t.Fatalf("Transition accepted: %v", err)
+	}
+	if err := writer.Transition(lifecycle, StateDeferred, "must reject"); err == nil {
+		t.Fatal("terminal lifecycle reopened")
+	}
+	attempts, err := List(root, "codex", "msg-terminal")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateAccepted {
+		t.Fatalf("attempts = %+v, want one accepted attempt", attempts)
+	}
+}
+
 // itoa is a tiny dependency-free int→string to keep the test file self-contained.
 func itoa(i int) string {
 	if i == 0 {


### PR DESCRIPTION
## Summary

This is the AMQ half of #682. It adds the AMQ-side inject-via protocol, deferred wake retry, and notification-attempt ledger v2. Full cross-repo completion still needs the Amit `bd36` provider injector.

## Contract

`--inject-via` now requires explicit progress reporting:

- `AMQ_INJECT_PROGRESS=accepted`: exit 0 plus the marker; provider acceptance is proven.
- `AMQ_INJECT_PROGRESS=deferred`: pre-dispatch rejection or no side effect; retain the cohort and retry the same attempt.
- `AMQ_INJECT_PROGRESS=uncertain`: any uncertain marker, including contradictory markers; terminal for provider replay.
- Timeout/deadline or a non-deferred failure: `Failed`; terminal for provider replay.
- Marker-less exit 0: preserve the legacy success return and byte-written ledger evidence, but do not claim provider acceptance.
- `Deferred -> Retried -> Accepted` uses one `AttemptID`; a later unread notification gets a new attempt.

Uncertain wins whenever its marker appears anywhere in stderr. A deferred result does not fall back to attention-only delivery.

## Adapter acceptance

Only adapters with application-level acceptance emit `=accepted`:

| Adapter | Emits `=accepted` | Evidence |
| --- | --- | --- |
| `CodexQueue` | Yes | Queue/application acceptance is observed. |
| `ClaudePrint` | Yes | The matching replay user event is observed. |
| `File`, `Ghostty`, `Cmux`, `CodexApp`, `ClaudeDesktop` | No | Transport or delivery submission is not provider acceptance. |

## Issue boundaries

- AMQ half of #682: the injector seam and lifecycle are implemented here; the provider-side `bd36` injector remains required for full cross-repo completion.
- #703: this closes the AMQ taxonomy-honesty and injector-seam portion only. It does not claim full raw-provider bug closure until a provider injector supplies application-level acceptance.

## Wake test change guard

No wake tests were removed or renamed. Existing helper processes now emit the explicit accepted marker required by the new protocol; all new behavioral coverage is additive.

## Verification

- `make ci` completed locally, including vet, lint, full tests, smoke, contract, and hook checks.
- Peer review: Round 2 `GO` from Claude.