### PR TITLE
fix(trace): preserve contradictory ledger history through compaction

### DIFF
--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -880,7 +880,7 @@ func compactRecords(records []Record, agent string, maxBytes int64) ([]byte, err
 		archive = candidate
 	}
 
-	if err := validateCompactedRecords(archive, agent); err != nil {
+	if err := validateCompactedRecords(archive, groups, agent); err != nil {
 		return nil, fmt.Errorf("validate compacted notification attempt journal: %w", err)
 	}
 	return marshalRecords(archive)
@@ -953,6 +953,23 @@ func compactAttempt(id string, records []Record) (compactedAttempt, error) {
 
 	if len(legacyResults) > 0 {
 		if legacy := matchingLegacyResult(*prepared, legacyResults); legacy != nil {
+			if len(lifecycle) > 0 {
+				// A legacy close on top of a lifecycle is only valid while the
+				// lifecycle is nonterminal. On a TERMINAL lifecycle it is
+				// contradictory history; compacting it to [prepared, legacy]
+				// would re-fold as a clean `written` and launder the
+				// contradiction (issue #708). Keep the whole group verbatim
+				// so the verdict and its evidence survive rotation.
+				orderedLifecycle := append([]Record{}, lifecycle...)
+				sort.SliceStable(orderedLifecycle, func(i, j int) bool {
+					return orderedLifecycle[i].Sequence < orderedLifecycle[j].Sequence
+				})
+				if foldLifecycle(*prepared, orderedLifecycle, legacy).State == StateInvalid {
+					result.records = append([]Record{}, ordered...)
+					result.mandatory = true
+					return result, nil
+				}
+			}
 			// Marker-less external injectors use a v2 prepared lifecycle record
 			// followed by a v1-shaped written result. Preserve that compatibility
 			// taxonomy instead of turning a terminal result back into "attempt".
@@ -1049,7 +1066,16 @@ func marshalRecords(records []Record) ([]byte, error) {
 	return data.Bytes(), nil
 }
 
-func validateCompactedRecords(records []Record, agent string) error {
+// validateCompactedRecords checks that a compacted archive is well formed and
+// that compaction did not change any attempt's verdict. original is the
+// pre-compaction record set grouped by attempt id; when it is nil (tests
+// validating a hand-built archive) an invalid fold is rejected outright.
+// When it is present, an invalid fold is acceptable only if the original
+// group also folded invalid and was preserved record-for-record: a
+// contradictory history is evidence that must survive rotation, while a
+// compaction that turns a valid history invalid, or an invalid one valid, is
+// a defect.
+func validateCompactedRecords(records []Record, original map[string][]Record, agent string) error {
 	for _, record := range records {
 		if err := validateRecord(record, agent); err != nil {
 			return err
@@ -1060,33 +1086,87 @@ func validateCompactedRecords(records []Record, agent string) error {
 		byAttempt[record.AttemptID] = append(byAttempt[record.AttemptID], record)
 	}
 	for attemptID, group := range byAttempt {
-		var prepared *Record
-		var events []Record
-		var legacy *Record
-		for i := range group {
-			record := group[i]
-			switch {
-			case record.Phase == PhasePrepared && prepared == nil:
-				copy := record
-				prepared = &copy
-			case record.Phase == PhaseResult && record.State != "":
-				events = append(events, record)
-			case record.Phase == PhaseResult && legacy == nil:
-				copy := record
-				legacy = &copy
-			}
-		}
-		if prepared == nil ||
-			prepared.Schema == legacySchemaVersion ||
-			(prepared.State == "" && len(events) == 0) {
+		folded, ok := foldRecordGroup(group)
+		if !ok {
 			continue
 		}
-		folded := foldLifecycle(*prepared, events, legacy)
+		var originalFolded *Attempt
+		if original != nil {
+			if originalGroup, present := original[attemptID]; present {
+				if attempt, ok := foldRecordGroup(deduplicateRecords(originalGroup)); ok {
+					originalFolded = &attempt
+				}
+			}
+		}
 		if folded.State == StateInvalid {
-			return fmt.Errorf("attempt %q has invalid compacted lifecycle", attemptID)
+			if originalFolded == nil || originalFolded.State != StateInvalid {
+				return fmt.Errorf("attempt %q has invalid compacted lifecycle", attemptID)
+			}
+			if !sameRecordIdentities(group, deduplicateRecords(original[attemptID])) {
+				return fmt.Errorf("attempt %q: contradictory history was not preserved verbatim through compaction", attemptID)
+			}
+			continue
+		}
+		if originalFolded != nil && originalFolded.State != folded.State {
+			return fmt.Errorf(
+				"attempt %q: compaction changed the verdict from %q to %q",
+				attemptID, originalFolded.State, folded.State,
+			)
 		}
 	}
 	return nil
+}
+
+// sameRecordIdentities reports whether two record groups carry exactly the
+// same records by deduplication identity (schema, attempt, sequence, phase).
+func sameRecordIdentities(left, right []Record) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	seen := make(map[recordDedupKey]int, len(left))
+	for _, record := range left {
+		seen[recordDeduplicationKey(record)]++
+	}
+	for _, record := range right {
+		key := recordDeduplicationKey(record)
+		if seen[key] == 0 {
+			return false
+		}
+		seen[key]--
+	}
+	return true
+}
+
+// foldRecordGroup folds one attempt's records the way List does. ok is false
+// when the group carries no v2 lifecycle information to fold (no prepared
+// record, a legacy v1 prepared record, or a v1-shaped pair with no events).
+func foldRecordGroup(group []Record) (Attempt, bool) {
+	var prepared *Record
+	var events []Record
+	var legacy *Record
+	for i := range group {
+		record := group[i]
+		switch {
+		case record.Phase == PhasePrepared && prepared == nil:
+			copy := record
+			prepared = &copy
+		case record.Phase == PhaseResult && record.State != "":
+			events = append(events, record)
+		case record.Phase == PhaseResult && legacy == nil:
+			copy := record
+			legacy = &copy
+		}
+	}
+	if prepared == nil ||
+		prepared.Schema == legacySchemaVersion ||
+		(prepared.State == "" && len(events) == 0) {
+		return Attempt{}, false
+	}
+	ordered := append([]Record{}, events...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Sequence < ordered[j].Sequence
+	})
+	return foldLifecycle(*prepared, ordered, legacy), true
 }
 
 // validateRecord checks the invariants a Record must satisfy. SchemaVersion

--- a/internal/notificationattempt/ledger.go
+++ b/internal/notificationattempt/ledger.go
@@ -857,7 +857,7 @@ func compactRecords(records []Record, agent string, maxBytes int64) ([]byte, err
 	}
 	if int64(len(mandatoryData)) > maxBytes {
 		return nil, fmt.Errorf(
-			"notification attempt journal compaction needs %d bytes for nonterminal attempts, cap is %d",
+			"notification attempt journal compaction needs %d bytes for nonterminal attempts and preserved contradictory history, cap is %d",
 			len(mandatoryData), maxBytes,
 		)
 	}
@@ -951,32 +951,31 @@ func compactAttempt(id string, records []Record) (compactedAttempt, error) {
 		return result, nil
 	}
 
+	orderedLifecycle := append([]Record{}, lifecycle...)
+	sort.SliceStable(orderedLifecycle, func(i, j int) bool {
+		return orderedLifecycle[i].Sequence < orderedLifecycle[j].Sequence
+	})
 	if len(legacyResults) > 0 {
-		if legacy := matchingLegacyResult(*prepared, legacyResults); legacy != nil {
-			if len(lifecycle) > 0 {
-				// A legacy close on top of a lifecycle is only valid while the
-				// lifecycle is nonterminal. On a TERMINAL lifecycle it is
-				// contradictory history; compacting it to [prepared, legacy]
-				// would re-fold as a clean `written` and launder the
-				// contradiction (issue #708). Keep the whole group verbatim
-				// so the verdict and its evidence survive rotation.
-				orderedLifecycle := append([]Record{}, lifecycle...)
-				sort.SliceStable(orderedLifecycle, func(i, j int) bool {
-					return orderedLifecycle[i].Sequence < orderedLifecycle[j].Sequence
-				})
-				if foldLifecycle(*prepared, orderedLifecycle, legacy).State == StateInvalid {
-					result.records = append([]Record{}, ordered...)
-					result.mandatory = true
-					return result, nil
-				}
-			}
+		// List keeps the LAST legacy result it reads for an attempt, so fold
+		// against that record, not the last matching one: a matching legacy
+		// result followed by an unmatched one renders invalid in trace.
+		legacy := legacyResults[len(legacyResults)-1]
+		if foldLifecycle(*prepared, orderedLifecycle, &legacy).State != StateInvalid {
 			// Marker-less external injectors use a v2 prepared lifecycle record
 			// followed by a v1-shaped written result. Preserve that compatibility
 			// taxonomy instead of turning a terminal result back into "attempt".
-			result.records = []Record{*prepared, *legacy}
+			result.records = []Record{*prepared, legacy}
 			return result, nil
 		}
-		result.records = []Record{*prepared}
+		// Contradictory history (a legacy close on a terminal lifecycle, or a
+		// legacy result whose identity does not match). Compacting it to
+		// [prepared, legacy] or [prepared] would re-fold as a clean verdict
+		// and launder the contradiction through rotation (issue #708). Keep
+		// the verdict AND the contradicting record, bounded: prepared, the
+		// latest lifecycle event, and the legacy record re-fold invalid for
+		// every contradiction class; fall back to the verbatim group only if
+		// the lifecycle itself is corrupt enough that the bound would not.
+		result.records = preserveContradictoryGroup(*prepared, orderedLifecycle, legacy, ordered)
 		result.mandatory = true
 		return result, nil
 	}
@@ -986,13 +985,12 @@ func compactAttempt(id string, records []Record) (compactedAttempt, error) {
 		return result, nil
 	}
 
-	orderedLifecycle := append([]Record{}, lifecycle...)
-	sort.SliceStable(orderedLifecycle, func(i, j int) bool {
-		return orderedLifecycle[i].Sequence < orderedLifecycle[j].Sequence
-	})
 	folded := foldLifecycle(*prepared, orderedLifecycle, nil)
 	if folded.State == StateInvalid {
-		result.records = []Record{*prepared}
+		// A corrupt lifecycle (sequence reuse, illegal transition) renders
+		// invalid in trace. Dropping the events would re-fold as a clean
+		// `attempt` and hide the corruption; keep the evidence verbatim.
+		result.records = append([]Record{}, ordered...)
 		result.mandatory = true
 		return result, nil
 	}
@@ -1071,7 +1069,8 @@ func marshalRecords(records []Record) ([]byte, error) {
 // pre-compaction record set grouped by attempt id; when it is nil (tests
 // validating a hand-built archive) an invalid fold is rejected outright.
 // When it is present, an invalid fold is acceptable only if the original
-// group also folded invalid and was preserved record-for-record: a
+// group also folded invalid and the compacted group is drawn from the
+// original records with its contradicting legacy record retained: a
 // contradictory history is evidence that must survive rotation, while a
 // compaction that turns a valid history invalid, or an invalid one valid, is
 // a defect.
@@ -1091,9 +1090,11 @@ func validateCompactedRecords(records []Record, original map[string][]Record, ag
 			continue
 		}
 		var originalFolded *Attempt
+		var originalGroup []Record
 		if original != nil {
-			if originalGroup, present := original[attemptID]; present {
-				if attempt, ok := foldRecordGroup(deduplicateRecords(originalGroup)); ok {
+			if candidate, present := original[attemptID]; present {
+				originalGroup = deduplicateRecords(candidate)
+				if attempt, ok := foldRecordGroup(originalGroup); ok {
 					originalFolded = &attempt
 				}
 			}
@@ -1102,8 +1103,13 @@ func validateCompactedRecords(records []Record, original map[string][]Record, ag
 			if originalFolded == nil || originalFolded.State != StateInvalid {
 				return fmt.Errorf("attempt %q has invalid compacted lifecycle", attemptID)
 			}
-			if !sameRecordIdentities(group, deduplicateRecords(original[attemptID])) {
-				return fmt.Errorf("attempt %q: contradictory history was not preserved verbatim through compaction", attemptID)
+			// A preserved contradiction must be drawn from the original records
+			// (nothing synthesized) and must keep the contradicting legacy
+			// record when the original had one: the verdict without its
+			// evidence is not audit history.
+			if !recordGroupIsSubset(group, originalGroup) ||
+				(hasLegacyResult(originalGroup) && !hasLegacyResult(group)) {
+				return fmt.Errorf("attempt %q: contradictory history lost its evidence through compaction", attemptID)
 			}
 			continue
 		}
@@ -1117,24 +1123,50 @@ func validateCompactedRecords(records []Record, original map[string][]Record, ag
 	return nil
 }
 
-// sameRecordIdentities reports whether two record groups carry exactly the
-// same records by deduplication identity (schema, attempt, sequence, phase).
-func sameRecordIdentities(left, right []Record) bool {
-	if len(left) != len(right) {
-		return false
+// preserveContradictoryGroup returns the smallest record set that still folds
+// to the same invalid verdict as the full group and retains the contradicting
+// legacy record: prepared, the latest lifecycle event (if any), and the legacy
+// result. When even that bound would fold valid (the lifecycle itself is
+// corrupt in a way the bound hides), the full group is returned verbatim.
+func preserveContradictoryGroup(prepared Record, orderedLifecycle []Record, legacy Record, full []Record) []Record {
+	bounded := []Record{prepared}
+	var boundedEvents []Record
+	if len(orderedLifecycle) > 0 {
+		latest := orderedLifecycle[len(orderedLifecycle)-1]
+		bounded = append(bounded, latest)
+		boundedEvents = []Record{latest}
 	}
-	seen := make(map[recordDedupKey]int, len(left))
-	for _, record := range left {
-		seen[recordDeduplicationKey(record)]++
+	bounded = append(bounded, legacy)
+	if foldLifecycle(prepared, boundedEvents, &legacy).State == StateInvalid {
+		return bounded
 	}
-	for _, record := range right {
+	return append([]Record{}, full...)
+}
+
+// recordGroupIsSubset reports whether every record in group has an identity
+// (schema, attempt, sequence, phase) present in original, with multiplicity.
+func recordGroupIsSubset(group, original []Record) bool {
+	available := make(map[recordDedupKey]int, len(original))
+	for _, record := range original {
+		available[recordDeduplicationKey(record)]++
+	}
+	for _, record := range group {
 		key := recordDeduplicationKey(record)
-		if seen[key] == 0 {
+		if available[key] == 0 {
 			return false
 		}
-		seen[key]--
+		available[key]--
 	}
 	return true
+}
+
+func hasLegacyResult(group []Record) bool {
+	for _, record := range group {
+		if record.Phase == PhaseResult && record.State == "" {
+			return true
+		}
+	}
+	return false
 }
 
 // foldRecordGroup folds one attempt's records the way List does. ok is false

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -1054,14 +1054,149 @@ func TestValidateCompactedRecordsRejectsVerdictChange(t *testing.T) {
 	if err := validateCompactedRecords(preserved, nil, "codex"); err == nil {
 		t.Fatal("validator accepted an invalid archive with no original context")
 	}
-	// Dropping the evidence record while staying invalid is also refused:
-	// the group must be preserved record-for-record.
-	partial := []Record{prepared, accepted, {
+	// Staying invalid is not enough: the contradicting legacy record must be
+	// retained, and nothing may be synthesized.
+	withoutEvidence := []Record{prepared, accepted, {
 		Schema: SchemaVersion, AttemptID: "laundered", Phase: PhaseResult,
 		MessageIDs: prepared.MessageIDs, Agent: "codex", Mode: "external",
 		RecordedAt: "2026-09-01T10:00:03Z", State: StateDeferred, Sequence: 2,
 	}}
-	if err := validateCompactedRecords(partial, original, "codex"); err == nil {
-		t.Fatal("validator accepted an invalid group that was not preserved verbatim")
+	if err := validateCompactedRecords(withoutEvidence, original, "codex"); err == nil {
+		t.Fatal("validator accepted an invalid group that dropped the contradicting legacy record")
+	}
+	synthesized := prepared
+	synthesized.Phase = PhaseResult
+	synthesized.State = StateFailed
+	synthesized.Sequence = 7
+	synthesized.RecordedAt = "2026-09-01T10:00:04Z"
+	if err := validateCompactedRecords([]Record{prepared, synthesized, legacy}, original, "codex"); err == nil {
+		t.Fatal("validator accepted a compacted record that never existed in the original")
+	}
+}
+
+// A long deferred/retried chain closed by a contradictory legacy result is
+// ordinary wake behavior plus one bad write. Preserving it verbatim would make
+// the group's mandatory footprint unbounded and block rotation; the bound
+// [prepared, latest event, legacy] must still fold invalid and keep the
+// legacy record. Sizing the cap below the verbatim footprint proves the bound
+// is what gets written.
+func TestCompactionBoundsContradictoryHistory(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "long-contradiction", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-long"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	records := []Record{prepared}
+	state := StateDeferred
+	for seq := uint64(1); seq <= 200; seq++ {
+		event := prepared
+		event.Phase = PhaseResult
+		event.State = state
+		event.Sequence = seq
+		event.RecordedAt = fmt.Sprintf("2026-09-01T10:%02d:%02dZ", seq/60, seq%60)
+		records = append(records, event)
+		if state == StateDeferred {
+			state = StateRetried
+		} else {
+			state = StateDeferred
+		}
+	}
+	accepted := prepared
+	accepted.Phase = PhaseResult
+	accepted.State = StateAccepted
+	accepted.Sequence = 201
+	accepted.RecordedAt = "2026-09-01T11:00:00Z"
+	legacy := prepared
+	legacy.Phase = PhaseResult
+	legacy.State = ""
+	legacy.Outcome = OutcomeWritten
+	legacy.RecordedAt = "2026-09-01T11:00:01Z"
+	legacy.Detail = "contradicts terminal accepted"
+	records = append(records, accepted, legacy)
+
+	compacted, err := compactRecords(records, "codex", 2048)
+	if err != nil {
+		t.Fatalf("compact long contradictory history under a tight cap: %v", err)
+	}
+	group := decodeCompactedForTest(t, compacted)
+	if len(group) != 3 || group[1].Sequence != 201 || group[2].Outcome != OutcomeWritten {
+		t.Fatalf("bounded contradictory group = %#v, want [prepared, accepted(201), legacy]", group)
+	}
+	folded, ok := foldRecordGroup(group)
+	if !ok || folded.State != StateInvalid {
+		t.Fatalf("bounded group folds to %q, want invalid", folded.State)
+	}
+}
+
+// A legacy result whose identity does not match the prepared record (message
+// set drift) is invalid in List. Compaction used to drop the unmatched record
+// and yield [prepared], which re-folds as `attempt`; with the verdict gate that
+// would fail every rotation forever. The group must keep the legacy record,
+// with or without lifecycle events.
+func TestCompactionPreservesUnmatchedLegacyResult(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "unmatched-legacy", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-a"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	legacy := prepared
+	legacy.Phase = PhaseResult
+	legacy.State = ""
+	legacy.MessageIDs = []string{"msg-a", "msg-b"}
+	legacy.Outcome = OutcomeWritten
+	legacy.RecordedAt = "2026-09-01T10:00:02Z"
+	deferred := prepared
+	deferred.Phase = PhaseResult
+	deferred.State = StateDeferred
+	deferred.Sequence = 1
+	deferred.RecordedAt = "2026-09-01T10:00:01Z"
+
+	for name, records := range map[string][]Record{
+		"no events":   {prepared, legacy},
+		"with events": {prepared, deferred, legacy},
+	} {
+		compacted, err := compactRecords(records, "codex", 64*1024)
+		if err != nil {
+			t.Fatalf("%s: compact unmatched legacy result: %v", name, err)
+		}
+		group := decodeCompactedForTest(t, compacted)
+		if len(group) != len(records) || !hasLegacyResult(group) {
+			t.Fatalf("%s: compacted group = %#v, want the unmatched legacy record retained", name, group)
+		}
+		folded, ok := foldRecordGroup(group)
+		if !ok || folded.State != StateInvalid {
+			t.Fatalf("%s: compacted group folds to %q, want invalid", name, folded.State)
+		}
+	}
+}
+
+// A corrupt lifecycle with no legacy result (an illegal transition, or the
+// sequence reuse the pre-#710 Transition defect produced) is invalid in List. Compaction used to reduce it to
+// [prepared], re-folding as a clean `attempt`; the evidence must survive.
+func TestCompactionPreservesCorruptLifecycleVerbatim(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "sequence-reuse", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-reuse"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	// attempt -> retried is an illegal transition; List renders it invalid.
+	gap := prepared
+	gap.Phase = PhaseResult
+	gap.State = StateRetried
+	gap.Sequence = 1
+	gap.RecordedAt = "2026-09-01T10:00:01Z"
+
+	records := []Record{prepared, gap}
+	compacted, err := compactRecords(records, "codex", 64*1024)
+	if err != nil {
+		t.Fatalf("compact corrupt lifecycle: %v", err)
+	}
+	group := decodeCompactedForTest(t, compacted)
+	if len(group) != 2 {
+		t.Fatalf("corrupt lifecycle compacted to %#v, want both records preserved", group)
+	}
+	folded, ok := foldRecordGroup(group)
+	if !ok || folded.State != StateInvalid {
+		t.Fatalf("corrupt lifecycle compacted group folds to %q, want invalid", folded.State)
 	}
 }

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -743,7 +743,7 @@ func TestCompactionPreservesSequencesAndLegacyRecords(t *testing.T) {
 		}
 		compacted = append(compacted, record)
 	}
-	if err := validateCompactedRecords(compacted, "codex"); err != nil {
+	if err := validateCompactedRecords(compacted, nil, "codex"); err != nil {
 		t.Fatalf("compacted records failed validation: %v", err)
 	}
 
@@ -811,7 +811,7 @@ func TestCompactionPreservesV2PreparedLegacyWrittenResult(t *testing.T) {
 	if len(records) != 2 || records[0].State != StateAttempt || records[1].Outcome != OutcomeWritten || records[1].State != "" {
 		t.Fatalf("compacted legacy pair = %#v, want v2 prepared plus written result", records)
 	}
-	if err := validateCompactedRecords(records, "codex"); err != nil {
+	if err := validateCompactedRecords(records, nil, "codex"); err != nil {
 		t.Fatalf("validate compacted legacy pair: %v", err)
 	}
 }
@@ -941,5 +941,127 @@ func TestAppendDoesNotRecreateRemovedInboxComponent(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(fsq.AgentBase(root, "claude"), "receipts", LogFilename)); err != nil {
 		t.Fatalf("receipts leaf not created on demand: %v", err)
+	}
+}
+
+func decodeCompactedForTest(t *testing.T, data []byte) []Record {
+	t.Helper()
+	var records []Record
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var record Record
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode compacted record: %v", err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+// A TERMINAL v2 lifecycle followed by a legacy written result is
+// contradictory history: List folds it to `invalid` with the legacy record
+// kept as evidence. Compaction must not reduce that group to
+// [prepared, legacy], which re-folds as a clean `written` and launders the
+// contradiction through rotation (issue #708). Legacy `written` is never
+// acceptance, so this is an audit-fidelity defect, not a false accept.
+func TestCompactionPreservesContradictoryTerminalLegacyHistory(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "terminal-legacy", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-terminal-legacy"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	accepted := prepared
+	accepted.Phase = PhaseResult
+	accepted.RecordedAt = "2026-09-01T10:00:01Z"
+	accepted.State = StateAccepted
+	accepted.Sequence = 1
+	legacy := prepared
+	legacy.Phase = PhaseResult
+	legacy.RecordedAt = "2026-09-01T10:00:02Z"
+	legacy.State = ""
+	legacy.Outcome = OutcomeWritten
+	legacy.Detail = "contradicts terminal accepted"
+
+	before := foldLifecycle(prepared, []Record{accepted}, &legacy)
+	if before.State != StateInvalid {
+		t.Fatalf("fixture fold = %q, want invalid", before.State)
+	}
+
+	compacted, err := compactRecords([]Record{prepared, accepted, legacy}, "codex", 64*1024)
+	if err != nil {
+		t.Fatalf("compact contradictory history: %v", err)
+	}
+	records := decodeCompactedForTest(t, compacted)
+	if len(records) != 3 {
+		t.Fatalf("compacted contradictory group = %d records, want all 3 preserved: %#v", len(records), records)
+	}
+
+	root := t.TempDir()
+	dir := filepath.Join(root, "agents", "codex", "receipts")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LogFilename+rotatedSuffix), compacted, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	attempts, err := List(root, "codex", "msg-terminal-legacy")
+	if err != nil {
+		t.Fatalf("List rotated contradictory history: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].State != StateInvalid {
+		t.Fatalf("post-rotation attempts = %#v, want one invalid attempt (compaction laundered the verdict)", attempts)
+	}
+	found := false
+	for _, rec := range attempts[0].History {
+		if rec.Detail == legacy.Detail {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("post-rotation history dropped the contradicting legacy record")
+	}
+}
+
+// The validator's contract is that compaction never changes a verdict. A
+// hand-built archive that reduces a contradictory (invalid) group to a clean
+// written pair must be rejected when the original is supplied, and an
+// invalid archive with no original context stays rejected as before.
+func TestValidateCompactedRecordsRejectsVerdictChange(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "laundered", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-laundered"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	accepted := prepared
+	accepted.Phase = PhaseResult
+	accepted.RecordedAt = "2026-09-01T10:00:01Z"
+	accepted.State = StateAccepted
+	accepted.Sequence = 1
+	legacy := prepared
+	legacy.Phase = PhaseResult
+	legacy.RecordedAt = "2026-09-01T10:00:02Z"
+	legacy.State = ""
+	legacy.Outcome = OutcomeWritten
+	original := map[string][]Record{"laundered": {prepared, accepted, legacy}}
+
+	laundered := []Record{prepared, legacy}
+	if err := validateCompactedRecords(laundered, original, "codex"); err == nil {
+		t.Fatal("validator accepted an archive that changed invalid -> written")
+	}
+	preserved := []Record{prepared, accepted, legacy}
+	if err := validateCompactedRecords(preserved, original, "codex"); err != nil {
+		t.Fatalf("validator rejected a verbatim-preserved contradictory group: %v", err)
+	}
+	if err := validateCompactedRecords(preserved, nil, "codex"); err == nil {
+		t.Fatal("validator accepted an invalid archive with no original context")
+	}
+	// Dropping the evidence record while staying invalid is also refused:
+	// the group must be preserved record-for-record.
+	partial := []Record{prepared, accepted, {
+		Schema: SchemaVersion, AttemptID: "laundered", Phase: PhaseResult,
+		MessageIDs: prepared.MessageIDs, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:03Z", State: StateDeferred, Sequence: 2,
+	}}
+	if err := validateCompactedRecords(partial, original, "codex"); err == nil {
+		t.Fatal("validator accepted an invalid group that was not preserved verbatim")
 	}
 }

--- a/internal/notificationattempt/ledger_test.go
+++ b/internal/notificationattempt/ledger_test.go
@@ -1200,3 +1200,48 @@ func TestCompactionPreservesCorruptLifecycleVerbatim(t *testing.T) {
 		t.Fatalf("corrupt lifecycle compacted group folds to %q, want invalid", folded.State)
 	}
 }
+
+// The valid legacy-close shape must keep compacting: a nonterminal lifecycle
+// (deferred/retried) closed by a matching legacy written result is the
+// marker-less degradation path, not a contradiction. It compacts to
+// [prepared, legacy] and re-folds `written`. An implementation that preserves
+// every lifecycle-plus-legacy group verbatim passes the contradiction tests
+// and fails this one.
+func TestCompactionStillReducesValidNonterminalLegacyClose(t *testing.T) {
+	prepared := Record{
+		Schema: SchemaVersion, AttemptID: "nonterminal-legacy", Phase: PhasePrepared,
+		MessageIDs: []string{"msg-nonterminal"}, Agent: "codex", Mode: "external",
+		RecordedAt: "2026-09-01T10:00:00Z", State: StateAttempt,
+	}
+	records := []Record{prepared}
+	for seq, state := range []string{StateDeferred, StateRetried, StateDeferred} {
+		event := prepared
+		event.Phase = PhaseResult
+		event.State = state
+		event.Sequence = uint64(seq + 1)
+		event.RecordedAt = fmt.Sprintf("2026-09-01T10:00:0%dZ", seq+1)
+		records = append(records, event)
+	}
+	legacy := prepared
+	legacy.Phase = PhaseResult
+	legacy.State = ""
+	legacy.Outcome = OutcomeWritten
+	legacy.RecordedAt = "2026-09-01T10:00:09Z"
+	records = append(records, legacy)
+
+	if before := foldLifecycle(prepared, records[1:4], &legacy); before.State != OutcomeWritten {
+		t.Fatalf("fixture fold = %q, want written", before.State)
+	}
+	compacted, err := compactRecords(records, "codex", 64*1024)
+	if err != nil {
+		t.Fatalf("compact valid legacy close: %v", err)
+	}
+	group := decodeCompactedForTest(t, compacted)
+	if len(group) != 2 || group[0].Phase != PhasePrepared || group[1].Outcome != OutcomeWritten {
+		t.Fatalf("valid legacy close compacted to %#v, want [prepared, legacy]", group)
+	}
+	folded, ok := foldRecordGroup(group)
+	if !ok || folded.State != OutcomeWritten {
+		t.Fatalf("compacted valid legacy close folds to %q, want written", folded.State)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last open #708 item: contradictory terminal+legacy ledger history laundered to `written` through per-attempt compaction after rotation.

A terminal v2 lifecycle followed by a legacy `written` result folds to `invalid`, with the legacy record kept in `History` as evidence. Compaction reduced that group to `[prepared, legacy]`, which re-folds as a clean `written`. Trace then reported a contradictory history as a normal byte-write after the first rotation.

- `compactAttempt` folds against the last legacy result, as `List` does, before choosing the `[prepared, legacy]` shape. A contradictory group (legacy close on a terminal lifecycle, or a legacy record whose identity does not match) is preserved bounded to `[prepared, latest event, legacy]`, which re-folds invalid for every contradiction class, and marked mandatory. The full group is kept only when the bound would hide a corrupt lifecycle. A corrupt lifecycle with no legacy result keeps its events instead of collapsing to `[prepared]`.
- `validateCompactedRecords` now receives the original groups and enforces the real contract: compaction never changes an attempt's verdict. An invalid compacted group is accepted only when the original also folded invalid, every compacted record comes from the original, and the contradicting legacy record is retained. With no original context (hand-built archives in tests) an invalid group is rejected as before.
- `foldRecordGroup` mirrors `List`'s grouping so the validator compares the fold trace will actually render.

Requires a buggy writer to reach; legacy `written` is never acceptance, so there was no false-accept path. This is audit fidelity.

## Wake test change guard

No existing test removed or weakened. Existing validator call sites pass `nil` for the original and keep their previous semantics. New tests, each negative-proven:

| Change | Test that fails when reverted |
| --- | --- |
| verbatim preservation in `compactAttempt` | `TestCompactionPreservesContradictoryTerminalLegacyHistory` (the validator catches the verdict change) |
| verdict-equality check in the validator | `TestValidateCompactedRecordsRejectsVerdictChange` |
| invalid-with-original acceptance | `TestCompactionPreservesContradictoryTerminalLegacyHistory` (regresses to "invalid compacted lifecycle") |
| bounded preservation (not verbatim) | `TestCompactionBoundsContradictoryHistory` (verbatim exceeds the cap) |
| last-legacy pick keeps an unmatched record | `TestCompactionPreservesUnmatchedLegacyResult` |
| corrupt lifecycle keeps its events | `TestCompactionPreservesCorruptLifecycleVerbatim` |
| validator evidence rule (subset + legacy retained) | `TestValidateCompactedRecordsRejectsVerdictChange` |
| valid nonterminal legacy close still compacts to two records | `TestCompactionStillReducesValidNonterminalLegacyClose` (fails if every lifecycle+legacy group is kept verbatim) |

## Verification

`internal/notificationattempt` green with `-race`; `GOOS=windows go vet ./...` clean; ledger-consuming `internal/cli` suites green.

Fixes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
