### PR TITLE
fix(trace): distinguish absent ledger from missing record

### DIFF
--- a/docs/trace.md
+++ b/docs/trace.md
@@ -33,8 +33,9 @@ The top-level schema is `amq/trace/v1`:
     },
     "notification": {
       "status": "no_evidence",
+      "state": "ledger_absent",
       "evidence": [],
-      "detail": "notification attempt history is unavailable because Phase A has no durable attempt ledger",
+      "detail": "no notification attempt ledger file was found",
       "next_step": "run 'amq doctor --ops' for current wake health; do not infer historical notification success"
     }
   }
@@ -75,7 +76,12 @@ presence.
 
 Notification success is never inferred from wake state, a mailbox file, or a
 delivery receipt. Phase A reports the notification leg as `no_evidence` when
-the journal is absent. When present, schema 2 distinguishes `accepted`
+the journal is absent. Its optional `state` distinguishes `ledger_absent`
+(no journal file), `ledger_present_no_record` (the active or rotated journal
+exists but has no record for this message), and `record_present`. On platforms
+where notification-attempt locking is unsupported, an absent journal is
+reported as `ledger_unsupported` rather than as a missing attempt. When present,
+schema 2 distinguishes `accepted`
 (explicit external-provider dispatch), `deferred`/`retried` (pre-dispatch busy
 with the cohort retained), and terminal `failed`; raw TIOCSTI and legacy
 injectors remain `written` byte evidence only. None of these states proves

--- a/internal/cli/trace.go
+++ b/internal/cli/trace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -15,6 +16,13 @@ import (
 )
 
 const traceSchema = "amq/trace/v1"
+
+const (
+	traceNotificationLedgerAbsent          = "ledger_absent"
+	traceNotificationLedgerPresentNoRecord = "ledger_present_no_record"
+	traceNotificationRecordPresent         = "record_present"
+	traceNotificationLedgerUnsupported     = "ledger_unsupported"
+)
 
 var traceLegOrder = []string{
 	"message",
@@ -37,6 +45,7 @@ type traceResult struct {
 
 type traceLeg struct {
 	Status   string          `json:"status"`
+	State    string          `json:"state,omitempty"`
 	Evidence []traceEvidence `json:"evidence"`
 	Detail   string          `json:"detail,omitempty"`
 	NextStep string          `json:"next_step,omitempty"`
@@ -92,16 +101,17 @@ type traceLocatedHeader struct {
 }
 
 type traceCollector struct {
-	root         string
-	deliveryRoot *fsq.DeliveryRoot
-	messageID    string
-	agents       []string
-	headers      []traceLocatedHeader
-	targets      []traceLocatedHeader
-	legs         map[string]traceLeg
-	legErrors    map[string][]string
-	seenRoutes   map[string]bool
-	seenThread   map[string]bool
+	root                      string
+	deliveryRoot              *fsq.DeliveryRoot
+	messageID                 string
+	agents                    []string
+	headers                   []traceLocatedHeader
+	targets                   []traceLocatedHeader
+	legs                      map[string]traceLeg
+	legErrors                 map[string][]string
+	seenRoutes                map[string]bool
+	seenThread                map[string]bool
+	notificationLedgerPresent bool
 }
 
 func runTrace(args []string) error {
@@ -407,6 +417,13 @@ func (c *traceCollector) scanReceipts() {
 
 func (c *traceCollector) scanNotificationAttempts() {
 	for _, agent := range c.agents {
+		ledgerPresent, err := c.notificationAttemptLedgerPresent(agent)
+		if err != nil {
+			c.addError("notification", fmt.Sprintf("scan agent %s notification attempt ledger: %v", agent, err))
+			continue
+		}
+		c.notificationLedgerPresent = c.notificationLedgerPresent || ledgerPresent
+
 		attempts, err := notificationattempt.ListDeliveryRoot(c.deliveryRoot, agent, c.messageID)
 		if err != nil {
 			c.addError("notification", fmt.Sprintf("scan agent %s notification attempts: %v", agent, err))
@@ -423,6 +440,37 @@ func (c *traceCollector) scanNotificationAttempts() {
 				Limitation:   notificationAttemptLimitation(attempt.State),
 			})
 		}
+	}
+}
+
+// notificationAttemptLedgerPresent checks both the active journal and its one
+// retained rotation. It uses the pinned DeliveryRoot rather than reopening
+// the base path, and filepath.Join keeps the relative path valid on Windows.
+func (c *traceCollector) notificationAttemptLedgerPresent(agent string) (bool, error) {
+	for _, filename := range []string{
+		notificationattempt.LogFilename,
+		notificationattempt.LogFilename + notificationattempt.RotatedSuffix,
+	} {
+		path := filepath.Join("agents", agent, "receipts", filename)
+		if _, err := c.deliveryRoot.Stat(path); err == nil {
+			return true, nil
+		} else if !os.IsNotExist(err) {
+			return false, fmt.Errorf("stat %s: %w", c.relative(path), err)
+		}
+	}
+	return false, nil
+}
+
+func notificationAttemptTraceState(ledgerPresent, recordPresent, supported bool) string {
+	switch {
+	case recordPresent:
+		return traceNotificationRecordPresent
+	case ledgerPresent:
+		return traceNotificationLedgerPresentNoRecord
+	case !supported:
+		return traceNotificationLedgerUnsupported
+	default:
+		return traceNotificationLedgerAbsent
 	}
 }
 
@@ -619,6 +667,7 @@ func (c *traceCollector) finishLegs() {
 				leg.Detail = "current file visibility found; original directory sync durability is no_evidence"
 				leg.NextStep = "inspect retained send output before retrying; do not infer retry safety from current file presence"
 			case "notification":
+				leg.State = traceNotificationRecordPresent
 				// Requirement 3: distinguish "no attempt recorded" from "recording
 				// failed". If any evidence has StateWriteFailed, the prepared write
 				// itself errored (the ledger could not persist the record) but the
@@ -637,6 +686,22 @@ func (c *traceCollector) finishLegs() {
 			leg.Status = "no_evidence"
 			leg.Detail = noEvidence[name].detail
 			leg.NextStep = noEvidence[name].next
+			if name == "notification" {
+				leg.State = notificationAttemptTraceState(
+					c.notificationLedgerPresent,
+					false,
+					notificationattempt.LedgerSupported,
+				)
+				switch leg.State {
+				case traceNotificationLedgerAbsent:
+					leg.Detail = "no notification attempt ledger file was found"
+				case traceNotificationLedgerPresentNoRecord:
+					leg.Detail = "notification attempt ledger exists, but no record for this message was found"
+				case traceNotificationLedgerUnsupported:
+					leg.Detail = fmt.Sprintf("notification attempt ledger is not supported on %s; delivery is not recorded", runtime.GOOS)
+					leg.NextStep = "inspect provider or terminal output; do not infer notification outcome from this trace"
+				}
+			}
 		}
 		c.legs[name] = leg
 	}
@@ -691,6 +756,9 @@ func writeTraceText(result traceResult) error {
 	for _, name := range traceLegOrder {
 		leg := result.Legs[name]
 		line := fmt.Sprintf("  %-12s %s", name, leg.Status)
+		if leg.State != "" {
+			line += " [" + leg.State + "]"
+		}
 		if len(leg.Evidence) > 0 {
 			line += fmt.Sprintf(" (%d)", len(leg.Evidence))
 		}

--- a/internal/cli/trace_test.go
+++ b/internal/cli/trace_test.go
@@ -27,21 +27,41 @@ func TestTraceJoinsWrittenAndIndeterminateNotificationAttempts(t *testing.T) {
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
 		t.Fatal(err)
 	}
-	writer := notificationattempt.NewWriter(root, "codex")
-	written, err := writer.Prepare([]string{"msg-notification"}, "raw")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := writer.Result(written, notificationattempt.OutcomeWritten, "terminal bytes accepted"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := writer.Prepare([]string{"msg-notification"}, "external"); err != nil {
-		t.Fatal(err)
-	}
+	writeTraceNotificationJournal(t, root, "codex",
+		notificationattempt.Record{
+			Schema:     notificationattempt.SchemaVersion,
+			AttemptID:  "attempt-written",
+			Phase:      notificationattempt.PhasePrepared,
+			MessageIDs: []string{"msg-notification"},
+			Agent:      "codex",
+			Mode:       "raw",
+			RecordedAt: "2026-09-01T08:00:00Z",
+		},
+		notificationattempt.Record{
+			Schema:     notificationattempt.SchemaVersion,
+			AttemptID:  "attempt-written",
+			Phase:      notificationattempt.PhaseResult,
+			MessageIDs: []string{"msg-notification"},
+			Agent:      "codex",
+			Mode:       "raw",
+			RecordedAt: "2026-09-01T08:00:01Z",
+			Outcome:    notificationattempt.OutcomeWritten,
+			Detail:     "terminal bytes accepted",
+		},
+		notificationattempt.Record{
+			Schema:     notificationattempt.SchemaVersion,
+			AttemptID:  "attempt-indeterminate",
+			Phase:      notificationattempt.PhasePrepared,
+			MessageIDs: []string{"msg-notification"},
+			Agent:      "codex",
+			Mode:       "external",
+			RecordedAt: "2026-09-01T08:00:02Z",
+		},
+	)
 
 	result := collectTrace(root, "msg-notification")
 	leg := result.Legs["notification"]
-	if leg.Status != "evidence" || len(leg.Evidence) != 2 {
+	if leg.Status != "evidence" || leg.State != traceNotificationRecordPresent || len(leg.Evidence) != 2 {
 		t.Fatalf("notification leg = %+v", leg)
 	}
 	states := map[string]bool{}
@@ -61,7 +81,9 @@ func TestTraceJoinsWrittenAndIndeterminateNotificationAttempts(t *testing.T) {
 
 type traceLegJSON struct {
 	Status   string            `json:"status"`
+	State    string            `json:"state"`
 	Evidence []json.RawMessage `json:"evidence"`
+	Detail   string            `json:"detail"`
 	NextStep string            `json:"next_step"`
 }
 
@@ -153,6 +175,9 @@ func TestTraceCommandEntryPointJoinsCurrentEvidence(t *testing.T) {
 	if notification.Status != "no_evidence" || notification.NextStep == "" {
 		t.Fatalf("notification leg = %#v", notification)
 	}
+	if notification.State != traceNotificationLedgerAbsent || notification.Detail != "no notification attempt ledger file was found" {
+		t.Fatalf("notification absent state = %#v", notification)
+	}
 
 	textOutput, _ := captureOutput(t, func() error {
 		return runTrace([]string{messageID, "--root", root})
@@ -161,6 +186,82 @@ func TestTraceCommandEntryPointJoinsCurrentEvidence(t *testing.T) {
 		if !strings.Contains(textOutput, want) {
 			t.Fatalf("trace text missing %q:\n%s", want, textOutput)
 		}
+	}
+}
+
+func TestTraceNotificationLedgerPresentWithoutMessageUsesPlatformPath(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	writeTraceNotificationJournal(t, root, "bob", notificationattempt.Record{
+		Schema:     notificationattempt.SchemaVersion,
+		AttemptID:  "attempt-other-message",
+		Phase:      notificationattempt.PhasePrepared,
+		MessageIDs: []string{"other-message"},
+		Agent:      "bob",
+		Mode:       "raw",
+		RecordedAt: "2026-09-01T08:10:00Z",
+	})
+
+	result := collectTrace(root, "target-message")
+	leg := result.Legs["notification"]
+	if leg.Status != "no_evidence" || leg.State != traceNotificationLedgerPresentNoRecord {
+		t.Fatalf("notification leg = %#v, want present ledger without target record", leg)
+	}
+	if leg.Detail != "notification attempt ledger exists, but no record for this message was found" {
+		t.Fatalf("notification detail = %q", leg.Detail)
+	}
+
+	textOutput, _ := captureOutput(t, func() error {
+		return runTrace([]string{"target-message", "--root", root})
+	})
+	if !strings.Contains(textOutput, "notification no_evidence [ledger_present_no_record]") {
+		t.Fatalf("trace text did not expose ledger state:\n%s", textOutput)
+	}
+}
+
+func TestTraceNotificationLedgerPresenceIncludesRotatedJournal(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	writeTraceNotificationJournalNamed(t, root, "bob", notificationattempt.LogFilename+notificationattempt.RotatedSuffix, notificationattempt.Record{
+		Schema:     notificationattempt.SchemaVersion,
+		AttemptID:  "attempt-rotated-other-message",
+		Phase:      notificationattempt.PhasePrepared,
+		MessageIDs: []string{"other-message"},
+		Agent:      "bob",
+		Mode:       "raw",
+		RecordedAt: "2026-09-01T08:20:00Z",
+	})
+
+	leg := collectTrace(root, "target-message").Legs["notification"]
+	if leg.State != traceNotificationLedgerPresentNoRecord {
+		t.Fatalf("notification state = %q, want rotated ledger present/no record", leg.State)
+	}
+}
+
+func TestNotificationAttemptTraceStatePrecedence(t *testing.T) {
+	tests := []struct {
+		name          string
+		ledgerPresent bool
+		recordPresent bool
+		supported     bool
+		want          string
+	}{
+		{name: "absent", want: traceNotificationLedgerAbsent, supported: true},
+		{name: "present without record", ledgerPresent: true, want: traceNotificationLedgerPresentNoRecord, supported: true},
+		{name: "record present", ledgerPresent: true, recordPresent: true, want: traceNotificationRecordPresent, supported: true},
+		{name: "unsupported without journal", want: traceNotificationLedgerUnsupported},
+		{name: "unsupported with existing journal", ledgerPresent: true, want: traceNotificationLedgerPresentNoRecord},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := notificationAttemptTraceState(tt.ledgerPresent, tt.recordPresent, tt.supported); got != tt.want {
+				t.Fatalf("notificationAttemptTraceState(%v, %v, %v) = %q, want %q", tt.ledgerPresent, tt.recordPresent, tt.supported, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -381,4 +482,31 @@ func decodeTraceEvidence(t *testing.T, raw json.RawMessage) map[string]any {
 		t.Fatalf("unmarshal trace evidence: %v\nraw: %s", err, raw)
 	}
 	return evidence
+}
+
+func writeTraceNotificationJournal(t testing.TB, root, agent string, records ...notificationattempt.Record) {
+	t.Helper()
+	writeTraceNotificationJournalNamed(t, root, agent, notificationattempt.LogFilename, records...)
+}
+
+func writeTraceNotificationJournalNamed(t testing.TB, root, agent, filename string, records ...notificationattempt.Record) {
+	t.Helper()
+	var data []byte
+	for _, record := range records {
+		line, err := json.Marshal(record)
+		if err != nil {
+			t.Fatalf("marshal notification attempt record: %v", err)
+		}
+		data = append(data, line...)
+		data = append(data, '\n')
+	}
+	deliveryRoot := openDeliveryRootForCLITest(t, root)
+	if _, err := deliveryRoot.WriteFileAtomic(
+		filepath.Join("agents", agent, "receipts"),
+		filename,
+		data,
+		0o600,
+	); err != nil {
+		t.Fatalf("write notification attempt journal: %v", err)
+	}
 }

--- a/internal/notificationattempt/flock_other.go
+++ b/internal/notificationattempt/flock_other.go
@@ -7,6 +7,10 @@ import (
 	"os"
 )
 
+// LedgerSupported reports whether this platform provides the flock primitive
+// required to coordinate journal rotation.
+const LedgerSupported = false
+
 // errLockingUnsupported is returned by the no-op fallbacks on platforms
 // without syscall.Flock. The ledger still compiles and runs; the rotation
 // race is not closed there, but those platforms (e.g. wasm/plan9) are not

--- a/internal/notificationattempt/flock_unix.go
+++ b/internal/notificationattempt/flock_unix.go
@@ -7,6 +7,10 @@ import (
 	"syscall"
 )
 
+// LedgerSupported reports whether this platform provides the flock primitive
+// required to coordinate journal rotation.
+const LedgerSupported = true
+
 // flockShared takes a shared advisory lock on the open lock file, blocking
 // until it is available. Shared locks do not contend with each other, so
 // concurrent appenders stay concurrent — the O_APPEND hot path keeps its

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -85,7 +85,8 @@ const (
 	StateInvalid  = "invalid"
 
 	LogFilename   = "notification-attempts.jsonl"
-	rotatedSuffix = ".1"
+	RotatedSuffix = ".1"
+	rotatedSuffix = RotatedSuffix
 
 	defaultMaxBytes = 256 * 1024
 )


### PR DESCRIPTION
## Summary
- distinguish an absent notification ledger from a present ledger with no record for the traced message
- expose an explicit unsupported-platform state for notification-attempt locking
- derive support and rotation facts from the notificationattempt package and cover current/rotated journals

## Verification
- `go test ./internal/cli -run '^(TestTrace|TestNotificationAttemptTraceState)' -count=1`\n- `GOOS=windows GOARCH=amd64 go test -c ./internal/cli -o /tmp/amq-701-trace-windows.test.exe`\n- `go vet ./internal/cli`\n- `make fmt-check`\n- `PATH=/tmp/amq-golangci-2.13.1:$PATH make ci`\n\nFixes #701