### PR TITLE
fix(wake): close release-gate injector and ledger findings

### DIFF
--- a/docs/wake-doorbell-acknowledgement.md
+++ b/docs/wake-doorbell-acknowledgement.md
@@ -30,8 +30,11 @@ turns; standalone AMQ keeps the second fact as its safer default.
 
 - `drained` is the default and preserves the existing retry ladder.
 - `injected` requires `--inject-via`. Only exit zero with the exact stderr line
-  `AMQ_INJECT_PROGRESS=accepted` acknowledges the current physical inbox
-  cohort and suppresses further input retries for that unchanged cohort.
+  `AMQ_INJECT_PROGRESS=accepted` acknowledges provider dispatch for the current
+  physical inbox cohort and suppresses further input retries for that unchanged
+  cohort. A marker-less exit-zero command remains a legacy transport success:
+  its ledger state is `written`, not provider `accepted`, but compatibility
+  transitions the current cohort to `announced` under `--retry-until injected`.
 - `AMQ_INJECT_PROGRESS=deferred` with a nonzero exit means the provider was
   busy or transitioning before dispatch. AMQ MUST retain the cohort, emit no
   terminal or attention fallback, and retry through the existing wake loop.

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -70,7 +70,9 @@ type wakeConfig struct {
 	skipExternalInjector          bool
 	terminalInjectorCohort        []string
 	terminalInjectorMode          string
+	terminalInjectorPhysical      map[string]*wakeFileIdentity
 	notificationAttempt           *notificationattempt.Lifecycle
+	notificationAttemptPhysical   map[string]*wakeFileIdentity
 	onBaselineReady               func(map[string]wakeFileIdentity) error
 	onPrepared                    func(wakeAdmissionWatcher) error
 	retainedAgent                 wakeRetainedAgent
@@ -584,15 +586,31 @@ func notifyNewMessages(cfg *wakeConfig) error {
 					return guardErr
 				}
 				if allowed {
-					// Exit zero is the strongest acceptance evidence the v0
-					// external transport exposes. It cannot prove the provider
-					// delivered the key, but advancing the cooldown bounds
-					// duplicate control-key injection. A false-success provider
-					// may therefore suppress one genuine interrupt until the
-					// next window; stronger evidence needs a structured protocol.
-					if err := injectVia(cfg, cfg.interruptKey); err == nil {
+					err := injectVia(cfg, cfg.interruptKey)
+					cfg.lastInjectorOutcome = classifyWakeInjectorOutcome(err)
+					if err != nil {
+						cfg.lastInjectorDetail = err.Error()
+					}
+					switch cfg.lastInjectorOutcome {
+					case wakeInjectorOutcomeAccepted, wakeInjectorOutcomeLegacy:
+						// A legacy zero exit is transport success for compatibility;
+						// only the accepted marker claims provider acceptance.
 						cfg.lastInterrupt = now
 						time.Sleep(50 * time.Millisecond)
+					case wakeInjectorOutcomeDeferred:
+						// Provider-side busy/transition is replayable, but must not
+						// fall back to a second notification in this scan.
+						return err
+					case wakeInjectorOutcomeUncertain:
+						// The key may have landed. Hold the exact completion debt
+						// and use recovery attention; never replay it.
+						cfg.inputDelivery.acceptanceUncertain = true
+						cfg.fallbackWarn = false
+						return enterWakeInputRecovery(
+							cfg,
+							currentPending,
+							&wakeInputDemotionBlockedError{err: err},
+						)
 					}
 				}
 			} else {
@@ -664,7 +682,7 @@ func deliverWithNotificationLedger(
 		// orphaned prepared record while the exact terminal-input debt is held.
 		return deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
 	}
-	if terminalInjectorForCohort(cfg, messageIDs) {
+	if terminalInjectorForCohort(cfg, messageIDs, currentPending) {
 		// A provider failure is terminal for the injector, but the existing
 		// attention cadence may still remind the operator. Suppress only the
 		// provider replay for this unchanged cohort; a new message cohort clears
@@ -715,13 +733,14 @@ func deliverWithNotificationLedger(
 		if lifecycle != nil || prepareErr != nil {
 			return
 		}
-		lifecycle, prepareErr = ensureNotificationAttempt(cfg, writer, messageIDs)
+		lifecycle, prepareErr = ensureNotificationAttempt(cfg, writer, messageIDs, currentPending)
 	}
 	defer func() { cfg.onNotificationAttemptStart = previousAttemptStart }()
 	deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
 	if isTerminalInjectorOutcome(cfg.lastInjectorOutcome) {
 		cfg.terminalInjectorCohort = append([]string{}, messageIDs...)
 		cfg.terminalInjectorMode = notificationAttemptMode(cfg)
+		cfg.terminalInjectorPhysical = snapshotWakeFileIdentities(currentPending)
 	}
 	if prepareErr != nil {
 		if cfg.debug {
@@ -759,6 +778,7 @@ func deliverWithNotificationLedger(
 			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist legacy notification result: %v\n", err)
 		}
 		cfg.notificationAttempt = nil
+		cfg.notificationAttemptPhysical = nil
 		return deliverErr
 	}
 	if err := writer.Transition(lifecycle, state, detail); err != nil && cfg.debug {
@@ -766,6 +786,7 @@ func deliverWithNotificationLedger(
 	}
 	if state != notificationattempt.StateDeferred {
 		cfg.notificationAttempt = nil
+		cfg.notificationAttemptPhysical = nil
 	}
 	return deliverErr
 }
@@ -774,12 +795,14 @@ func ensureNotificationAttempt(
 	cfg *wakeConfig,
 	writer *notificationattempt.Writer,
 	messageIDs []string,
+	currentPending map[string]os.FileInfo,
 ) (*notificationattempt.Lifecycle, error) {
 	mode := notificationAttemptMode(cfg)
 	if cfg.notificationAttempt != nil &&
 		cfg.notificationAttempt.Agent == cfg.me &&
 		cfg.notificationAttempt.Mode == mode &&
 		sameWakeMessageIDs(cfg.notificationAttempt.MessageIDs, messageIDs) &&
+		sameKnownWakeCohort(cfg.notificationAttemptPhysical, currentPending) &&
 		cfg.notificationAttempt.State != notificationattempt.StateAccepted &&
 		cfg.notificationAttempt.State != notificationattempt.StateFailed {
 		return cfg.notificationAttempt, nil
@@ -789,19 +812,43 @@ func ensureNotificationAttempt(
 		return nil, err
 	}
 	cfg.notificationAttempt = lifecycle
+	cfg.notificationAttemptPhysical = snapshotWakeFileIdentities(currentPending)
 	return lifecycle, nil
 }
 
-func terminalInjectorForCohort(cfg *wakeConfig, messageIDs []string) bool {
+func terminalInjectorForCohort(
+	cfg *wakeConfig,
+	messageIDs []string,
+	currentPending map[string]os.FileInfo,
+) bool {
 	return cfg != nil &&
 		cfg.injectVia != "" &&
 		len(cfg.terminalInjectorCohort) > 0 &&
 		cfg.terminalInjectorMode == notificationAttemptMode(cfg) &&
-		sameWakeMessageIDs(cfg.terminalInjectorCohort, messageIDs)
+		sameWakeMessageIDs(cfg.terminalInjectorCohort, messageIDs) &&
+		sameKnownWakeCohort(cfg.terminalInjectorPhysical, currentPending)
 }
 
 func isTerminalInjectorOutcome(outcome wakeInjectorOutcome) bool {
 	return outcome == wakeInjectorOutcomeFailed || outcome == wakeInjectorOutcomeUncertain
+}
+
+func classifyWakeInjectorOutcome(err error) wakeInjectorOutcome {
+	if err == nil {
+		return wakeInjectorOutcomeAccepted
+	}
+	// Legacy wraps the same terminal-progress detail as uncertain. Check it
+	// first so marker-less exit zero keeps its compatibility meaning.
+	if isWakeInjectorLegacy(err) {
+		return wakeInjectorOutcomeLegacy
+	}
+	if isWakeInjectorDeferred(err) {
+		return wakeInjectorOutcomeDeferred
+	}
+	if isWakeTerminalProgressUncertain(err) {
+		return wakeInjectorOutcomeUncertain
+	}
+	return wakeInjectorOutcomeFailed
 }
 
 func sameWakeMessageIDs(left, right []string) bool {
@@ -1446,20 +1493,22 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		}
 		if err := injectVia(cfg, plainText); err != nil {
 			cfg.lastInjectorDetail = err.Error()
-			if isWakeInjectorDeferred(err) {
+			switch classifyWakeInjectorOutcome(err) {
+			case wakeInjectorOutcomeDeferred:
 				cfg.lastInjectorOutcome = wakeInjectorOutcomeDeferred
 				return err
-			}
-			if isWakeInjectorLegacy(err) {
+			case wakeInjectorOutcomeLegacy:
 				cfg.lastInjectorOutcome = wakeInjectorOutcomeLegacy
 				// Preserve the v1 external-injector contract: a marker-less
 				// exit-zero command is a successful transport result. The
 				// lifecycle ledger records it as written/uncertain, while the
 				// wake loop keeps its existing retry-until policy.
 				return nil
-			}
-			var uncertain *wakeTerminalProgressUncertainError
-			if errors.As(err, &uncertain) {
+			case wakeInjectorOutcomeUncertain:
+				var uncertain *wakeTerminalProgressUncertainError
+				if !errors.As(err, &uncertain) {
+					uncertain = &wakeTerminalProgressUncertainError{err: err}
+				}
 				if cfg.lastInjectorOutcome == wakeInjectorOutcomeNone {
 					cfg.lastInjectorOutcome = wakeInjectorOutcomeUncertain
 				}
@@ -1467,8 +1516,9 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 				_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
 				cfg.fallbackWarn = false
 				return &wakeInputDemotionBlockedError{err: uncertain}
+			default:
+				cfg.lastInjectorOutcome = wakeInjectorOutcomeFailed
 			}
-			cfg.lastInjectorOutcome = wakeInjectorOutcomeFailed
 			if cfg.fallbackWarn {
 				_ = writeWakeDiagnostic(cfg, "amq wake: --inject-via failed: %v\n", err)
 				_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")

--- a/internal/cli/wake_injector_status.go
+++ b/internal/cli/wake_injector_status.go
@@ -21,35 +21,38 @@ const (
 	wakeInjectorProgressUncertain wakeInjectorProgress = "uncertain"
 )
 
-// parseWakeInjectorProgress accepts only complete marker lines. Uncertain has
+// parseWakeInjectorProgress accepts only exact complete marker lines. A single
+// trailing carriage return is allowed for CRLF output. Uncertain has
 // precedence over every other marker so a contradictory provider response can
 // never be treated as a successful or replayable delivery.
 func parseWakeInjectorProgress(stderr string) wakeInjectorProgress {
-	if strings.Contains(stderr, wakeInjectorProgressPrefix+string(wakeInjectorProgressUncertain)) {
-		return wakeInjectorProgressUncertain
-	}
-	var progress wakeInjectorProgress
 	accepted := false
 	deferred := false
+	uncertain := false
 	for _, rawLine := range strings.Split(stderr, "\n") {
-		line := strings.TrimSpace(rawLine)
-		if !strings.HasPrefix(line, wakeInjectorProgressPrefix) {
-			continue
-		}
-		candidate := wakeInjectorProgress(strings.TrimSpace(strings.TrimPrefix(line, wakeInjectorProgressPrefix)))
-		switch candidate {
-		case wakeInjectorProgressDeferred:
+		line := strings.TrimSuffix(rawLine, "\r")
+		switch line {
+		case wakeInjectorProgressPrefix + string(wakeInjectorProgressDeferred):
 			deferred = true
-			progress = candidate
-		case wakeInjectorProgressAccepted:
+		case wakeInjectorProgressPrefix + string(wakeInjectorProgressAccepted):
 			accepted = true
-			progress = candidate
+		case wakeInjectorProgressPrefix + string(wakeInjectorProgressUncertain):
+			uncertain = true
 		}
+	}
+	if uncertain {
+		return wakeInjectorProgressUncertain
 	}
 	if accepted && deferred {
 		return wakeInjectorProgressUncertain
 	}
-	return progress
+	if deferred {
+		return wakeInjectorProgressDeferred
+	}
+	if accepted {
+		return wakeInjectorProgressAccepted
+	}
+	return ""
 }
 
 type wakeInjectorDeferredError struct {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -134,6 +134,33 @@ func TestBuildInterruptText_CustomOverride(t *testing.T) {
 	}
 }
 
+func TestParseWakeInjectorProgressRequiresExactMarkerLines(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   wakeInjectorProgress
+	}{
+		{name: "accepted", stderr: "AMQ_INJECT_PROGRESS=accepted\n", want: wakeInjectorProgressAccepted},
+		{name: "deferred", stderr: "AMQ_INJECT_PROGRESS=deferred\n", want: wakeInjectorProgressDeferred},
+		{name: "uncertain", stderr: "AMQ_INJECT_PROGRESS=uncertain\n", want: wakeInjectorProgressUncertain},
+		{name: "crlf", stderr: "AMQ_INJECT_PROGRESS=accepted\r\n", want: wakeInjectorProgressAccepted},
+		{name: "leading space", stderr: " AMQ_INJECT_PROGRESS=uncertain\n", want: ""},
+		{name: "trailing space", stderr: "AMQ_INJECT_PROGRESS=accepted \n", want: ""},
+		{name: "quoted marker", stderr: "diagnostic: AMQ_INJECT_PROGRESS=uncertain\n", want: ""},
+		{name: "marker suffix", stderr: "AMQ_INJECT_PROGRESS=accepted: provider\n", want: ""},
+		{name: "embedded marker", stderr: "prefix AMQ_INJECT_PROGRESS=deferred suffix\n", want: ""},
+		{name: "uncertain precedence", stderr: "AMQ_INJECT_PROGRESS=accepted\nAMQ_INJECT_PROGRESS=uncertain\n", want: wakeInjectorProgressUncertain},
+		{name: "quoted uncertain ignored", stderr: "AMQ_INJECT_PROGRESS=accepted\nquoted AMQ_INJECT_PROGRESS=uncertain\n", want: wakeInjectorProgressAccepted},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseWakeInjectorProgress(test.stderr); got != test.want {
+				t.Fatalf("parseWakeInjectorProgress(%q) = %q, want %q", test.stderr, got, test.want)
+			}
+		})
+	}
+}
+
 func TestBuildNotificationTextRestoresPeerHeadersForOutput(t *testing.T) {
 	text := buildNotificationText(
 		"collab",
@@ -203,6 +230,7 @@ func TestNotificationPrefix(t *testing.T) {
 }
 
 const injectViaHelperEnv = "AMQ_TEST_INJECT_VIA_HELPER"
+const injectViaProgressEnv = "AMQ_TEST_INJECT_VIA_PROGRESS"
 
 func injectViaCaptureConfig(t *testing.T, fixedArgs ...string) (*wakeConfig, string) {
 	t.Helper()
@@ -246,11 +274,27 @@ func TestInjectViaHelperProcess(t *testing.T) {
 	}
 	outputPath := os.Args[separator+1]
 	payload := strings.Join(os.Args[separator+2:], "\n")
+	switch os.Getenv(injectViaProgressEnv) {
+	case "timeout":
+		time.Sleep(2 * time.Second)
+	}
 	if err := os.WriteFile(outputPath, []byte(payload), 0o600); err != nil {
 		_, _ = os.Stderr.WriteString("write inject-via helper output: " + err.Error() + "\n")
 		os.Exit(3)
 	}
-	_, _ = os.Stderr.WriteString("AMQ_INJECT_PROGRESS=accepted\n")
+	switch os.Getenv(injectViaProgressEnv) {
+	case "legacy", "":
+		if os.Getenv(injectViaProgressEnv) == "legacy" {
+			os.Exit(0)
+		}
+		_, _ = os.Stderr.WriteString("AMQ_INJECT_PROGRESS=accepted\n")
+	case "deferred":
+		_, _ = os.Stderr.WriteString("AMQ_INJECT_PROGRESS=deferred\n")
+		os.Exit(1)
+	case "uncertain":
+		_, _ = os.Stderr.WriteString("AMQ_INJECT_PROGRESS=uncertain\n")
+		os.Exit(1)
+	}
 	os.Exit(0)
 }
 
@@ -1762,6 +1806,83 @@ func TestNotifyNewMessages_InjectViaExitZeroAdvancesInterruptCooldown(t *testing
 	}
 	if string(got) != expected {
 		t.Fatalf("expected inject-via log %q, got %q", expected, string(got))
+	}
+}
+
+func TestNotifyNewMessagesInjectViaInterruptClassifiesEveryOutcome(t *testing.T) {
+	tests := []struct {
+		name          string
+		progress      string
+		injectTimeout time.Duration
+		wantOutcome   wakeInjectorOutcome
+		wantErr       bool
+		wantRecovery  bool
+		wantCooldown  bool
+	}{
+		{name: "accepted", progress: "", wantOutcome: wakeInjectorOutcomeAccepted, wantCooldown: true},
+		{name: "legacy zero exit", progress: "legacy", wantOutcome: wakeInjectorOutcomeLegacy, wantCooldown: true},
+		{name: "deferred", progress: "deferred", wantOutcome: wakeInjectorOutcomeDeferred, wantErr: true},
+		{name: "uncertain", progress: "uncertain", wantOutcome: wakeInjectorOutcomeUncertain, wantRecovery: true},
+		{name: "timeout", progress: "timeout", injectTimeout: 20 * time.Millisecond, wantOutcome: wakeInjectorOutcomeFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(injectViaProgressEnv, test.progress)
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+			message := format.Message{Header: format.Header{
+				Schema: 1, ID: "interrupt-" + test.name, From: "codex", To: []string{"alice"},
+				Thread: "p2p/alice__codex", Subject: "urgent", Created: "2026-09-01T10:00:00Z",
+				Priority: "urgent", Labels: []string{"interrupt"},
+			}}
+			data, err := message.Marshal()
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if _, err := deliverToInboxForTest(t, root, "alice", "interrupt.md", data); err != nil {
+				t.Fatalf("deliver: %v", err)
+			}
+
+			cfg, _ := injectViaCaptureConfig(t)
+			cfg.me = "alice"
+			cfg.root = root
+			cfg.session = "session1"
+			cfg.injectMode = wakeInjectModeRaw
+			cfg.injectTimeout = test.injectTimeout
+			cfg.interrupt = true
+			cfg.interruptKey = "\x03"
+			cfg.interruptLabel = "interrupt"
+			cfg.interruptPriority = "urgent"
+			cfg.interruptCooldown = time.Minute
+			cfg.attentionIsTTY = func() bool { return false }
+			cfg.attentionWrite = func(data []byte) (int, error) { return len(data), nil }
+
+			deliveryErr := notifyNewMessages(cfg)
+			if test.wantErr {
+				if deliveryErr == nil || !isWakeInjectorDeferred(deliveryErr) {
+					t.Fatalf("notify error = %v, want deferred injector error", deliveryErr)
+				}
+			} else if deliveryErr != nil {
+				t.Fatalf("notify error = %v", deliveryErr)
+			}
+			if cfg.lastInjectorOutcome != test.wantOutcome {
+				t.Fatalf("last injector outcome = %v, want %v", cfg.lastInjectorOutcome, test.wantOutcome)
+			}
+			if got := !cfg.lastInterrupt.IsZero(); got != test.wantCooldown {
+				t.Fatalf("interrupt cooldown recorded = %t, want %t", got, test.wantCooldown)
+			}
+			if cfg.inputRecoveryRequired != test.wantRecovery {
+				t.Fatalf("input recovery required = %t, want %t", cfg.inputRecoveryRequired, test.wantRecovery)
+			}
+			if test.wantRecovery && !cfg.inputDelivery.acceptanceUncertain {
+				t.Fatal("uncertain interrupt did not retain acceptance uncertainty")
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -6226,6 +6226,157 @@ exit 1
 	}
 }
 
+func TestTerminalInjectorLatchDoesNotSuppressPhysicalReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	countPath := filepath.Join(secureTempDirForTest(t), "inject-count")
+	injector := writeExecutableScriptForTest(t, "fail-then-accept", fmt.Sprintf(`#!/bin/sh
+count=0
+if [ -f %q ]; then count=$(cat %q); fi
+count=$((count + 1))
+printf '%%s' "$count" > %q
+if [ "$count" -eq 1 ]; then
+  echo ordinary failure >&2
+  exit 1
+fi
+echo AMQ_INJECT_PROGRESS=accepted >&2
+exit 0
+`, countPath, countPath, countPath))
+	writeMessage := func(filename, id string) {
+		t.Helper()
+		message := format.Message{Header: format.Header{
+			Schema: 1, ID: id, From: "peer", To: []string{"codex"},
+			Thread: "p2p/peer__codex", Subject: id,
+			Created: "2026-09-01T09:00:00Z",
+		}}
+		data, err := message.Marshal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeMessage("same-name.md", "same-id")
+	cfg := protocolWakeConfigForTest(t, root, injector, nil)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first notify: %v", err)
+	}
+
+	path := filepath.Join(fsq.AgentInboxNew(root, "codex"), "same-name.md")
+	replacement := path + ".replacement"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read original message: %v", err)
+	}
+	if err := os.WriteFile(replacement, data, 0o600); err != nil {
+		t.Fatalf("write replacement message: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove original message: %v", err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("rename replacement message: %v", err)
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("replacement notify: %v", err)
+	}
+	count, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read injector count: %v", err)
+	}
+	if got := strings.TrimSpace(string(count)); got != "2" {
+		t.Fatalf("injector calls after physical replacement = %q, want 2", got)
+	}
+}
+
+func TestTerminalInjectorLatchDoesNotSuppressShrunkCohort(t *testing.T) {
+	current := wakeDoorbellTestFiles(t, "first.md", "second.md")
+	cfg := &wakeConfig{
+		injectVia:                "/injector",
+		terminalInjectorCohort:   []string{"first", "second"},
+		terminalInjectorMode:     "external",
+		terminalInjectorPhysical: snapshotWakeFileIdentities(current),
+	}
+	if terminalInjectorForCohort(cfg, []string{"second"}, current) {
+		t.Fatal("terminal injector latch suppressed a shrunk cohort")
+	}
+}
+
+func TestDeferredNotificationAttemptDoesNotReusePhysicalReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	mailbox := t.TempDir()
+	path := filepath.Join(mailbox, "pending.md")
+	if err := os.WriteFile(path, []byte("first"), 0o600); err != nil {
+		t.Fatalf("write original pending file: %v", err)
+	}
+	originalInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat original pending file: %v", err)
+	}
+	current := map[string]os.FileInfo{"pending.md": originalInfo}
+
+	cfg := &wakeConfig{
+		me:         "codex",
+		root:       root,
+		injectVia:  "/injector",
+		injectMode: wakeInjectModePaste,
+	}
+	writer := notificationattempt.NewWriter(root, "codex")
+	lifecycle, err := writer.Begin([]string{"same-message"}, notificationAttemptMode(cfg))
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	cfg.notificationAttempt = lifecycle
+	cfg.notificationAttemptPhysical = snapshotWakeFileIdentities(current)
+
+	reused, err := ensureNotificationAttempt(cfg, writer, []string{"same-message"}, current)
+	if err != nil {
+		t.Fatalf("reuse current lifecycle: %v", err)
+	}
+	if reused != lifecycle {
+		t.Fatal("unchanged physical cohort did not reuse deferred lifecycle")
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove original pending file: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("write replacement pending file: %v", err)
+	}
+	replacementInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replacement pending file: %v", err)
+	}
+	replacement := map[string]os.FileInfo{"pending.md": replacementInfo}
+	if sameKnownWakeCohort(cfg.notificationAttemptPhysical, replacement) {
+		t.Fatal("physical replacement retained the old cohort identity")
+	}
+
+	fresh, err := ensureNotificationAttempt(cfg, writer, []string{"same-message"}, replacement)
+	if err != nil {
+		t.Fatalf("begin replacement lifecycle: %v", err)
+	}
+	if fresh == lifecycle || fresh.AttemptID == lifecycle.AttemptID {
+		t.Fatalf("replacement reused deferred attempt ID: old=%q new=%q", lifecycle.AttemptID, fresh.AttemptID)
+	}
+}
+
 func TestInjectViaDeferredRetainsCohortWithoutAttentionOrAcceptance(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -120,10 +120,28 @@ func (a App) Run(ctx context.Context, args []string) int {
 		return 2
 	}
 	if err != nil {
-		_, _ = fmt.Fprintln(a.Stderr, err)
+		writeCommandError(a.Stderr, err)
 		return 1
 	}
 	return 0
+}
+
+func writeCommandError(w io.Writer, err error) {
+	if !errors.Is(err, adapter.ErrInjectUncertain) {
+		_, _ = fmt.Fprintln(w, err)
+		return
+	}
+
+	// Keep the machine-readable marker on its own line. The wrapped error is
+	// still useful to an operator, but its diagnostics must not look like a
+	// second progress marker to a strict line parser.
+	marker := adapter.ErrInjectUncertain.Error()
+	_, _ = fmt.Fprintln(w, marker)
+	detail := strings.TrimSpace(strings.ReplaceAll(err.Error(), marker, ""))
+	detail = strings.TrimLeft(detail, ": ")
+	if detail != "" {
+		_, _ = fmt.Fprintln(w, detail)
+	}
 }
 
 type registerOptions struct {

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -871,6 +871,14 @@ type acceptedInjectProgressAdapter struct {
 
 func (acceptedInjectProgressAdapter) ReportsProviderAcceptance() {}
 
+type uncertainInjectProgressAdapter struct {
+	injectProgressAdapter
+}
+
+func (uncertainInjectProgressAdapter) Inject(context.Context, string, string) error {
+	return fmt.Errorf("submit failed: %w: %s", adapter.ErrInjectUncertain, adapter.ErrInjectUncertain)
+}
+
 func TestInjectReportsProviderAcceptanceOnlyForOptInAdapters(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -905,6 +913,30 @@ func TestInjectReportsProviderAcceptanceOnlyForOptInAdapters(t *testing.T) {
 				t.Fatalf("accepted marker = %t, want %t; stderr = %q", gotMarker, test.wantMarker, stderr.String())
 			}
 		})
+	}
+}
+
+func TestInjectUncertainPrintsStandaloneMarkerAndSeparateDiagnostics(t *testing.T) {
+	selected := uncertainInjectProgressAdapter{
+		injectProgressAdapter: injectProgressAdapter{name: "uncertain"},
+	}
+	adapters := adapter.NewRegistry(selected)
+	var stderr bytes.Buffer
+	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr, Adapters: &adapters}).Run(
+		context.Background(),
+		[]string{"inject", selected.Name(), "target", "payload"},
+	)
+	if code != 1 {
+		t.Fatalf("inject code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stderr.String(), "\n"), "\n")
+	if len(lines) < 2 || lines[0] != adapter.ErrInjectUncertain.Error() {
+		t.Fatalf("stderr = %q, want standalone uncertainty marker followed by diagnostics", stderr.String())
+	}
+	for _, line := range lines[1:] {
+		if strings.Contains(line, adapter.ErrInjectUncertain.Error()) {
+			t.Fatalf("diagnostic line %q repeats the machine-readable marker", line)
+		}
 	}
 }
 

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -15,7 +15,8 @@
 //     concurrency (two notifications both read current, both append, one
 //     record vanishes silently). O_APPEND gives kernel-level atomic appends
 //     on local filesystems: concurrent writers each append a full line and
-//     neither loses data. There is no read-modify-write and no lock.
+//     neither loses data. A stable sidecar lock gates rotation and readers;
+//     shared append locks do not serialize ordinary writers.
 //
 //  2. ONE log, not two. The prototype used separate prepared/result files
 //     rotated independently; whichever crossed the size cap first dropped its
@@ -36,6 +37,7 @@ package notificationattempt
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -87,6 +89,7 @@ const (
 	LogFilename   = "notification-attempts.jsonl"
 	RotatedSuffix = ".1"
 	rotatedSuffix = RotatedSuffix
+	lockFilename  = LogFilename + ".lock"
 
 	defaultMaxBytes = 256 * 1024
 )
@@ -133,8 +136,8 @@ type Lifecycle struct {
 
 // Writer appends prepared/result records to the per-agent notification log.
 // Each append opens the file with O_APPEND (kernel-level atomic append on
-// local filesystems), writes one JSON line, and closes. There is no
-// read-modify-write and no lock — concurrent writers do not lose data.
+// local filesystems), writes one JSON line, and closes. A stable sidecar lock
+// gates rotation and readers without serializing ordinary appenders.
 type Writer struct {
 	root     string
 	agent    string
@@ -277,11 +280,12 @@ func (w *Writer) Result(prepared Record, outcome, detail string) error {
 }
 
 // append writes one JSON line to the log with O_APPEND. On local filesystems
-// O_APPEND writes are atomic w.r.t. other O_APPEND writers, so concurrent
-// notifications neither lose data nor need a lock. If the file would exceed
-// maxBytes, the current file is moved to .1 (rotation) and a fresh file
-// starts. Rotation is best-effort: if the rename fails, the append proceeds
-// (an over-size audit log is better than a lost record).
+// O_APPEND writes are atomic w.r.t. other O_APPEND writers. If the file would
+// exceed maxBytes, rotation compacts both generations into an atomically
+// replaced .1 file while holding the exclusive sidecar lock, then truncates
+// the current file only after the replacement succeeds. A rotation error is
+// returned after the append so callers see the persistence problem without
+// losing the new record.
 func (w *Writer) append(record Record) error {
 	if w.maxBytes <= 0 {
 		return fmt.Errorf("notification attempt journal size cap must be positive")
@@ -310,7 +314,6 @@ func (w *Writer) append(record Record) error {
 	}
 	dir := filepath.Join("agents", w.agent, "receipts")
 	fullPath := filepath.Join(root.Base(), dir, LogFilename)
-	lockPath := fullPath + ".lock"
 
 	// Coordination model: a separate lock file carries the flock; the data file
 	// stays O_APPEND so the hot-path write remains kernel-atomic at EOF among
@@ -334,7 +337,7 @@ func (w *Writer) append(record Record) error {
 	// data file does not orphan a held lock. (flock is per-inode; had we locked
 	// the data file, a rename-based rotation would detach the lock. We truncate
 	// in place anyway, but the separate lock file is robust to either choice.)
-	lockFile, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	lockFile, err := root.OpenLockFile(dir, lockFilename, 0o600)
 	if err != nil {
 		return fmt.Errorf("open notification attempt journal lock: %w", err)
 	}
@@ -351,6 +354,7 @@ func (w *Writer) append(record Record) error {
 		rotate = info.Size()+int64(len(data)) > w.maxBytes
 	}
 
+	var rotationErr error
 	if rotate {
 		// LOCK_EX serializes rotation against all appenders: it blocks until
 		// every in-flight LOCK_SH appender has finished its write and released,
@@ -367,24 +371,8 @@ func (w *Writer) append(record Record) error {
 			rotate = false
 		}
 		if rotate {
-			rotated := fullPath + rotatedSuffix
-			current, readErr := os.ReadFile(fullPath)
-			if readErr != nil && !os.IsNotExist(readErr) {
-				// Can't read current to merge — shed the over-size log by rename
-				// (better than a lost record); the prior .1 is overwritten. Still
-				// under LOCK_EX so no appender is racing us.
-				_ = os.Rename(fullPath, rotated)
-			} else if readErr == nil {
-				// Merge current into .1 (preserve older generations), then
-				// truncate current in place. We hold LOCK_EX so no appender can
-				// O_APPEND a record between this read and the truncate — the
-				// race that reintroduced silent loss is closed.
-				if existing, eerr := os.ReadFile(rotated); eerr == nil {
-					_ = os.WriteFile(rotated, append(existing, current...), 0o600)
-				} else {
-					_ = os.WriteFile(rotated, current, 0o600)
-				}
-				_ = os.Truncate(fullPath, 0)
+			if err := w.rotateJournal(root, dir, fullPath); err != nil {
+				rotationErr = fmt.Errorf("rotate notification attempt journal: %w", err)
 			}
 		}
 		// Downgrade LOCK_EX -> LOCK_SH for the append. A flock conversion is
@@ -420,13 +408,42 @@ func (w *Writer) append(record Record) error {
 	// atomically, no lost-update race (requirement 1, preserved).
 	f, err := os.OpenFile(fullPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
-		return fmt.Errorf("open notification attempt journal: %w", err)
+		return errors.Join(rotationErr, fmt.Errorf("open notification attempt journal: %w", err))
 	}
 	defer func() { _ = f.Close() }()
 	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("write notification attempt record: %w", err)
+		return errors.Join(rotationErr, fmt.Errorf("write notification attempt record: %w", err))
 	}
-	return nil
+	return rotationErr
+}
+
+func (w *Writer) rotateJournal(root *fsq.DeliveryRoot, dir, fullPath string) error {
+	records, err := readRecordsUnlocked(root, w.agent)
+	if err != nil {
+		return err
+	}
+	records = deduplicateRecords(records)
+	archive, err := compactRecords(records, w.agent, w.maxBytes)
+	if err != nil {
+		return err
+	}
+	if _, err := root.WriteFileAtomic(dir, LogFilename+rotatedSuffix, archive, 0o600); err != nil {
+		return err
+	}
+
+	current, err := os.OpenFile(fullPath, os.O_WRONLY, 0o600)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open current journal for truncation: %w", err)
+	}
+	truncateErr := current.Truncate(0)
+	if truncateErr == nil {
+		truncateErr = current.Sync()
+	}
+	closeErr := current.Close()
+	return errors.Join(truncateErr, closeErr)
 }
 
 // List reads the notification log for an agent and returns the joined
@@ -502,10 +519,14 @@ func ListDeliveryRoot(root *fsq.DeliveryRoot, agent, messageID string) ([]Attemp
 }
 
 func foldLifecycle(prepared Record, events []Record, legacyResult *Record) Attempt {
+	orderedEvents := append([]Record{}, events...)
+	sort.SliceStable(orderedEvents, func(i, j int) bool {
+		return orderedEvents[i].Sequence < orderedEvents[j].Sequence
+	})
 	attempt := Attempt{
 		State:    StateInvalid,
 		Prepared: prepared,
-		History:  append([]Record{prepared}, events...),
+		History:  append([]Record{prepared}, orderedEvents...),
 	}
 	if prepared.State != StateAttempt || prepared.Sequence != 0 || prepared.Outcome != "" {
 		return attempt
@@ -528,12 +549,12 @@ func foldLifecycle(prepared Record, events []Record, legacyResult *Record) Attem
 	}
 	state := prepared.State
 	sequence := prepared.Sequence
-	for _, event := range events {
+	for _, event := range orderedEvents {
 		if event.AttemptID != prepared.AttemptID ||
 			event.Agent != prepared.Agent ||
 			event.Mode != prepared.Mode ||
 			!sameStrings(event.MessageIDs, prepared.MessageIDs) ||
-			event.Sequence != sequence+1 ||
+			event.Sequence <= sequence ||
 			!validLifecycleTransition(state, event.State) {
 			return attempt
 		}
@@ -552,6 +573,40 @@ func foldLifecycle(prepared Record, events []Record, legacyResult *Record) Attem
 // history around it. (An audit log that refuses to read because one line is
 // bad would hide evidence of every other attempt.)
 func readRecords(root *fsq.DeliveryRoot, agent string) ([]Record, error) {
+	dir := filepath.Join("agents", agent, "receipts")
+	if LedgerSupported {
+		lockFile, err := openExistingLockFile(root, dir)
+		if err != nil {
+			return nil, fmt.Errorf("open notification attempt journal lock: %w", err)
+		}
+		if lockFile != nil {
+			defer func() { _ = lockFile.Close() }()
+			if err := flockShared(lockFile); err != nil {
+				return nil, fmt.Errorf("lock notification attempt journal for read: %w", err)
+			}
+			defer flockRelease(lockFile)
+		}
+	}
+
+	records, err := readRecordsUnlocked(root, agent)
+	if err != nil {
+		return nil, err
+	}
+	return deduplicateRecords(records), nil
+}
+
+func openExistingLockFile(root *fsq.DeliveryRoot, dir string) (*os.File, error) {
+	lockFile, _, err := root.OpenRegularNoFollow(filepath.Join(dir, lockFilename))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return lockFile, nil
+}
+
+func readRecordsUnlocked(root *fsq.DeliveryRoot, agent string) ([]Record, error) {
 	dir := filepath.Join("agents", agent, "receipts")
 	var records []Record
 	// Read .1 (older) first, then the current file, so records are in
@@ -589,6 +644,314 @@ func readRecords(root *fsq.DeliveryRoot, agent string) ([]Record, error) {
 		}
 	}
 	return records, nil
+}
+
+func deduplicateRecords(records []Record) []Record {
+	seen := make(map[recordDedupKey]struct{}, len(records))
+	deduplicated := make([]Record, 0, len(records))
+	for _, record := range records {
+		key := recordDeduplicationKey(record)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduplicated = append(deduplicated, record)
+	}
+	return deduplicated
+}
+
+type recordDedupKey struct {
+	schema    int
+	attemptID string
+	sequence  uint64
+	phase     string
+}
+
+func recordDeduplicationKey(record Record) recordDedupKey {
+	// A v2 sequence identifies one lifecycle event. Keep phase in the key so
+	// sequence-zero prepared records and v2 legacy result pairs remain distinct.
+	// The schema also keeps a legacy v1 prepared/result pair intact.
+	return recordDedupKey{
+		schema:    record.Schema,
+		attemptID: record.AttemptID,
+		sequence:  record.Sequence,
+		phase:     record.Phase,
+	}
+}
+
+type compactedAttempt struct {
+	id         string
+	records    []Record
+	mandatory  bool
+	latestTime string
+}
+
+func compactRecords(records []Record, agent string, maxBytes int64) ([]byte, error) {
+	groups := make(map[string][]Record)
+	for _, record := range deduplicateRecords(records) {
+		groups[record.AttemptID] = append(groups[record.AttemptID], record)
+	}
+
+	ids := make([]string, 0, len(groups))
+	for id := range groups {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	var mandatory []compactedAttempt
+	var optional []compactedAttempt
+	for _, id := range ids {
+		compacted, err := compactAttempt(id, groups[id])
+		if err != nil {
+			return nil, err
+		}
+		if compacted.mandatory {
+			mandatory = append(mandatory, compacted)
+		} else {
+			optional = append(optional, compacted)
+		}
+	}
+
+	var archive []Record
+	for _, attempt := range mandatory {
+		archive = append(archive, attempt.records...)
+	}
+	mandatoryData, err := marshalRecords(archive)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(mandatoryData)) > maxBytes {
+		return nil, fmt.Errorf(
+			"notification attempt journal compaction needs %d bytes for nonterminal attempts, cap is %d",
+			len(mandatoryData), maxBytes,
+		)
+	}
+
+	sort.SliceStable(optional, func(i, j int) bool {
+		if optional[i].latestTime == optional[j].latestTime {
+			return optional[i].id < optional[j].id
+		}
+		return optional[i].latestTime > optional[j].latestTime
+	})
+	for _, attempt := range optional {
+		candidate := append(append([]Record{}, archive...), attempt.records...)
+		candidateData, err := marshalRecords(candidate)
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(candidateData)) > maxBytes {
+			continue
+		}
+		archive = candidate
+	}
+
+	if err := validateCompactedRecords(archive, agent); err != nil {
+		return nil, fmt.Errorf("validate compacted notification attempt journal: %w", err)
+	}
+	return marshalRecords(archive)
+}
+
+func compactAttempt(id string, records []Record) (compactedAttempt, error) {
+	ordered := append([]Record{}, records...)
+
+	var prepared *Record
+	var lifecycle []Record
+	var legacyResults []Record
+	for i := range ordered {
+		record := ordered[i]
+		switch record.Phase {
+		case PhasePrepared:
+			if prepared == nil {
+				copy := record
+				prepared = &copy
+			}
+		case PhaseResult:
+			if record.State != "" {
+				lifecycle = append(lifecycle, record)
+			} else {
+				legacyResults = append(legacyResults, record)
+			}
+		}
+	}
+
+	latestTime := ""
+	for _, record := range ordered {
+		if record.RecordedAt > latestTime {
+			latestTime = record.RecordedAt
+		}
+	}
+	result := compactedAttempt{id: id, latestTime: latestTime}
+	if prepared == nil {
+		// An orphan result cannot create an Attempt without synthesizing a
+		// prepared record. Keep its newest raw record as optional evidence.
+		return compactedAttempt{
+			id:         id,
+			records:    []Record{ordered[len(ordered)-1]},
+			latestTime: latestTime,
+		}, nil
+	}
+
+	if prepared.Schema == legacySchemaVersion {
+		if legacy := matchingLegacyResult(*prepared, legacyResults); legacy != nil {
+			result.records = []Record{*prepared, *legacy}
+			return result, nil
+		}
+		result.records = []Record{*prepared}
+		result.mandatory = true
+		return result, nil
+	}
+
+	if prepared.State == "" {
+		if len(lifecycle) > 0 {
+			result.records = []Record{*prepared}
+			result.mandatory = true
+			return result, nil
+		}
+		if legacy := matchingLegacyResult(*prepared, legacyResults); legacy != nil {
+			result.records = []Record{*prepared, *legacy}
+			return result, nil
+		}
+		result.records = []Record{*prepared}
+		result.mandatory = true
+		return result, nil
+	}
+
+	if len(legacyResults) > 0 {
+		if legacy := matchingLegacyResult(*prepared, legacyResults); legacy != nil {
+			// Marker-less external injectors use a v2 prepared lifecycle record
+			// followed by a v1-shaped written result. Preserve that compatibility
+			// taxonomy instead of turning a terminal result back into "attempt".
+			result.records = []Record{*prepared, *legacy}
+			return result, nil
+		}
+		result.records = []Record{*prepared}
+		result.mandatory = true
+		return result, nil
+	}
+	if len(lifecycle) == 0 {
+		result.records = []Record{*prepared}
+		result.mandatory = true
+		return result, nil
+	}
+
+	orderedLifecycle := append([]Record{}, lifecycle...)
+	sort.SliceStable(orderedLifecycle, func(i, j int) bool {
+		return orderedLifecycle[i].Sequence < orderedLifecycle[j].Sequence
+	})
+	folded := foldLifecycle(*prepared, orderedLifecycle, nil)
+	if folded.State == StateInvalid {
+		result.records = []Record{*prepared}
+		result.mandatory = true
+		return result, nil
+	}
+
+	switch folded.State {
+	case StateDeferred:
+		result.records = []Record{*prepared, latestLifecycleState(orderedLifecycle, StateDeferred)}
+		result.mandatory = true
+	case StateRetried:
+		latestRetried := latestLifecycleState(orderedLifecycle, StateRetried)
+		deferred := latestLifecycleStateBefore(orderedLifecycle, StateDeferred, latestRetried.Sequence)
+		if deferred.State == "" {
+			result.records = []Record{*prepared}
+			result.mandatory = true
+			return result, nil
+		}
+		result.records = []Record{*prepared, deferred, latestRetried}
+		result.mandatory = true
+	case StateAccepted, StateFailed:
+		result.records = []Record{*prepared, latestLifecycleState(orderedLifecycle, folded.State)}
+	default:
+		result.records = []Record{*prepared}
+		result.mandatory = true
+	}
+
+	return result, nil
+}
+
+func matchingLegacyResult(prepared Record, results []Record) *Record {
+	for i := len(results) - 1; i >= 0; i-- {
+		result := results[i]
+		if result.AttemptID == prepared.AttemptID &&
+			result.Agent == prepared.Agent &&
+			result.Mode == prepared.Mode &&
+			sameStrings(result.MessageIDs, prepared.MessageIDs) {
+			copy := result
+			return &copy
+		}
+	}
+	return nil
+}
+
+func latestLifecycleState(events []Record, state string) Record {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].State == state {
+			return events[i]
+		}
+	}
+	return Record{}
+}
+
+func latestLifecycleStateBefore(events []Record, state string, sequence uint64) Record {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Sequence < sequence && events[i].State == state {
+			return events[i]
+		}
+	}
+	return Record{}
+}
+
+func marshalRecords(records []Record) ([]byte, error) {
+	var data bytes.Buffer
+	for _, record := range records {
+		line, err := json.Marshal(record)
+		if err != nil {
+			return nil, err
+		}
+		data.Write(line)
+		data.WriteByte('\n')
+	}
+	return data.Bytes(), nil
+}
+
+func validateCompactedRecords(records []Record, agent string) error {
+	for _, record := range records {
+		if err := validateRecord(record, agent); err != nil {
+			return err
+		}
+	}
+	byAttempt := make(map[string][]Record)
+	for _, record := range records {
+		byAttempt[record.AttemptID] = append(byAttempt[record.AttemptID], record)
+	}
+	for attemptID, group := range byAttempt {
+		var prepared *Record
+		var events []Record
+		var legacy *Record
+		for i := range group {
+			record := group[i]
+			switch {
+			case record.Phase == PhasePrepared && prepared == nil:
+				copy := record
+				prepared = &copy
+			case record.Phase == PhaseResult && record.State != "":
+				events = append(events, record)
+			case record.Phase == PhaseResult && legacy == nil:
+				copy := record
+				legacy = &copy
+			}
+		}
+		if prepared == nil ||
+			prepared.Schema == legacySchemaVersion ||
+			(prepared.State == "" && len(events) == 0) {
+			continue
+		}
+		folded := foldLifecycle(*prepared, events, legacy)
+		if folded.State == StateInvalid {
+			return fmt.Errorf("attempt %q has invalid compacted lifecycle", attemptID)
+		}
+	}
+	return nil
 }
 
 // validateRecord checks the invariants a Record must satisfy. SchemaVersion

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -1,6 +1,7 @@
 package notificationattempt
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func TestWriterPersistsPreparedAndResultInSingleLog(t *testing.T) {
@@ -153,10 +156,10 @@ func TestConcurrentAppendsAcrossRotation(t *testing.T) {
 	writer := NewWriter(root, "codex")
 	// Tiny cap so rotation triggers frequently and appends are very likely to
 	// land inside the rotation window.
-	writer.maxBytes = 300
+	writer.maxBytes = 32 * 1024
 
-	const appenders = 16
-	const recordsEach = 200
+	const appenders = 8
+	const recordsEach = 40
 	var wg sync.WaitGroup
 	wg.Add(appenders)
 
@@ -184,8 +187,14 @@ func TestConcurrentAppendsAcrossRotation(t *testing.T) {
 					RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
 				}
 				if err := writer.append(rec); err != nil {
-					t.Errorf("append %d/%d: %v", a, i, err)
-					return
+					// A burst can make the mandatory nonterminal snapshot exceed
+					// the hard archive cap before LOCK_EX is acquired. The writer
+					// must report that condition, but it still appends this record
+					// and must not truncate the current generation.
+					if !strings.Contains(err.Error(), "nonterminal attempts") {
+						t.Errorf("append %d/%d: %v", a, i, err)
+						return
+					}
 				}
 				local = append(local, id)
 			}
@@ -263,8 +272,7 @@ func min(a, b int) int {
 func TestRotationNeverOrphansResult(t *testing.T) {
 	root := t.TempDir()
 	writer := NewWriter(root, "codex")
-	// Small cap so rotation triggers after a few records.
-	writer.maxBytes = 600
+	writer.maxBytes = 4 * 1024
 
 	// Write a prepared+result pair, then enough records to rotate the
 	// prepared into .1 while the result stays in the current file.
@@ -275,20 +283,25 @@ func TestRotationNeverOrphansResult(t *testing.T) {
 	if err := writer.Result(prepared, OutcomeWritten, ""); err != nil {
 		t.Fatal(err)
 	}
-	// Pad with extra records to force rotation.
-	for i := 0; i < 10; i++ {
-		rec := Record{
-			Schema:     SchemaVersion,
-			AttemptID:  "pad-" + itoa(i),
-			Phase:      PhasePrepared,
-			MessageIDs: []string{"msg-pad"},
-			Agent:      "codex",
-			Mode:       "raw",
-			RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
-		}
-		if err := writer.append(rec); err != nil {
-			t.Fatalf("pad append %d: %v", i, err)
-		}
+	// Set the cap just above the existing pair, then append one record that
+	// forces exactly one rotation. The pair must remain joinable in .1.
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	info, err := os.Stat(filepath.Join(dir, LogFilename))
+	if err != nil {
+		t.Fatalf("stat current journal before rotation: %v", err)
+	}
+	writer.maxBytes = info.Size() + 1
+	pad := Record{
+		Schema:     SchemaVersion,
+		AttemptID:  "pad",
+		Phase:      PhasePrepared,
+		MessageIDs: []string{"msg-pad"},
+		Agent:      "codex",
+		Mode:       "raw",
+		RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := writer.append(pad); err != nil {
+		t.Fatalf("pad append: %v", err)
 	}
 
 	// List must join the prepared (in .1) with its result — no orphan.
@@ -310,7 +323,7 @@ func TestRotationNeverOrphansResult(t *testing.T) {
 func TestRotationCapsBothGenerations(t *testing.T) {
 	root := t.TempDir()
 	writer := NewWriter(root, "codex")
-	writer.maxBytes = 420
+	writer.maxBytes = 4 * 1024
 
 	for i := 0; i < 12; i++ {
 		rec := Record{
@@ -328,16 +341,39 @@ func TestRotationCapsBothGenerations(t *testing.T) {
 	}
 
 	dir := filepath.Join(root, "agents", "codex", "receipts")
-	// The current file must be under the cap (it is the hot-path append target).
-	// The .1 file accumulates merged generations and may exceed the cap — that
-	// is correct for an audit log (history is the value; the cap bounds the
-	// active append target, not the archive).
+	// Force one rotation after the initial records. Both generations are now
+	// bounded by the same cap; the archive compactor may omit terminal history,
+	// but it must never grow without limit.
+	infoBefore, err := os.Stat(filepath.Join(dir, LogFilename))
+	if err != nil {
+		t.Fatalf("stat current journal before rotation: %v", err)
+	}
+	writer.maxBytes = infoBefore.Size() + 1
+	pad := Record{
+		Schema:     SchemaVersion,
+		AttemptID:  "rotation-pad",
+		Phase:      PhasePrepared,
+		MessageIDs: []string{"msg-pad"},
+		Agent:      "codex",
+		Mode:       "raw",
+		RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := writer.append(pad); err != nil {
+		t.Fatalf("rotation pad append: %v", err)
+	}
 	info, err := os.Stat(filepath.Join(dir, LogFilename))
 	if err != nil {
 		t.Fatalf("stat %s: %v", LogFilename, err)
 	}
 	if info.Size() > writer.maxBytes {
 		t.Fatalf("%s size = %d, cap = %d", LogFilename, info.Size(), writer.maxBytes)
+	}
+	rotatedInfo, err := os.Stat(filepath.Join(dir, LogFilename+rotatedSuffix))
+	if err != nil {
+		t.Fatalf("stat %s: %v", LogFilename+rotatedSuffix, err)
+	}
+	if rotatedInfo.Size() > writer.maxBytes {
+		t.Fatalf("%s size = %d, cap = %d", LogFilename+rotatedSuffix, rotatedInfo.Size(), writer.maxBytes)
 	}
 	// .1 must exist (rotation happened).
 	if _, err := os.Stat(filepath.Join(dir, LogFilename+rotatedSuffix)); os.IsNotExist(err) {
@@ -422,6 +458,9 @@ func TestListEmptyJournalIsNotAnError(t *testing.T) {
 	if attempts != nil {
 		t.Fatalf("List on empty journal should return nil attempts, got %d", len(attempts))
 	}
+	if _, err := os.Stat(filepath.Join(root, "agents", "codex", "receipts", lockFilename)); !os.IsNotExist(err) {
+		t.Fatalf("List on empty journal created a lock file: %v", err)
+	}
 }
 
 func TestLifecycleRetainsAttemptIDAcrossDeferredRetryAccepted(t *testing.T) {
@@ -481,6 +520,234 @@ func TestLifecycleRejectsTerminalReopen(t *testing.T) {
 	}
 	if len(attempts) != 1 || attempts[0].State != StateAccepted {
 		t.Fatalf("attempts = %+v, want one accepted attempt", attempts)
+	}
+}
+
+func TestRotationFailureDoesNotTruncateCurrentJournal(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	writer.maxBytes = 300
+	first := Record{
+		Schema: SchemaVersion, AttemptID: "rotation-first", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-first"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	second := first
+	second.AttemptID = "rotation-second"
+	second.MessageIDs = []string{"msg-second"}
+	if err := writer.append(first); err != nil {
+		t.Fatalf("append first: %v", err)
+	}
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	if err := os.Mkdir(filepath.Join(dir, LogFilename+rotatedSuffix), 0o700); err != nil {
+		t.Fatalf("make archive failure fixture: %v", err)
+	}
+	if err := writer.append(second); err == nil {
+		t.Fatal("append succeeded despite archive replacement failure")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, LogFilename))
+	if err != nil {
+		t.Fatalf("read current journal: %v", err)
+	}
+	if got := strings.Count(string(data), "\n"); got != 2 {
+		t.Fatalf("current journal lines = %d, want both records preserved", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, LogFilename+rotatedSuffix)); err != nil {
+		t.Fatalf("archive failure fixture disappeared: %v", err)
+	}
+}
+
+func TestCompactionPreservesSequencesAndLegacyRecords(t *testing.T) {
+	base := func(id, messageID, recordedAt string) Record {
+		return Record{
+			Schema: SchemaVersion, AttemptID: id, Phase: PhasePrepared,
+			MessageIDs: []string{messageID}, Agent: "codex", Mode: "external",
+			RecordedAt: recordedAt, State: StateAttempt,
+		}
+	}
+	deferred := base("v2-deferred", "msg-deferred", "2026-09-01T10:00:00Z")
+	retried := base("v2-retried", "msg-retried", "2026-09-01T10:00:01Z")
+	accepted := base("v2-accepted", "msg-accepted", "2026-09-01T10:00:02Z")
+	legacyPrepared := Record{
+		Schema: legacySchemaVersion, AttemptID: "v1-pair", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-v1"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:03Z",
+	}
+	legacyResult := legacyPrepared
+	legacyResult.Phase = PhaseResult
+	legacyResult.RecordedAt = "2026-09-01T10:00:04Z"
+	legacyResult.Outcome = OutcomeWritten
+	v1Open := legacyPrepared
+	v1Open.AttemptID = "v1-open"
+	v1Open.MessageIDs = []string{"msg-v1-open"}
+	v1Open.RecordedAt = "2026-09-01T10:00:05Z"
+
+	records := []Record{
+		deferred,
+		{Schema: SchemaVersion, AttemptID: deferred.AttemptID, Phase: PhaseResult, MessageIDs: deferred.MessageIDs, Agent: "codex", Mode: "external", RecordedAt: "2026-09-01T10:00:06Z", State: StateDeferred, Sequence: 4},
+		{Schema: SchemaVersion, AttemptID: deferred.AttemptID, Phase: PhaseResult, MessageIDs: deferred.MessageIDs, Agent: "codex", Mode: "external", RecordedAt: "2026-09-01T10:00:07Z", State: StateRetried, Sequence: 9},
+		{Schema: SchemaVersion, AttemptID: deferred.AttemptID, Phase: PhaseResult, MessageIDs: deferred.MessageIDs, Agent: "codex", Mode: "external", RecordedAt: "2026-09-01T10:00:08Z", State: StateDeferred, Sequence: 15},
+		retried,
+		{Schema: SchemaVersion, AttemptID: retried.AttemptID, Phase: PhaseResult, MessageIDs: retried.MessageIDs, Agent: "codex", Mode: "external", RecordedAt: "2026-09-01T10:00:09Z", State: StateDeferred, Sequence: 2},
+		{Schema: SchemaVersion, AttemptID: retried.AttemptID, Phase: PhaseResult, MessageIDs: retried.MessageIDs, Agent: "codex", Mode: "external", RecordedAt: "2026-09-01T10:00:10Z", State: StateRetried, Sequence: 7},
+		accepted,
+		{Schema: SchemaVersion, AttemptID: accepted.AttemptID, Phase: PhaseResult, MessageIDs: accepted.MessageIDs, Agent: "codex", Mode: "external", RecordedAt: "2026-09-01T10:00:11Z", State: StateAccepted, Sequence: 11},
+		legacyPrepared,
+		legacyResult,
+		v1Open,
+	}
+
+	first, err := compactRecords(records, "codex", 64*1024)
+	if err != nil {
+		t.Fatalf("compact records: %v", err)
+	}
+	second, err := compactRecords(records, "codex", 64*1024)
+	if err != nil {
+		t.Fatalf("repeat compact records: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("compaction is not deterministic:\nfirst=%s\nsecond=%s", first, second)
+	}
+	var compacted []Record
+	for _, line := range strings.Split(strings.TrimSpace(string(first)), "\n") {
+		var record Record
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode compacted record: %v", err)
+		}
+		compacted = append(compacted, record)
+	}
+	if err := validateCompactedRecords(compacted, "codex"); err != nil {
+		t.Fatalf("compacted records failed validation: %v", err)
+	}
+
+	byID := make(map[string][]Record)
+	for _, record := range compacted {
+		byID[record.AttemptID] = append(byID[record.AttemptID], record)
+	}
+	if got := len(byID["v1-pair"]); got != 2 {
+		t.Fatalf("v1 pair records = %d, want 2", got)
+	}
+	for _, record := range byID["v1-pair"] {
+		if record.Schema != legacySchemaVersion {
+			t.Fatalf("v1 pair record was synthesized as schema %d", record.Schema)
+		}
+	}
+	if got := len(byID["v1-open"]); got != 1 {
+		t.Fatalf("v1 prepared-without-result records = %d, want 1", got)
+	}
+	if got := len(byID[deferred.AttemptID]); got != 2 || byID[deferred.AttemptID][1].Sequence != 15 {
+		t.Fatalf("deferred compacted records = %#v, want prepared plus latest sequence 15", byID[deferred.AttemptID])
+	}
+	if got := len(byID[retried.AttemptID]); got != 3 || byID[retried.AttemptID][1].Sequence != 2 || byID[retried.AttemptID][2].Sequence != 7 {
+		t.Fatalf("retried compacted records = %#v, want original sequences 0,2,7", byID[retried.AttemptID])
+	}
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "agents", "codex", "receipts"), 0o700); err != nil {
+		t.Fatalf("make list fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "agents", "codex", "receipts", LogFilename), first, 0o600); err != nil {
+		t.Fatalf("write compacted fixture: %v", err)
+	}
+	attempts, err := List(root, "codex", "msg-retried")
+	if err != nil {
+		t.Fatalf("List compacted fixture: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateRetried || attempts[0].Result == nil || attempts[0].Result.Sequence != 7 {
+		t.Fatalf("round-trip retried attempt = %#v", attempts)
+	}
+}
+
+func TestCompactionPreservesV2PreparedLegacyWrittenResult(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "v2-legacy-written", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-v2-legacy-written"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	result := prepared
+	result.Phase = PhaseResult
+	result.RecordedAt = "2026-09-01T10:00:01Z"
+	result.State = ""
+	result.Outcome = OutcomeWritten
+	compacted, err := compactRecords([]Record{prepared, result}, "codex", 64*1024)
+	if err != nil {
+		t.Fatalf("compact legacy written result: %v", err)
+	}
+	var records []Record
+	for _, line := range strings.Split(strings.TrimSpace(string(compacted)), "\n") {
+		var record Record
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode compacted legacy result: %v", err)
+		}
+		records = append(records, record)
+	}
+	if len(records) != 2 || records[0].State != StateAttempt || records[1].Outcome != OutcomeWritten || records[1].State != "" {
+		t.Fatalf("compacted legacy pair = %#v, want v2 prepared plus written result", records)
+	}
+	if err := validateCompactedRecords(records, "codex"); err != nil {
+		t.Fatalf("validate compacted legacy pair: %v", err)
+	}
+}
+
+func TestListDeduplicatesCrashWindowAcrossGenerations(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "crash-window", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-crash"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	accepted := prepared
+	accepted.Phase = PhaseResult
+	accepted.RecordedAt = "2026-09-01T10:00:01Z"
+	accepted.State = StateAccepted
+	accepted.Sequence = 4
+	data, err := marshalRecords([]Record{prepared, accepted})
+	if err != nil {
+		t.Fatalf("marshal crash-window records: %v", err)
+	}
+	duplicate := accepted
+	duplicate.Detail = "duplicate crash-window copy"
+	duplicateData, err := marshalRecords([]Record{prepared, duplicate})
+	if err != nil {
+		t.Fatalf("marshal duplicate crash-window records: %v", err)
+	}
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	if err := os.WriteFile(filepath.Join(dir, LogFilename+rotatedSuffix), data, 0o600); err != nil {
+		t.Fatalf("write rotated crash-window records: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LogFilename), duplicateData, 0o600); err != nil {
+		t.Fatalf("write current crash-window records: %v", err)
+	}
+	attempts, err := List(root, "codex", "msg-crash")
+	if err != nil {
+		t.Fatalf("List crash-window records: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateAccepted || len(attempts[0].History) != 2 {
+		t.Fatalf("crash-window attempts = %#v, want one two-event accepted attempt", attempts)
+	}
+}
+
+func TestCompactionRefusesNonterminalOverflow(t *testing.T) {
+	first := Record{
+		Schema: SchemaVersion, AttemptID: "overflow-first", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-overflow-first"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	second := first
+	second.AttemptID = "overflow-second"
+	second.MessageIDs = []string{"msg-overflow-second"}
+	firstData, err := marshalRecords([]Record{first})
+	if err != nil {
+		t.Fatalf("marshal first overflow record: %v", err)
+	}
+	if _, err := compactRecords([]Record{first, second}, "codex", int64(len(firstData))); err == nil {
+		t.Fatal("compaction accepted a nonterminal archive larger than cap")
 	}
 }
 


### PR DESCRIPTION
## Summary
- close injector marker parsing, recovery, and terminal latch findings
- make retained wake repair lifecycle fail closed across inbox component replacement
- add v2 notification-attempt lifecycle logging with bounded atomic compaction and sidecar locking

## Verification
- `go vet ./...`
- focused CLI, keepalive, and notification-attempt tests
- Claude review: GO

## Known local-suite issue
- `go test ./...` has one cross-package order-sensitive failure in `TestRepairedWakeExitsWithoutInjectingAfterInboxComponentReplacement` (`mkdir .../agents/codex/inbox: file exists`); the target passes repeatedly and the full `internal/cli` package passes. Claude is running the clean-main discriminator separately; this test is outside the wave diff.
- `make ci` reached the local linter but stopped on installed `golangci-lint 2.13.2` versus the repository-required `2.13.1`; CI uses the pinned toolchain.