### PR TITLE
fix(test): isolate the test cwd from live queues and stop ledger appends recreating mailboxes

### DIFF
--- a/internal/cli/implicit_root_registration_test.go
+++ b/internal/cli/implicit_root_registration_test.go
@@ -11,17 +11,22 @@ import (
 )
 
 func TestProductionDefaultRootCallsStayBehindErrorPreservingRegistration(t *testing.T) {
-	entries, err := os.ReadDir(".")
+	// The process cwd is the secure temp root (TestMain, issue #707), so scan
+	// the package source directory explicitly. A scan of cwd here would see
+	// zero production files and pass this architecture guard vacuously.
+	entries, err := os.ReadDir(cliTestPackageDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	files := token.NewFileSet()
+	scanned := 0
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		file, err := parser.ParseFile(files, filepath.Join(".", name), nil, 0)
+		scanned++
+		file, err := parser.ParseFile(files, filepath.Join(cliTestPackageDir, name), nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", name, err)
 		}
@@ -45,5 +50,8 @@ func TestProductionDefaultRootCallsStayBehindErrorPreservingRegistration(t *test
 				return true
 			})
 		}
+	}
+	if scanned == 0 {
+		t.Fatalf("scanned no production files under %s; the guard is vacuous", cliTestPackageDir)
 	}
 }

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -406,7 +406,7 @@ func TestResolveRealAMQBinaryRejectsRelativePath(t *testing.T) {
 
 func buildAdoptionSmokeAMQ(t *testing.T) string {
 	t.Helper()
-	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	repoRoot, err := cliTestRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -203,7 +203,7 @@ func TestV061PrepareV0611ApplyCompatibility(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and executes two real amq binaries")
 	}
-	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	repoRoot, err := cliTestRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -397,7 +397,7 @@ func TestCLIResultEncoderUsesPackageGoldens(t *testing.T) {
 		{file: "prepare_result_v1.golden.json", result: &launchapi.PrepareResultV1{}},
 		{file: "apply_result_v1.golden.json", result: &launchapi.ApplyResultV1{}},
 	} {
-		golden, err := os.ReadFile(filepath.Join("..", "..", "launchapi", "testdata", test.file))
+		golden, err := os.ReadFile(filepath.Join(cliTestPackageDir, "..", "..", "launchapi", "testdata", test.file))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -446,7 +446,7 @@ func dereferenceGoldenResult(result any) any {
 }
 
 func TestCLIAndPackageResultGoldenParity(t *testing.T) {
-	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	repoRoot, err := cliTestRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/launch_tmux_e2e_test.go
+++ b/internal/cli/launch_tmux_e2e_test.go
@@ -26,7 +26,7 @@ func TestTmuxRealBinaryFreshServerRestartResumeLoop(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux is not installed")
 	}
-	repo, err := filepath.Abs(filepath.Join("..", ".."))
+	repo, err := cliTestRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestRunRealAMQJSONParseIgnoresUpdateHintOnStderr(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and executes the real amq binary")
 	}
-	repo, err := filepath.Abs(filepath.Join("..", ".."))
+	repo, err := cliTestRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/main_cwd_isolation_test.go
+++ b/internal/cli/main_cwd_isolation_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The test process must not run from inside a checkout that can carry a live
+// queue: the cwd-local routing guard would read that queue as repo-local
+// evidence and refuse every pinned temp-root operation (issue #707). Reverting
+// the TestMain chdir fails this everywhere, not only on a poisoned machine.
+func TestProcessWorkingDirectoryIsIsolatedFromRepoLocalQueue(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(cliSecureTempRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("test cwd = %s, want the secure temp root %s", got, want)
+	}
+	local, ok, err := cwdLocalMailboxRootForSession("")
+	if err != nil {
+		t.Fatalf("cwd-local probe: %v", err)
+	}
+	if ok {
+		t.Fatalf("cwd-local probe found an initialized queue %s from the test cwd", local)
+	}
+}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -66,6 +66,25 @@ func TestMain(m *testing.M) {
 	}
 
 	cliSecureTempRoot = tempRoot
+	workingDir, err := os.Getwd()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "resolve test working directory: %v\n", err)
+		_ = os.RemoveAll(tempRoot)
+		os.Exit(1)
+	}
+	// Run every test from the secure temp root, not the package directory.
+	// The cwd-local routing guard walks up from cwd to the Git top looking for
+	// an initialized .agent-mail; on a developer checkout that finds the live
+	// queue, and every test that pins a temp root then fails with "active
+	// root ... conflicts with initialized repo-local root ... detected from
+	// cwd" (issue #707). CI never sees this because its checkout has no queue.
+	// The temp root sits directly under HOME, which the walk treats as global
+	// state rather than repo-local evidence.
+	if err := os.Chdir(tempRoot); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "isolate test working directory: %v\n", err)
+		_ = os.RemoveAll(tempRoot)
+		os.Exit(1)
+	}
 
 	// Isolate the update-check cache (issue #646 class) so tests that drive
 	// runUpgrade / the update Notifier never write through to the developer's
@@ -91,6 +110,10 @@ func TestMain(m *testing.M) {
 	}
 
 	exitCode := m.Run()
+	if err := os.Chdir(workingDir); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "restore test working directory: %v\n", err)
+		exitCode = 1
+	}
 	cliSecureTempRoot = ""
 	if err := os.RemoveAll(tempRoot); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "remove secure test temp root: %v\n", err)

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -92,7 +92,11 @@ func TestMain(m *testing.M) {
 	// root ... conflicts with initialized repo-local root ... detected from
 	// cwd" (issue #707). CI never sees this because its checkout has no queue.
 	// The temp root sits directly under HOME, which the walk treats as global
-	// state rather than repo-local evidence.
+	// state rather than repo-local evidence, unless HOME is itself a Git
+	// worktree (dotfiles kept as a repo in HOME): then the walk's ceiling is
+	// HOME, ~/.amqrc becomes worktree-local authority, and the same refusal
+	// returns. TestProcessWorkingDirectoryIsIsolatedFromRepoLocalQueue names
+	// that state instead of letting pinned tests fail one by one.
 	if err := os.Chdir(tempRoot); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "isolate test working directory: %v\n", err)
 		_ = os.RemoveAll(tempRoot)

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -17,6 +17,18 @@ const (
 
 var cliSecureTempRoot string
 
+// cliTestPackageDir is the package source directory the test process started
+// in. TestMain moves the process cwd to the secure temp root (issue #707), so
+// tests that need the repository (building ./cmd/amq, launchapi goldens, git
+// history) resolve it from here instead of from cwd.
+var cliTestPackageDir string
+
+// cliTestRepoRoot returns the absolute repository root for tests that build or
+// read repository files. It does not depend on the process cwd.
+func cliTestRepoRoot() (string, error) {
+	return filepath.Abs(filepath.Join(cliTestPackageDir, "..", ".."))
+}
+
 // TestMain gives the cli package a hermetic environment so the developer's shell
 // can't leak routing context into tests. The cross-tree send guard (issue #144)
 // keys off AM_ROOT / AM_BASE_ROOT; without this, running the suite from inside a
@@ -72,6 +84,7 @@ func TestMain(m *testing.M) {
 		_ = os.RemoveAll(tempRoot)
 		os.Exit(1)
 	}
+	cliTestPackageDir = workingDir
 	// Run every test from the secure temp root, not the package directory.
 	// The cwd-local routing guard walks up from cwd to the Git top looking for
 	// an initialized .agent-mail; on a developer checkout that finds the live

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/update"
@@ -17,11 +18,17 @@ const (
 
 var cliSecureTempRoot string
 
-// cliTestPackageDir is the package source directory the test process started
-// in. TestMain moves the process cwd to the secure temp root (issue #707), so
-// tests that need the repository (building ./cmd/amq, launchapi goldens, git
-// history) resolve it from here instead of from cwd.
-var cliTestPackageDir string
+// cliTestPackageDir is this package's source directory, resolved from the
+// test source file itself rather than from cwd. TestMain moves the process cwd
+// to the secure temp root (issue #707), so tests that need the repository
+// (building ./cmd/amq, launchapi goldens, git history) resolve it from here.
+var cliTestPackageDir = func() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("resolve cli test package directory: runtime.Caller failed")
+	}
+	return filepath.Dir(file)
+}()
 
 // cliTestRepoRoot returns the absolute repository root for tests that build or
 // read repository files. It does not depend on the process cwd.
@@ -84,7 +91,6 @@ func TestMain(m *testing.M) {
 		_ = os.RemoveAll(tempRoot)
 		os.Exit(1)
 	}
-	cliTestPackageDir = workingDir
 	// Run every test from the secure temp root, not the package directory.
 	// The cwd-local routing guard walks up from cwd to the Git top looking for
 	// an initialized .agent-mail; on a developer checkout that finds the live

--- a/internal/cli/wake_brew_upgrade_two_binary_e2e_darwin_test.go
+++ b/internal/cli/wake_brew_upgrade_two_binary_e2e_darwin_test.go
@@ -41,7 +41,7 @@ func TestTwoBinaryBrewUpgradeStaleLockRemoval(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and executes two real amq binaries")
 	}
-	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	repoRoot, err := cliTestRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wake_owner_mixed_version_test.go
+++ b/internal/cli/wake_owner_mixed_version_test.go
@@ -23,7 +23,7 @@ const wakeStateLegacyWriterCommit = "fbc574a8d2b26b2526dfae5d9c5c87408007ac39"
 const wakeStateP2aRollbackCommit = "acd9e35511f0d5f13c9ed68349929bfcf488cecf"
 
 func TestOwnerFencePreservesClaimAgainstExactE370Binary(t *testing.T) {
-	repoRootCommand := exec.Command("git", "rev-parse", "--show-toplevel")
+	repoRootCommand := exec.Command("git", "-C", cliTestPackageDir, "rev-parse", "--show-toplevel")
 	repoRootOutput, err := repoRootCommand.CombinedOutput()
 	if err != nil {
 		t.Skipf("mixed-version git history unavailable: %v", err)
@@ -621,7 +621,7 @@ func runHistoricalDoctorOpsForCoexistenceTest(t *testing.T, binary, root string)
 
 func buildHistoricalAMQForWakeStateTest(t *testing.T, commit string) string {
 	t.Helper()
-	repoRootOutput, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	repoRootOutput, err := exec.Command("git", "-C", cliTestPackageDir, "rev-parse", "--show-toplevel").CombinedOutput()
 	if err != nil {
 		t.Skipf("mixed-version git history unavailable: %v", err)
 	}

--- a/internal/cli/wake_self_upgrade_mixed_version_unix_test.go
+++ b/internal/cli/wake_self_upgrade_mixed_version_unix_test.go
@@ -46,7 +46,7 @@ func TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0580Reader(t *testing.T) {
 
 func extractWakeSelfUpgradeHistoricalV0580(t *testing.T) string {
 	t.Helper()
-	repoRootOutput, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	repoRootOutput, err := exec.Command("git", "-C", cliTestPackageDir, "rev-parse", "--show-toplevel").CombinedOutput()
 	if err != nil {
 		t.Fatalf("mixed-version git history unavailable: %v", err)
 	}

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -466,6 +466,22 @@ func (r *DeliveryRoot) EnsureAgentDirs(agent string) error {
 	return nil
 }
 
+// EnsureAgentDir creates exactly one mailbox leaf for an agent through the
+// pinned root capability. Writers that own a single leaf (for example the
+// notification-attempt ledger under receipts) use this instead of
+// EnsureAgentDirs so a routine write never recreates inbox or DLQ components
+// an operator or repair path deliberately removed or replaced. Mailbox
+// provisioning stays explicit: init, coop, and launch own EnsureAgentDirs.
+func (r *DeliveryRoot) EnsureAgentDir(agent string, leaf MailboxLeaf) error {
+	if err := ValidateHandle(agent); err != nil {
+		return err
+	}
+	if err := r.VerifyBase(); err != nil {
+		return err
+	}
+	return r.root.MkdirAll(MailboxRootRelativePath(agent, leaf), 0o700)
+}
+
 // LayoutState classifies a pinned root's top-level queue layout.
 type LayoutState int
 

--- a/internal/fsq/delivery_root_agent_dir_test.go
+++ b/internal/fsq/delivery_root_agent_dir_test.go
@@ -1,0 +1,45 @@
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// EnsureAgentDir creates exactly the requested leaf. A writer that owns one
+// leaf must not provision the rest of the mailbox as a side effect; an
+// implementation that delegates to EnsureAgentDirs fails the inbox assertion.
+func TestEnsureAgentDirCreatesOnlyTheRequestedLeaf(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	identity, err := SnapshotDeliveryRoot(root)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	delivery, err := OpenDeliveryRoot(root, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = delivery.Close() }()
+
+	if err := delivery.EnsureAgentDir("codex", MailboxReceipts); err != nil {
+		t.Fatalf("EnsureAgentDir: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(root, "agents", "codex", "receipts"))
+	if err != nil || !info.IsDir() {
+		t.Fatalf("receipts leaf not created: info=%v err=%v", info, err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("receipts leaf mode = %o, want 0700", info.Mode().Perm())
+	}
+	for _, other := range []string{"inbox", "outbox", "dlq"} {
+		if _, err := os.Lstat(filepath.Join(root, "agents", "codex", other)); !os.IsNotExist(err) {
+			t.Fatalf("EnsureAgentDir(receipts) also created %s (err=%v)", other, err)
+		}
+	}
+	if err := delivery.EnsureAgentDir("../escape", MailboxReceipts); err == nil {
+		t.Fatal("EnsureAgentDir accepted a path-traversal handle")
+	}
+}

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -309,7 +309,11 @@ func (w *Writer) append(record Record) error {
 	}
 	defer func() { _ = root.Close() }()
 
-	if err := root.EnsureAgentDirs(w.agent); err != nil {
+	// Only the receipts leaf: a ledger append must never recreate inbox or
+	// DLQ components as a side effect. A repaired wake writes its result
+	// record after the doorbell lands, and recreating a replaced inbox in
+	// that window races the operator (issue #707).
+	if err := root.EnsureAgentDir(w.agent, fsq.MailboxReceipts); err != nil {
 		return fmt.Errorf("ensure notification attempt receipts dir: %w", err)
 	}
 	dir := filepath.Join("agents", w.agent, "receipts")

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -773,3 +773,46 @@ func itoa(i int) string {
 	}
 	return string(buf[pos:])
 }
+
+// A ledger append must create only its own receipts leaf. Recreating a
+// removed inbox component as a side effect of writing a receipt races the
+// operator or repair path that removed it (issue #707: the repaired wake's
+// result append re-created agents/codex/inbox between a test's rename and
+// mkdir, failing with "file exists" only under cross-package load). An
+// implementation that calls EnsureAgentDirs here fails this test.
+func TestAppendDoesNotRecreateRemovedInboxComponent(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	inbox := filepath.Join(fsq.AgentBase(root, "codex"), "inbox")
+	if err := os.RemoveAll(inbox); err != nil {
+		t.Fatal(err)
+	}
+	dlq := filepath.Join(fsq.AgentBase(root, "codex"), "dlq")
+	if err := os.RemoveAll(dlq); err != nil {
+		t.Fatal(err)
+	}
+
+	writer := NewWriter(root, "codex")
+	if _, err := writer.Prepare([]string{"msg-no-recreate"}, "raw"); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	for _, removed := range []string{inbox, dlq} {
+		if _, err := os.Lstat(removed); !os.IsNotExist(err) {
+			t.Fatalf("ledger append recreated removed mailbox component %s (err=%v)", removed, err)
+		}
+	}
+	// The receipts leaf itself is still created on demand for a fresh agent.
+	fresh := NewWriter(root, "claude")
+	if _, err := fresh.Prepare([]string{"msg-fresh"}, "raw"); err != nil {
+		t.Fatalf("Prepare for fresh agent: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentBase(root, "claude"), "receipts", LogFilename)); err != nil {
+		t.Fatalf("receipts leaf not created on demand: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Root-causes and fixes both #707 symptoms. Neither was what the issue guessed.

**Symptom 2 is the developer's live queue, not stale TMPDIR state.** The test process runs from the package directory under the checkout. The cwd-local routing guard (`cwdLocalMailboxRootForSession`) walks up from cwd to the Git top and finds the checkout's initialized `.agent-mail`, so every test that pins a temp root is refused with `active root ... conflicts with initialized repo-local root ... detected from cwd`. Scrubbing `AM_*` cannot clear it because the evidence is a directory, not an env var. CI never sees it because its checkout has no queue; a worktree does not reproduce it for the same reason. Fix: `TestMain` runs the process from the secure temp root under `HOME`, which the walk treats as global state rather than repo-local evidence. Doctor and cleanup need no change: there is no stale marker, and the refusal already names the repin remedy.

Moving the cwd exposed nine tests that resolved the repository from cwd (building `./cmd/amq`, launchapi goldens, `git rev-parse --show-toplevel`). They now resolve it from the package directory recorded in `TestMain` (`cliTestRepoRoot`), so they pass from any cwd.

**Symptom 1 is a real race in production code.** The notification-attempt ledger append called `EnsureAgentDirs`, recreating `inbox/{tmp,new,cur}` as a side effect of writing a receipt. The repaired wake writes its result record after the doorbell output line the fixture waits for, so under cross-package load it recreated the inbox between the fixture's rename and mkdir. Fix: `DeliveryRoot.EnsureAgentDir(agent, leaf)` creates exactly one leaf, and the ledger ensures only `receipts`. Mailbox provisioning stays with init, coop, and launch.

## Wake test change guard

No existing test removed or weakened. New tests, each negative-proven by reverting the named change:

| Change | Test that fails when reverted |
| --- | --- |
| TestMain chdir into the secure temp root | `TestProcessWorkingDirectoryIsIsolatedFromRepoLocalQueue` (fails everywhere, not only on a poisoned machine) |
| ledger ensures only the receipts leaf | `TestAppendDoesNotRecreateRemovedInboxComponent` |
| `EnsureAgentDir` creates one leaf, validates the handle | `TestEnsureAgentDirCreatesOnlyTheRequestedLeaf` |

## Verification

- Symptom 2 reproduced on clean main (a2b30f3) from the main checkout: a full `go test ./internal/cli` fails 15 tests, all with the cwd-conflict refusal (two surface as `exit code = 5, want 2`). The full test binary built from this branch, run from that same poisoned cwd, passes.
- `TestRepairedWakeExitsWithoutInjectingAfterInboxComponentReplacement` green at `-count=10` and the repair suite green on the fixed tree.
- `internal/fsq`, `internal/notificationattempt`, focused `internal/cli` green; `GOOS=windows go vet ./...` clean.

Fixes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
