### PR TITLE
docs: testing policy update and retire graceful-exit semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,9 +243,16 @@ Opt-in live proofs (`AMQ_CMUX_LIVE`, `AMQ_GHOSTTY_LIVE`, `AMQ_CLAUDE_LIVE`,
 part of `make ci`. Operator commands are in
 [the public launch API guide](docs/launch-api.md).
 
-Tests must include a negative case that a plausible wrong implementation would
-fail. For concurrency, routing, wake, and filesystem work, exercise the actual
-hostile boundary rather than only a helper or mock.
+Two kinds of test exist. One small happy-path test per user-visible behavior
+ships in the same PR as the behavior. A regression test for a defect observed
+in the field or in CI ships in the same PR as the fix and reproduces that
+failure and nothing more; its comment names the issue or CI run it came from.
+Both are deterministic and fast (under 5 seconds, no child process, no
+network) unless the observed defect lives at exactly that boundary and cannot
+be reproduced without it. Do not add speculative negative cases, mutation
+demonstrations, guard tests about tests, or tests for existing behavior with
+no observed defect. A slow or flaky test is deleted or rewritten to this bar,
+not tuned.
 
 ## Security
 
@@ -265,7 +272,7 @@ hostile boundary rather than only a helper or mock.
   `fix(wake): preserve replacement generation`.
 - Run `make ci` before committing and follow every pushed CI run to completion.
 - Do not commit placeholders, weaken a validator, regenerate goldens to hide a
-  defect, or split code from the tests that prove it.
+  defect, or split code from the test that ships with it.
 
 ## Documentation Policy
 

--- a/docs/wake-operations.md
+++ b/docs/wake-operations.md
@@ -91,8 +91,10 @@ socket. Raw wakes are stopped from the owning terminal or supervisor.
 Retirement preserves mailbox contents. Exact lock removal is its commit point:
 a failure before that point is `refused`; a later target or state cleanup
 failure is `retired_with_residue`, an exit-0 success with a warning. The other
-successful result is `retired`. A replacement generation is never selected
-for cleanup.
+successful result is `retired`. A wake that removes its own lock while exiting
+from the retire's SIGTERM is `retired` once that exact process is gone; a lock
+that vanishes while the process stays alive is `refused`. A replacement
+generation is never selected for cleanup.
 
 The lifecycle boundaries are:
 


### PR DESCRIPTION
Aligns the project testing contract with the sponsor ruling of 2026-09-03: one happy-path test per user-visible behavior, plus regression tests for defects observed in the field or in CI, shipped with the fix and citing the source. Removes the mandatory negative-case rule.

Also records the retire outcome #715 changed: a wake that removes its own lock while exiting from the retire's SIGTERM is retired once that process is gone; a lock that vanishes while the process stays alive is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)