### PR TITLE
fix(wake): re-arm deferred cohorts and type rotation-only ledger errors

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -702,6 +702,15 @@ func deliverWithNotificationLedger(
 	writer := notificationattempt.NewWriter(cfg.root, cfg.me)
 	if cfg.injectVia == "" || cfg.injectMode == wakeInjectModeNone {
 		prepared, prepareErr := writer.Prepare(messageIDs, notificationAttemptMode(cfg))
+		if notificationattempt.IsRotationOnly(prepareErr) {
+			// The prepared record persisted; only the size-capped rotation
+			// failed. Proceed on the normal path — recording a failure result
+			// here would join a REAL prepared record into a false `failed`.
+			if cfg.debug {
+				_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: notification journal rotation: %v\n", prepareErr)
+			}
+			prepareErr = nil
+		}
 		deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
 		if prepareErr != nil {
 			// The prepared write failed. Record a result with outcome=failed so
@@ -710,6 +719,7 @@ func deliverWithNotificationLedger(
 				AttemptID:  prepared.AttemptID,
 				MessageIDs: messageIDs,
 				Agent:      cfg.me,
+				Mode:       notificationAttemptMode(cfg),
 			}
 			if resultErr := writer.Result(reconstructed, notificationattempt.OutcomeFailed, "prepared write failed: "+prepareErr.Error()); resultErr != nil && cfg.debug {
 				_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
@@ -829,6 +839,15 @@ func ensureNotificationAttempt(
 		return cfg.notificationAttempt, nil
 	}
 	lifecycle, err := writer.Begin(messageIDs, mode)
+	if notificationattempt.IsRotationOnly(err) && lifecycle != nil {
+		// The lifecycle record persisted; only journal rotation failed. This
+		// IS a live attempt — cache it and continue, or a later transition
+		// would begin a duplicate AttemptID for the same cohort.
+		if cfg.debug {
+			_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: notification journal rotation: %v\n", err)
+		}
+		err = nil
+	}
 	if err != nil {
 		// Begin may return the built identity with the error (append failure).
 		// Pass it through so the caller can record "recording failed"
@@ -1058,7 +1077,10 @@ func recordWakeAttempt(
 	if isWakeInjectorDeferred(deliveryErr) {
 		// Provider-side busy/transition is a silent transport deferral. Keep
 		// the existing cohort and its normal input retry ladder; do not spend
-		// the reminder budget or emit attention output.
+		// the reminder budget or emit attention output. Reconcile an
+		// announced/parked cohort first: the interrupt path records before
+		// plan() runs, and unseen additions must re-arm the ladder.
+		cfg.doorbell.reconcileDeferredCohort(currentPending)
 		cfg.doorbell.recordDeferredInputAttempt(now)
 		persistWakeDoorbellStatusBestEffort(cfg)
 		return

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -713,15 +713,9 @@ func deliverWithNotificationLedger(
 		}
 		deliverErr := deliverNewMessageNotification(cfg, notice, deferForInput, currentPending)
 		if prepareErr != nil {
-			// The prepared write failed. Record a result with outcome=failed so
-			// trace can surface "recording failed" rather than a silent hole.
-			reconstructed := notificationattempt.Record{
-				AttemptID:  prepared.AttemptID,
-				MessageIDs: messageIDs,
-				Agent:      cfg.me,
-				Mode:       notificationAttemptMode(cfg),
-			}
-			if resultErr := writer.Result(reconstructed, notificationattempt.OutcomeFailed, "prepared write failed: "+prepareErr.Error()); resultErr != nil && cfg.debug {
+			// The prepared write failed. Record a failed result so trace can
+			// surface "recording failed" rather than a silent hole.
+			if resultErr := writer.WriteFailure(prepared.AttemptID, messageIDs, notificationAttemptMode(cfg), prepareErr); resultErr != nil && cfg.debug {
 				_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
 			}
 			return deliverErr
@@ -767,13 +761,7 @@ func deliverWithNotificationLedger(
 			// Best-effort requirement-3 marker: record that an attempt was
 			// made but its prepared record could not be persisted, so trace
 			// reports "recording failed" instead of "no attempt recorded".
-			reconstructed := notificationattempt.Record{
-				AttemptID:  lifecycle.AttemptID,
-				MessageIDs: append([]string{}, lifecycle.MessageIDs...),
-				Agent:      lifecycle.Agent,
-				Mode:       lifecycle.Mode,
-			}
-			if resultErr := writer.Result(reconstructed, notificationattempt.OutcomeFailed, "prepared write failed: "+prepareErr.Error()); resultErr != nil && cfg.debug {
+			if resultErr := writer.WriteFailure(lifecycle.AttemptID, lifecycle.MessageIDs, lifecycle.Mode, prepareErr); resultErr != nil && cfg.debug {
 				_, _ = fmt.Fprintf(os.Stderr, "amq wake [debug]: persist notification attempt result: %v\n", resultErr)
 			}
 		}

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -141,6 +141,37 @@ func (state *wakeDoorbellState) recordAttempt(now time.Time) {
 	}
 }
 
+// reconcileDeferredCohort mirrors plan()'s announced/parked expansion handling
+// for attempts recorded outside a plan() pass — the interrupt path injects
+// before the doorbell plan runs. A deferred provider outcome must leave the
+// retry ladder armed for cohort content the agent has not seen; without this,
+// a deferred attempt recorded in the announced or parked phase writes into
+// state nextDeadline() never reads and the doorbell stalls until an unrelated
+// inbox event.
+func (state *wakeDoorbellState) reconcileDeferredCohort(current map[string]os.FileInfo) {
+	if len(current) == 0 {
+		return
+	}
+	switch state.phase {
+	case wakeDoorbellAnnounced:
+		// A replaced physical file keeps its name but is a message the agent
+		// has never seen; it re-arms like an addition (same rule as plan()).
+		if wakeCohortExpanded(state.cohort, current) ||
+			wakeCohortReplacedInPlace(state.cohort, current) {
+			state.arm(current)
+		}
+	case wakeDoorbellParked:
+		if wakeCohortExpanded(state.cohort, current) {
+			state.cohort = snapshotWakeFileIdentities(current)
+			state.presentationConfirmed = false
+			if state.attemptBudget < wakeDoorbellLifetimeAttemptCap {
+				state.attemptBudget++
+				state.phase = wakeDoorbellRetrying
+			}
+		}
+	}
+}
+
 func (state *wakeDoorbellState) recordDeferredInputAttempt(now time.Time) {
 	state.recordAttemptWithBase(now, wakeDoorbellRetryBase, wakeDoorbellRetryMax)
 }

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -61,15 +61,8 @@ func (state *wakeDoorbellState) plan(
 		return wakeDoorbellPlan{}
 	}
 	if state.phase == wakeDoorbellAnnounced {
-		// A replaced physical file keeps its name but is a message the agent
-		// has never seen; it re-arms like an addition, not like a drain.
-		if wakeCohortExpanded(state.cohort, current) ||
-			wakeCohortReplacedInPlace(state.cohort, current) {
-			state.arm(current)
+		if state.reconcileAnnouncedCohort(current) {
 			return wakeDoorbellPlan{attempt: true, prompt: coopWakeDoorbell}
-		}
-		if wakeCohortProgressed(state.cohort, current) {
-			state.recordInjected(current)
 		}
 		return wakeDoorbellPlan{}
 	}
@@ -86,11 +79,7 @@ func (state *wakeDoorbellState) plan(
 		// "drain everything" doorbell covers the whole current cohort, so N
 		// unread messages do not need N doorbells.
 		if state.phase == wakeDoorbellParked {
-			state.cohort = snapshotWakeFileIdentities(current)
-			state.presentationConfirmed = false
-			if state.attemptBudget < wakeDoorbellLifetimeAttemptCap {
-				state.attemptBudget++
-				state.phase = wakeDoorbellRetrying
+			if state.reviveParkedCohort(current) {
 				state.pullForwardForAddition(now)
 			}
 		} else {
@@ -141,33 +130,64 @@ func (state *wakeDoorbellState) recordAttempt(now time.Time) {
 	}
 }
 
-// reconcileDeferredCohort mirrors plan()'s announced/parked expansion handling
-// for attempts recorded outside a plan() pass — the interrupt path injects
-// before the doorbell plan runs. A deferred provider outcome must leave the
-// retry ladder armed for cohort content the agent has not seen; without this,
-// a deferred attempt recorded in the announced or parked phase writes into
+// reconcileAnnouncedCohort applies the announced-phase cohort rules shared by
+// plan() and the deferred interrupt path. A replaced physical file keeps its
+// name but is a message the agent has never seen; it re-arms like an
+// addition, not like a drain. Progress alone re-snapshots the cohort to what
+// remains. It reports whether the ladder was re-armed.
+func (state *wakeDoorbellState) reconcileAnnouncedCohort(current map[string]os.FileInfo) bool {
+	if wakeCohortExpanded(state.cohort, current) ||
+		wakeCohortReplacedInPlace(state.cohort, current) {
+		state.arm(current)
+		return true
+	}
+	if wakeCohortProgressed(state.cohort, current) {
+		state.recordInjected(current)
+	}
+	return false
+}
+
+// reviveParkedCohort applies the parked-phase addition rule shared by plan()
+// and the deferred interrupt path: the parked cohort adopts the expanded
+// content, and the ladder revives only while the lifetime attempt budget
+// allows another announcement. It reports whether the ladder revived.
+func (state *wakeDoorbellState) reviveParkedCohort(current map[string]os.FileInfo) bool {
+	state.cohort = snapshotWakeFileIdentities(current)
+	state.presentationConfirmed = false
+	if state.attemptBudget >= wakeDoorbellLifetimeAttemptCap {
+		return false
+	}
+	state.attemptBudget++
+	state.phase = wakeDoorbellRetrying
+	return true
+}
+
+// reconcileDeferredCohort applies plan()'s announced/parked cohort rules for
+// attempts recorded outside a plan() pass — the interrupt path injects before
+// the doorbell plan runs. A deferred provider outcome must leave the retry
+// ladder armed for cohort content the agent has not seen; without this, a
+// deferred attempt recorded in the announced or parked phase writes into
 // state nextDeadline() never reads and the doorbell stalls until an unrelated
-// inbox event.
+// inbox event. The caller advances the retry deadline afterwards, so no
+// pull-forward happens here.
 func (state *wakeDoorbellState) reconcileDeferredCohort(current map[string]os.FileInfo) {
 	if len(current) == 0 {
 		return
 	}
 	switch state.phase {
 	case wakeDoorbellAnnounced:
-		// A replaced physical file keeps its name but is a message the agent
-		// has never seen; it re-arms like an addition (same rule as plan()).
-		if wakeCohortExpanded(state.cohort, current) ||
-			wakeCohortReplacedInPlace(state.cohort, current) {
-			state.arm(current)
-		}
+		state.reconcileAnnouncedCohort(current)
 	case wakeDoorbellParked:
+		if wakeCohortProgressed(state.cohort, current) {
+			// plan(): progress on a parked cohort (a drain or an in-place
+			// replacement) resets the ladder and arms the remaining cohort
+			// fresh.
+			state.reset()
+			state.arm(current)
+			return
+		}
 		if wakeCohortExpanded(state.cohort, current) {
-			state.cohort = snapshotWakeFileIdentities(current)
-			state.presentationConfirmed = false
-			if state.attemptBudget < wakeDoorbellLifetimeAttemptCap {
-				state.attemptBudget++
-				state.phase = wakeDoorbellRetrying
-			}
+			state.reviveParkedCohort(current)
 		}
 	}
 }

--- a/internal/cli/wake_doorbell_deferred_test.go
+++ b/internal/cli/wake_doorbell_deferred_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// A deferred injector outcome recorded while the doorbell is ANNOUNCED (the
+// interrupt path runs before plan(), so plan()'s expansion re-arm never
+// fires) must re-arm the ladder for unseen additions. A no-reconcile
+// implementation leaves phase=announced, and nextDeadline() returns nothing —
+// the deferred doorbell stalls until an unrelated inbox event (#708).
+func TestDeferredAttemptReArmsAnnouncedCohortOnAddition(t *testing.T) {
+	now := time.Now()
+	seen := fakeWakePendingFiles(t, "a.md")
+	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
+	cfg.doorbell.arm(seen)
+	cfg.doorbell.recordInjected(seen)
+	if cfg.doorbell.phase != wakeDoorbellAnnounced {
+		t.Fatalf("setup phase = %v, want announced", cfg.doorbell.phase)
+	}
+
+	expanded := fakeWakePendingFiles(t, "a.md", "b.md")
+	deferredErr := &wakeInjectorDeferredError{err: errors.New("provider busy")}
+	recordWakeAttempt(cfg, now, expanded, deferredErr)
+
+	if cfg.doorbell.phase != wakeDoorbellRetrying {
+		t.Fatalf("phase after deferred addition = %v, want retrying", cfg.doorbell.phase)
+	}
+	if _, ok := cfg.doorbell.cohort["b.md"]; !ok {
+		t.Fatal("deferred re-arm did not adopt the added message into the cohort")
+	}
+	if _, armed := cfg.doorbell.nextDeadline(); !armed {
+		t.Fatal("deferred attempt on an announced cohort left no retry deadline (silent stall)")
+	}
+}
+
+// Same for a PARKED cohort: an addition must revive the ladder (with the
+// lifetime-budget increment plan() uses); an unchanged parked cohort must
+// stay parked — deferred is not an excuse to resurrect a terminally parked
+// cohort with no new content.
+func TestDeferredAttemptRevivesParkedCohortOnlyOnAddition(t *testing.T) {
+	now := time.Now()
+	seen := fakeWakePendingFiles(t, "a.md")
+	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
+	cfg.doorbell.arm(seen)
+	cfg.doorbell.parkCurrentCohort()
+
+	deferredErr := &wakeInjectorDeferredError{err: errors.New("provider busy")}
+
+	// Unchanged cohort: stays parked, no deadline.
+	recordWakeAttempt(cfg, now, seen, deferredErr)
+	if cfg.doorbell.phase != wakeDoorbellParked {
+		t.Fatalf("unchanged parked cohort phase = %v, want parked", cfg.doorbell.phase)
+	}
+
+	// Addition: revives.
+	expanded := fakeWakePendingFiles(t, "a.md", "b.md")
+	recordWakeAttempt(cfg, now, expanded, deferredErr)
+	if cfg.doorbell.phase != wakeDoorbellRetrying {
+		t.Fatalf("parked+addition phase = %v, want retrying", cfg.doorbell.phase)
+	}
+	if _, armed := cfg.doorbell.nextDeadline(); !armed {
+		t.Fatal("parked+addition deferred attempt left no retry deadline")
+	}
+}
+
+func fakeWakePendingFiles(t *testing.T, names ...string) map[string]os.FileInfo {
+	t.Helper()
+	dir := t.TempDir()
+	out := make(map[string]os.FileInfo, len(names))
+	for _, name := range names {
+		path := dir + "/" + name
+		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[name] = info
+	}
+	return out
+}

--- a/internal/cli/wake_doorbell_deferred_test.go
+++ b/internal/cli/wake_doorbell_deferred_test.go
@@ -7,6 +7,34 @@ import (
 	"time"
 )
 
+func deferredInjectorErrorForTest() error {
+	return &wakeInjectorDeferredError{err: errors.New("provider busy")}
+}
+
+// withAddedWakeFile returns cohort plus one new file, keeping the existing
+// entries' physical identities (a fresh wakeDoorbellTestFiles call would give
+// every name a new inode and read as an in-place replacement, not an addition).
+func withAddedWakeFile(t *testing.T, cohort map[string]os.FileInfo, name string) map[string]os.FileInfo {
+	t.Helper()
+	out := make(map[string]os.FileInfo, len(cohort)+1)
+	for k, v := range cohort {
+		out[k] = v
+	}
+	out[name] = wakeDoorbellTestFiles(t, name)[name]
+	return out
+}
+
+// withoutWakeFile returns a copy of cohort with one file drained.
+func withoutWakeFile(cohort map[string]os.FileInfo, name string) map[string]os.FileInfo {
+	out := make(map[string]os.FileInfo, len(cohort))
+	for k, v := range cohort {
+		if k != name {
+			out[k] = v
+		}
+	}
+	return out
+}
+
 // A deferred injector outcome recorded while the doorbell is ANNOUNCED (the
 // interrupt path runs before plan(), so plan()'s expansion re-arm never
 // fires) must re-arm the ladder for unseen additions. A no-reconcile
@@ -14,7 +42,7 @@ import (
 // the deferred doorbell stalls until an unrelated inbox event (#708).
 func TestDeferredAttemptReArmsAnnouncedCohortOnAddition(t *testing.T) {
 	now := time.Now()
-	seen := fakeWakePendingFiles(t, "a.md")
+	seen := wakeDoorbellTestFiles(t, "a.md")
 	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
 	cfg.doorbell.arm(seen)
 	cfg.doorbell.recordInjected(seen)
@@ -22,9 +50,8 @@ func TestDeferredAttemptReArmsAnnouncedCohortOnAddition(t *testing.T) {
 		t.Fatalf("setup phase = %v, want announced", cfg.doorbell.phase)
 	}
 
-	expanded := fakeWakePendingFiles(t, "a.md", "b.md")
-	deferredErr := &wakeInjectorDeferredError{err: errors.New("provider busy")}
-	recordWakeAttempt(cfg, now, expanded, deferredErr)
+	expanded := withAddedWakeFile(t, seen, "b.md")
+	recordWakeAttempt(cfg, now, expanded, deferredInjectorErrorForTest())
 
 	if cfg.doorbell.phase != wakeDoorbellRetrying {
 		t.Fatalf("phase after deferred addition = %v, want retrying", cfg.doorbell.phase)
@@ -37,50 +64,142 @@ func TestDeferredAttemptReArmsAnnouncedCohortOnAddition(t *testing.T) {
 	}
 }
 
+// An in-place replacement (same name, different physical file) is a message
+// the agent has never seen. plan() re-arms an announced cohort for it; the
+// deferred interrupt path must too. An expansion-only reconcile leaves the
+// replaced message announced with no deadline.
+func TestDeferredAttemptReArmsAnnouncedCohortOnInPlaceReplacement(t *testing.T) {
+	now := time.Now()
+	seen := wakeDoorbellTestFiles(t, "a.md")
+	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
+	cfg.doorbell.arm(seen)
+	cfg.doorbell.recordInjected(seen)
+
+	replaced := wakeDoorbellTestFiles(t, "a.md") // fresh temp dir: new inode, same name
+	if !wakeCohortReplacedInPlace(cfg.doorbell.cohort, replaced) {
+		t.Skip("filesystem does not expose a distinct identity for the replacement")
+	}
+	recordWakeAttempt(cfg, now, replaced, deferredInjectorErrorForTest())
+
+	if cfg.doorbell.phase != wakeDoorbellRetrying {
+		t.Fatalf("phase after deferred replacement = %v, want retrying", cfg.doorbell.phase)
+	}
+	if _, armed := cfg.doorbell.nextDeadline(); !armed {
+		t.Fatal("deferred attempt on a replaced announced message left no retry deadline")
+	}
+}
+
+// Progress on an announced cohort (the agent drained part of it) is not new
+// content: the cohort re-snapshots to what remains (plan()'s recordInjected
+// rule) and stays announced. A reconcile that arms on any change would spam a
+// doorbell for messages the agent has already seen.
+func TestDeferredAttemptOnAnnouncedProgressReSnapshotsWithoutReArm(t *testing.T) {
+	now := time.Now()
+	seen := wakeDoorbellTestFiles(t, "a.md", "b.md")
+	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
+	cfg.doorbell.arm(seen)
+	cfg.doorbell.recordInjected(seen)
+
+	drained := withoutWakeFile(seen, "b.md")
+	recordWakeAttempt(cfg, now, drained, deferredInjectorErrorForTest())
+
+	if cfg.doorbell.phase != wakeDoorbellAnnounced {
+		t.Fatalf("phase after deferred progress = %v, want announced (no new content)", cfg.doorbell.phase)
+	}
+	if len(cfg.doorbell.cohort) != 1 {
+		t.Fatalf("announced cohort after progress = %d files, want 1", len(cfg.doorbell.cohort))
+	}
+	if _, stale := cfg.doorbell.cohort["b.md"]; stale {
+		t.Fatal("drained message still in the announced cohort snapshot")
+	}
+}
+
 // Same for a PARKED cohort: an addition must revive the ladder (with the
 // lifetime-budget increment plan() uses); an unchanged parked cohort must
 // stay parked — deferred is not an excuse to resurrect a terminally parked
 // cohort with no new content.
 func TestDeferredAttemptRevivesParkedCohortOnlyOnAddition(t *testing.T) {
 	now := time.Now()
-	seen := fakeWakePendingFiles(t, "a.md")
+	seen := wakeDoorbellTestFiles(t, "a.md")
 	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
 	cfg.doorbell.arm(seen)
 	cfg.doorbell.parkCurrentCohort()
-
-	deferredErr := &wakeInjectorDeferredError{err: errors.New("provider busy")}
+	budget := cfg.doorbell.attemptBudget
 
 	// Unchanged cohort: stays parked, no deadline.
-	recordWakeAttempt(cfg, now, seen, deferredErr)
+	recordWakeAttempt(cfg, now, seen, deferredInjectorErrorForTest())
 	if cfg.doorbell.phase != wakeDoorbellParked {
 		t.Fatalf("unchanged parked cohort phase = %v, want parked", cfg.doorbell.phase)
 	}
+	if _, armed := cfg.doorbell.nextDeadline(); armed {
+		t.Fatal("unchanged parked cohort must not regain a retry deadline")
+	}
 
-	// Addition: revives.
-	expanded := fakeWakePendingFiles(t, "a.md", "b.md")
-	recordWakeAttempt(cfg, now, expanded, deferredErr)
+	// Addition: revives, spending one lifetime-budget unit.
+	expanded := withAddedWakeFile(t, seen, "b.md")
+	recordWakeAttempt(cfg, now, expanded, deferredInjectorErrorForTest())
 	if cfg.doorbell.phase != wakeDoorbellRetrying {
 		t.Fatalf("parked+addition phase = %v, want retrying", cfg.doorbell.phase)
+	}
+	if cfg.doorbell.attemptBudget != budget+1 {
+		t.Fatalf("parked+addition budget = %d, want %d (plan()'s revive increment)", cfg.doorbell.attemptBudget, budget+1)
 	}
 	if _, armed := cfg.doorbell.nextDeadline(); !armed {
 		t.Fatal("parked+addition deferred attempt left no retry deadline")
 	}
 }
 
-func fakeWakePendingFiles(t *testing.T, names ...string) map[string]os.FileInfo {
-	t.Helper()
-	dir := t.TempDir()
-	out := make(map[string]os.FileInfo, len(names))
-	for _, name := range names {
-		path := dir + "/" + name
-		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		info, err := os.Stat(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		out[name] = info
+// The lifetime cap is the anti-spam invariant: a parked cohort that has
+// already spent wakeDoorbellLifetimeAttemptCap must NOT revive on a further
+// addition. An implementation that revives unconditionally passes the
+// addition test above and fails here.
+func TestDeferredAttemptDoesNotReviveParkedCohortPastLifetimeCap(t *testing.T) {
+	now := time.Now()
+	seen := wakeDoorbellTestFiles(t, "a.md")
+	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
+	cfg.doorbell.arm(seen)
+	cfg.doorbell.attemptBudget = wakeDoorbellLifetimeAttemptCap
+	cfg.doorbell.parkCurrentCohort()
+
+	expanded := withAddedWakeFile(t, seen, "b.md")
+	recordWakeAttempt(cfg, now, expanded, deferredInjectorErrorForTest())
+
+	if cfg.doorbell.phase != wakeDoorbellParked {
+		t.Fatalf("parked cohort at lifetime cap phase = %v, want parked", cfg.doorbell.phase)
 	}
-	return out
+	if cfg.doorbell.attemptBudget != wakeDoorbellLifetimeAttemptCap {
+		t.Fatalf("budget past cap = %d, want %d", cfg.doorbell.attemptBudget, wakeDoorbellLifetimeAttemptCap)
+	}
+	if _, armed := cfg.doorbell.nextDeadline(); armed {
+		t.Fatal("parked cohort at lifetime cap regained a retry deadline (anti-spam cap broken)")
+	}
+}
+
+// Progress on a PARKED cohort (agent drained one message, an urgent one
+// remains, the interrupt injector defers) follows plan()'s rule: reset the
+// ladder and arm the remaining cohort fresh. An expansion-only reconcile
+// leaves it parked, nextDeadline() returns nothing, and the deferred urgent
+// interrupt stalls until an unrelated inbox event.
+func TestDeferredAttemptOnParkedProgressResetsAndArms(t *testing.T) {
+	now := time.Now()
+	seen := wakeDoorbellTestFiles(t, "a.md", "urgent.md")
+	cfg := &wakeConfig{retryUntil: wakeRetryUntilInjected, injectVia: "/bin/echo"}
+	cfg.doorbell.arm(seen)
+	cfg.doorbell.parkCurrentCohort()
+
+	drained := withoutWakeFile(seen, "a.md")
+	recordWakeAttempt(cfg, now, drained, deferredInjectorErrorForTest())
+
+	if cfg.doorbell.phase != wakeDoorbellRetrying {
+		t.Fatalf("parked+progress phase = %v, want retrying", cfg.doorbell.phase)
+	}
+	if cfg.doorbell.attemptBudget != wakeDoorbellInitialAttemptBudget {
+		t.Fatalf("parked+progress budget = %d, want fresh initial budget %d", cfg.doorbell.attemptBudget, wakeDoorbellInitialAttemptBudget)
+	}
+	if len(cfg.doorbell.cohort) != 1 {
+		t.Fatalf("armed cohort after progress = %d files, want 1", len(cfg.doorbell.cohort))
+	}
+	if _, armed := cfg.doorbell.nextDeadline(); !armed {
+		t.Fatal("parked+progress deferred attempt left no retry deadline (urgent interrupt stalls)")
+	}
 }

--- a/internal/cli/wake_ledger_rotation_test.go
+++ b/internal/cli/wake_ledger_rotation_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/notificationattempt"
+)
+
+// sabotageNotificationJournalRotation fills the default-capped journal past
+// its cap with one large (valid, optional) record and puts a DIRECTORY at the
+// archive path, so every later append persists its record but fails rotation.
+// It returns the archive path so a test can clear the sabotage before List.
+func sabotageNotificationJournalRotation(t *testing.T, root string) string {
+	t.Helper()
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	// Many small valid records (List scans line by line with a bounded token
+	// size); orphan results are optional under compaction, so only the
+	// sabotaged archive path makes rotation fail.
+	var filler strings.Builder
+	for i := 0; filler.Len() < 300*1024; i++ {
+		fmt.Fprintf(&filler,
+			`{"schema":%d,"attempt_id":"fill-%d","phase":"result","message_ids":["msg-fill"],"agent":"codex","mode":"raw","recorded_at":"2026-09-01T10:00:00Z","outcome":"written","detail":"filler"}`+"\n",
+			notificationattempt.SchemaVersion, i,
+		)
+	}
+	if err := os.WriteFile(filepath.Join(dir, notificationattempt.LogFilename), []byte(filler.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rotated := filepath.Join(dir, notificationattempt.LogFilename+notificationattempt.RotatedSuffix)
+	if err := os.Mkdir(rotated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return rotated
+}
+
+// v1 path (no external injector): a rotation-only error from Prepare means the
+// prepared record persisted. The delivery result must join it normally. An
+// implementation that treats every Prepare error as "record lost" writes a
+// failure result for a real prepared record, and a successfully written
+// notification traces as `failed`.
+func TestV1RotationOnlyPrepareErrorDoesNotFabricateFailedAttempt(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	rotated := sabotageNotificationJournalRotation(t, root)
+	cfg := &wakeConfig{
+		me:            "codex",
+		root:          root,
+		wakeOwner:     &wakeOwner{},
+		injectMode:    wakeInjectModeRaw,
+		retryUntil:    wakeRetryUntilInjected,
+		terminalWrite: func(string) error { return nil },
+	}
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	if err := deliverWithNotificationLedger(cfg, []string{"msg-v1-rotation"}, peerWakeNotification("pending message"), false, current); err != nil {
+		t.Fatalf("delivery error = %v", err)
+	}
+	if err := os.Remove(rotated); err != nil {
+		t.Fatal(err)
+	}
+	attempts := listNotificationAttemptsForTest(t, root, "msg-v1-rotation")
+	if len(attempts) != 1 {
+		t.Fatalf("attempts = %+v, want exactly one", attempts)
+	}
+	if attempts[0].State != notificationattempt.OutcomeWritten {
+		t.Fatalf("attempt state under rotation-only error = %q (result %+v), want written", attempts[0].State, attempts[0].Result)
+	}
+}
+
+// v2 path: Begin under a rotation-only error returns a PERSISTED lifecycle.
+// It must be cached like any live attempt; otherwise the next scan for the
+// same cohort begins a second AttemptID and the deferred attempt's
+// transitions land on a duplicate.
+func TestV2RotationOnlyBeginCachesLiveLifecycle(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	sabotageNotificationJournalRotation(t, root)
+	cfg := protocolWakeConfigForTest(t, root, "/bin/echo", nil)
+	writer := notificationattempt.NewWriter(root, "codex")
+	ids := []string{"msg-v2-rotation"}
+	current := wakeDoorbellTestFiles(t, "pending.md")
+
+	first, err := ensureNotificationAttempt(cfg, writer, ids, current)
+	if err != nil || first == nil {
+		t.Fatalf("first ensure = (%v, %v), want live lifecycle without error", first, err)
+	}
+	if cfg.notificationAttempt == nil {
+		t.Fatal("rotation-only Begin did not cache the persisted lifecycle")
+	}
+	second, err := ensureNotificationAttempt(cfg, writer, ids, current)
+	if err != nil || second == nil {
+		t.Fatalf("second ensure = (%v, %v)", second, err)
+	}
+	if second.AttemptID != first.AttemptID {
+		t.Fatalf("second scan began a duplicate attempt %q, want cached %q", second.AttemptID, first.AttemptID)
+	}
+}

--- a/internal/cli/wake_ledger_rotation_test.go
+++ b/internal/cli/wake_ledger_rotation_test.go
@@ -1,3 +1,8 @@
+//go:build darwin || linux
+
+// These tests drive the raw (TIOCSTI) v1 delivery path and reuse the unix-only
+// wake test helpers, so they share wake_unix_test.go's build constraint.
+
 package cli
 
 import (

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -253,11 +253,19 @@ func (w *Writer) Transition(lifecycle *Lifecycle, state, detail string) error {
 		State:      state,
 		Sequence:   lifecycle.Sequence + 1,
 	}
-	if err := w.append(record); err != nil {
+	err := w.append(record)
+	if err == nil || IsRotationOnly(err) {
+		// The record landed (a rotation-only error keeps it). Advance the
+		// handle: leaving it behind makes the next transition reuse this
+		// sequence, and a repeated sequence folds the whole attempt to
+		// invalid — a delivered notification would then trace as invalid
+		// because the journal was over its cap.
+		lifecycle.State = state
+		lifecycle.Sequence = record.Sequence
+	}
+	if err != nil {
 		return fmt.Errorf("persist notification attempt transition: %w", err)
 	}
-	lifecycle.State = state
-	lifecycle.Sequence = record.Sequence
 	return nil
 }
 
@@ -323,6 +331,28 @@ func (w *Writer) Result(prepared Record, outcome, detail string) error {
 		return fmt.Errorf("persist notification attempt result: %w", err)
 	}
 	return nil
+}
+
+// WriteFailure records that an attempt was made but its prepared record could
+// not be persisted (requirement 3: trace must distinguish "recording failed"
+// from "no attempt recorded"). It reconstructs the minimal prepared identity
+// from the attempt id the failed Prepare/Begin returned and appends a failed
+// result carrying the write error, so List surfaces the orphan as a
+// write-failed attempt with its mode and normalized ids intact.
+func (w *Writer) WriteFailure(attemptID string, messageIDs []string, mode string, writeErr error) error {
+	detail := "prepared write failed"
+	if writeErr != nil {
+		detail += ": " + writeErr.Error()
+	}
+	// The caller's raw ids; a persisted prepared record carries normalized
+	// ones. Normalize so the orphan surfaces with the same ids a prepared
+	// record would have had (and an all-blank list is refused by Result).
+	return w.Result(Record{
+		AttemptID:  attemptID,
+		MessageIDs: normalizedMessageIDs(messageIDs),
+		Agent:      w.agent,
+		Mode:       strings.TrimSpace(mode),
+	}, OutcomeFailed, detail)
 }
 
 // append writes one JSON line to the log with O_APPEND. On local filesystems

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -146,12 +146,40 @@ type Writer struct {
 }
 
 func NewWriter(root, agent string) *Writer {
+	return NewWriterWithMaxBytes(root, agent, defaultMaxBytes)
+}
+
+// NewWriterWithMaxBytes is NewWriter with an explicit journal size cap.
+func NewWriterWithMaxBytes(root, agent string, maxBytes int64) *Writer {
 	return &Writer{
 		root:     root,
 		agent:    agent,
-		maxBytes: defaultMaxBytes,
+		maxBytes: maxBytes,
 		now:      time.Now,
 	}
+}
+
+// RotationError reports that the RECORD WAS PERSISTED but the size-capped
+// journal rotation around it failed or was refused. Callers distinguishing
+// "record lost" from "record kept, journal over its cap" must errors.As for
+// this type: treating a rotation-only error as a lost record fabricates a
+// failure result for an attempt whose prepared record exists (and the two
+// then join into a false `failed` attempt in trace).
+type RotationError struct {
+	Err error
+}
+
+func (e *RotationError) Error() string {
+	return fmt.Sprintf("notification attempt record persisted; journal rotation failed: %v", e.Err)
+}
+
+func (e *RotationError) Unwrap() error { return e.Err }
+
+// IsRotationOnly reports whether err means the append succeeded and only the
+// journal rotation failed.
+func IsRotationOnly(err error) bool {
+	var rotation *RotationError
+	return errors.As(err, &rotation)
 }
 
 // Prepare appends a prepared record and returns it. If the append fails, it
@@ -432,7 +460,12 @@ func (w *Writer) append(record Record) error {
 	if _, err := f.Write(data); err != nil {
 		return errors.Join(rotationErr, fmt.Errorf("write notification attempt record: %w", err))
 	}
-	return rotationErr
+	if rotationErr != nil {
+		// The record itself landed; only rotation failed. Type it so callers
+		// do not fabricate a lost-record failure for a persisted attempt.
+		return &RotationError{Err: rotationErr}
+	}
+	return nil
 }
 
 func (w *Writer) rotateJournal(root *fsq.DeliveryRoot, dir, fullPath string) error {
@@ -581,6 +614,8 @@ func foldLifecycle(prepared Record, events []Record, legacyResult *Record) Attem
 			legacyResult.Agent != prepared.Agent ||
 			legacyResult.Mode != prepared.Mode ||
 			!sameStrings(legacyResult.MessageIDs, prepared.MessageIDs) {
+			resultCopy := *legacyResult
+			attempt.History = append(attempt.History, resultCopy)
 			return attempt
 		}
 		resultCopy := *legacyResult
@@ -623,6 +658,10 @@ func foldLifecycle(prepared Record, events []Record, legacyResult *Record) Attem
 			attempt.History = append(attempt.History, resultCopy)
 			return attempt
 		}
+		// Invalid fold: keep the contradicting legacy record in History so
+		// trace shows the evidence, not just the `invalid` verdict.
+		resultCopy := *legacyResult
+		attempt.History = append(attempt.History, resultCopy)
 		return attempt
 	}
 	attempt.State = state

--- a/internal/notificationattempt/rotation_error_test.go
+++ b/internal/notificationattempt/rotation_error_test.go
@@ -1,0 +1,96 @@
+package notificationattempt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A rotation failure around a SUCCESSFUL append must surface as a typed
+// RotationError, not a plain error — callers that treat any append error as
+// "record lost" fabricate a failure result that joins the real prepared
+// record into a false `failed` attempt. Rotation is forced to fail by making
+// the .1 archive path un-writable (a directory in its place).
+func TestAppendRotationFailureIsTypedAndRecordPersists(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriterWithMaxBytes(root, "codex", 400)
+
+	// Fill past the cap so the next append rotates.
+	if _, err := writer.Prepare([]string{"msg-fill-1"}, "raw"); err != nil {
+		t.Fatalf("fill 1: %v", err)
+	}
+	if _, err := writer.Prepare([]string{"msg-fill-2"}, "raw"); err != nil && !IsRotationOnly(err) {
+		t.Fatalf("fill 2: %v", err)
+	}
+
+	// Sabotage the archive path: a DIRECTORY named notification-attempts.jsonl.1
+	// makes WriteFileAtomic's rename fail.
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	rotated := filepath.Join(dir, LogFilename+RotatedSuffix)
+	_ = os.Remove(rotated)
+	if err := os.Mkdir(rotated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := writer.Prepare([]string{"msg-under-rotation-failure"}, "raw")
+	if err == nil {
+		t.Fatal("expected a rotation error")
+	}
+	if !IsRotationOnly(err) {
+		t.Fatalf("rotation failure not typed RotationError: %v", err)
+	}
+	if prepared.AttemptID == "" {
+		t.Fatal("rotation-only error must still return the persisted record")
+	}
+	// The record must actually be on disk despite the rotation failure.
+	raw, readErr := os.ReadFile(filepath.Join(dir, LogFilename))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(raw), "msg-under-rotation-failure") {
+		t.Fatal("record was lost despite rotation-only error contract")
+	}
+	// And a genuinely lost append (unwritable journal) must NOT be typed.
+	writer2 := NewWriter("/nonexistent/root/path", "codex")
+	if _, err := writer2.Prepare([]string{"msg-lost"}, "raw"); err == nil || IsRotationOnly(err) {
+		t.Fatalf("lost append misclassified as rotation-only: %v", err)
+	}
+}
+
+// An invalid fold (contradictory terminal lifecycle + legacy result) must keep
+// the contradicting legacy record in History — trace shows evidence, not just
+// the verdict.
+func TestInvalidFoldKeepsContradictingLegacyRecordInHistory(t *testing.T) {
+	writer := NewWriter(t.TempDir(), "codex")
+	lifecycle, err := writer.Begin([]string{"msg-evidence"}, "inject-via")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := writer.Transition(lifecycle, StateAccepted, ""); err != nil {
+		t.Fatalf("Transition: %v", err)
+	}
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: lifecycle.AttemptID, Phase: PhasePrepared,
+		MessageIDs: lifecycle.MessageIDs, Agent: lifecycle.Agent, Mode: lifecycle.Mode, State: StateAttempt,
+	}
+	if err := writer.Result(prepared, OutcomeWritten, "contradicts terminal accepted"); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	attempts, err := List(writer.root, "codex", "msg-evidence")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateInvalid {
+		t.Fatalf("attempts = %+v, want one invalid", attempts)
+	}
+	found := false
+	for _, rec := range attempts[0].History {
+		if rec.Outcome == OutcomeWritten {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("invalid fold dropped the contradicting legacy record from History")
+	}
+}

--- a/internal/notificationattempt/rotation_error_test.go
+++ b/internal/notificationattempt/rotation_error_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // A rotation failure around a SUCCESSFUL append must surface as a typed
@@ -15,23 +16,8 @@ import (
 func TestAppendRotationFailureIsTypedAndRecordPersists(t *testing.T) {
 	root := t.TempDir()
 	writer := NewWriterWithMaxBytes(root, "codex", 400)
-
-	// Fill past the cap so the next append rotates.
-	if _, err := writer.Prepare([]string{"msg-fill-1"}, "raw"); err != nil {
-		t.Fatalf("fill 1: %v", err)
-	}
-	if _, err := writer.Prepare([]string{"msg-fill-2"}, "raw"); err != nil && !IsRotationOnly(err) {
-		t.Fatalf("fill 2: %v", err)
-	}
-
-	// Sabotage the archive path: a DIRECTORY named notification-attempts.jsonl.1
-	// makes WriteFileAtomic's rename fail.
+	sabotageRotation(t, root, writer)
 	dir := filepath.Join(root, "agents", "codex", "receipts")
-	rotated := filepath.Join(dir, LogFilename+RotatedSuffix)
-	_ = os.Remove(rotated)
-	if err := os.Mkdir(rotated, 0o700); err != nil {
-		t.Fatal(err)
-	}
 
 	prepared, err := writer.Prepare([]string{"msg-under-rotation-failure"}, "raw")
 	if err == nil {
@@ -92,5 +78,143 @@ func TestInvalidFoldKeepsContradictingLegacyRecordInHistory(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("invalid fold dropped the contradicting legacy record from History")
+	}
+}
+
+// sabotageRotation fills the journal past the writer's cap and puts a
+// DIRECTORY named notification-attempts.jsonl.1 at the archive path, so
+// WriteFileAtomic's rename fails and every later append persists its record
+// but fails rotation (typed RotationError).
+func sabotageRotation(t *testing.T, root string, writer *Writer) (rotatedPath string) {
+	t.Helper()
+	if _, err := writer.Prepare([]string{"msg-fill-1"}, "raw"); err != nil {
+		t.Fatalf("fill 1: %v", err)
+	}
+	if _, err := writer.Prepare([]string{"msg-fill-2"}, "raw"); err != nil && !IsRotationOnly(err) {
+		t.Fatalf("fill 2: %v", err)
+	}
+	rotated := filepath.Join(root, "agents", writer.agent, "receipts", LogFilename+RotatedSuffix)
+	_ = os.Remove(rotated)
+	if err := os.Mkdir(rotated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return rotated
+}
+
+// A rotation-only failure around a Transition must still advance the caller's
+// lifecycle handle: the record landed. An implementation that returns before
+// advancing leaves State/Sequence stale, the next Transition re-writes the
+// same sequence, and foldLifecycle rejects the attempt as invalid — a
+// delivered notification then traces as invalid because the journal was over
+// its size cap.
+func TestTransitionRotationFailureAdvancesLifecycle(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriterWithMaxBytes(root, "codex", 400)
+	rotated := sabotageRotation(t, root, writer)
+
+	lifecycle, err := writer.Begin([]string{"msg-transition-rotation"}, "inject-via")
+	if !IsRotationOnly(err) || lifecycle == nil {
+		t.Fatalf("Begin under rotation failure = (%v, %v), want lifecycle + rotation-only error", lifecycle, err)
+	}
+	err = writer.Transition(lifecycle, StateDeferred, "provider busy")
+	if !IsRotationOnly(err) {
+		t.Fatalf("Transition under rotation failure = %v, want rotation-only error", err)
+	}
+	if lifecycle.State != StateDeferred || lifecycle.Sequence != 1 {
+		t.Fatalf("lifecycle after rotation-only transition = %s/%d, want deferred/1", lifecycle.State, lifecycle.Sequence)
+	}
+	if err := writer.Transition(lifecycle, StateRetried, "provider retry attempted"); !IsRotationOnly(err) {
+		t.Fatalf("second Transition = %v, want rotation-only error", err)
+	}
+	if lifecycle.Sequence != 2 {
+		t.Fatalf("lifecycle sequence after second transition = %d, want 2", lifecycle.Sequence)
+	}
+	// Every record lives in the current journal; clear the sabotage so List
+	// can read the receipts directory.
+	if err := os.Remove(rotated); err != nil {
+		t.Fatal(err)
+	}
+	attempts, err := List(root, "codex", "msg-transition-rotation")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateRetried || len(attempts[0].History) != 3 {
+		t.Fatalf("attempts = %+v, want one retried attempt with a 3-record history", attempts)
+	}
+}
+
+// WriteFailure reconstructs the identity of an attempt whose prepared write
+// was lost. List must surface it as write_failed carrying the mode and the
+// same normalized ids a persisted prepared record would have had; an
+// implementation that copies the raw ids or drops Mode produces an orphan that
+// does not join a prepared record's shape (Mode:"" and unsorted duplicates).
+func TestWriteFailureSurfacesModeAndNormalizedIDs(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	if err := writer.WriteFailure("attempt-lost", []string{" msg-b ", "msg-a", "msg-b"}, "external", os.ErrPermission); err != nil {
+		t.Fatalf("WriteFailure: %v", err)
+	}
+	attempts, err := List(root, "codex", "msg-a")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateWriteFailed {
+		t.Fatalf("attempts = %+v, want one write_failed attempt", attempts)
+	}
+	got := attempts[0]
+	if got.Prepared.Mode != "external" || got.Result == nil || got.Result.Mode != "external" {
+		t.Fatalf("write-failed attempt lost its mode: prepared %q result %+v", got.Prepared.Mode, got.Result)
+	}
+	if !sameStrings(got.Prepared.MessageIDs, []string{"msg-a", "msg-b"}) || !sameStrings(got.Result.MessageIDs, []string{"msg-a", "msg-b"}) {
+		t.Fatalf("write-failed ids not normalized: prepared %v result %v", got.Prepared.MessageIDs, got.Result.MessageIDs)
+	}
+	if !strings.Contains(got.Result.Detail, "prepared write failed") || !strings.Contains(got.Result.Detail, os.ErrPermission.Error()) {
+		t.Fatalf("write-failed detail = %q, want the write error", got.Result.Detail)
+	}
+	if err := writer.WriteFailure("attempt-empty", []string{" ", ""}, "external", nil); err == nil {
+		t.Fatal("WriteFailure with no usable ids must refuse, not persist an unjoinable record")
+	}
+}
+
+// A v2 prepared record whose only companion is a legacy result with a
+// different identity (message set) is contradictory: the fold must stay
+// invalid AND keep the mismatched result in History as evidence. Dropping it
+// shows `invalid` with nothing to explain why.
+func TestLegacyResultWithMismatchedIdentityStaysInvalidWithEvidence(t *testing.T) {
+	root := t.TempDir()
+	writer := NewWriter(root, "codex")
+	lifecycle, err := writer.Begin([]string{"msg-mismatch"}, "external")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	mismatched := Record{
+		Schema:     SchemaVersion,
+		AttemptID:  lifecycle.AttemptID,
+		Phase:      PhaseResult,
+		MessageIDs: []string{"msg-mismatch", "msg-other"},
+		Agent:      "codex",
+		Mode:       "external",
+		RecordedAt: writer.now().UTC().Format(time.RFC3339Nano),
+		Outcome:    OutcomeWritten,
+		Detail:     "identity drift",
+	}
+	if err := writer.append(mismatched); err != nil {
+		t.Fatalf("append mismatched legacy result: %v", err)
+	}
+	attempts, err := List(root, "codex", "msg-mismatch")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateInvalid {
+		t.Fatalf("attempts = %+v, want one invalid attempt", attempts)
+	}
+	found := false
+	for _, rec := range attempts[0].History {
+		if rec.Detail == "identity drift" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("mismatched legacy result dropped from History; invalid verdict has no evidence")
 	}
 }


### PR DESCRIPTION
## Summary

Closes the #708 follow-ups deferred out of the v0.77.0 release wave (reviewer should-fix + backlog items, all evidence-verified there), plus the should-fix round from this PR's fresh-context review:

- **Deferred re-arm**: the deferred interrupt path now applies the same announced/parked cohort rules as `plan()`, through shared helpers (`reconcileAnnouncedCohort`, `reviveParkedCohort`) so the two paths cannot drift again. Announced: unseen additions or in-place replacements re-arm, progress re-snapshots. Parked: progress resets and arms the remaining cohort (an urgent deferred interrupt no longer stalls with no deadline), an addition revives only under the lifetime attempt cap, an unchanged cohort stays parked.
- **Typed `RotationError`** (+ `IsRotationOnly`): "record persisted, rotation failed" is distinguishable from "record lost". The v1 wake path no longer fabricates a failure result that joins a real prepared record into a false `failed`; the v2 path caches the live lifecycle instead of beginning a duplicate AttemptID; `Transition` advances the lifecycle handle on a rotation-only error so the next transition does not reuse a sequence and fold the delivered attempt to `invalid`.
- **Audit fidelity**: invalid folds keep the contradicting legacy record in `History`; write-failure results are recorded through one `Writer.WriteFailure` that carries `Mode` and normalized message ids (the v1 and v2 inline reconstructions are gone).

## Wake test change guard

New tests only; no existing wake test removed or weakened. Every production change is negative-proven by reverting it and watching the named test fail:

| Change | Test that fails when reverted |
| --- | --- |
| announced re-arm on addition | `TestDeferredAttemptReArmsAnnouncedCohortOnAddition` |
| announced re-arm on in-place replacement | `TestDeferredAttemptReArmsAnnouncedCohortOnInPlaceReplacement` |
| announced progress re-snapshot | `TestDeferredAttemptOnAnnouncedProgressReSnapshotsWithoutReArm` |
| parked revive on addition (+budget increment) | `TestDeferredAttemptRevivesParkedCohortOnlyOnAddition` |
| lifetime cap guard | `TestDeferredAttemptDoesNotReviveParkedCohortPastLifetimeCap` |
| parked progress reset+arm | `TestDeferredAttemptOnParkedProgressResetsAndArms` |
| v1 rotation-only clearing | `TestV1RotationOnlyPrepareErrorDoesNotFabricateFailedAttempt` |
| v2 rotation-only lifecycle caching | `TestV2RotationOnlyBeginCachesLiveLifecycle` |
| Transition advance on rotation-only | `TestTransitionRotationFailureAdvancesLifecycle` |
| WriteFailure mode + normalized ids | `TestWriteFailureSurfacesModeAndNormalizedIDs` |
| fold keeps mismatched legacy evidence | `TestLegacyResultWithMismatchedIdentityStaysInvalidWithEvidence` |
| typed rotation error, record persists | `TestAppendRotationFailureIsTypedAndRecordPersists` |
| fold keeps contradicting legacy record | `TestInvalidFoldKeepsContradictingLegacyRecordInHistory` |

## Verification

gofmt/vet clean on the changed packages; `internal/notificationattempt` and all `internal/keepalive` packages green; focused `internal/cli` wake suites green. Full local `go test ./internal/cli` is subject to the documented #707 machine-state poison, tracked separately.

Refs #708 (one backlog bullet stays open: contradictory terminal+legacy history laundering through per-attempt compaction; see the issue comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
