### PR TITLE
fix(cli): tell agents a live wake makes watch and monitor redundant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,9 +216,11 @@ See [Wake operations](docs/wake-operations.md) for the full contract.
 ## Coordination Workflows
 
 During active work, run `amq drain --include-body` between phases. Use
-`send --wait-for drained` when delivery proof matters and `watch` when waiting
-for a response. Reply to the initiator, preserve the existing thread, send
-status at start and phase boundaries, and finish with changes and verification.
+`send --wait-for drained` when delivery proof matters. Use `watch` only when no
+wake is live for you; a live wake already delivers a doorbell, and a blocking
+wait would hold your turn while the doorbell queues behind it. Reply to the
+initiator, preserve the existing thread, send status at start and phase
+boundaries, and finish with changes and verification.
 
 The [co-op guide](COOP.md) owns peer roles, phased flow, wake use, supervisor
 recipes, and troubleshooting. The `amq-cli` skill owns agent-facing command

--- a/COOP.md
+++ b/COOP.md
@@ -261,8 +261,9 @@ amq watch --timeout 60s                           # Block until message arrives 
 amq list --new                                    # Peek without side effects
 ```
 
-If `amq wake` is running for you (`amq who` shows `notifier_live`), it already
-delivers a doorbell into your terminal. Do not also run `watch`, `monitor`, or a
+If `amq wake` is running for you (`amq wake check --me <you> --json` reports
+`live_wake` true with a mode other than `none`), it already delivers a
+doorbell into your terminal. Do not also run `watch`, `monitor`, or a
 polling loop: a blocking wait holds your turn and the doorbell queues behind
 it. Receive with `amq drain --include-body` when the doorbell fires. The one
 exception is the supervisor recipe below, where the wake is notify-only

--- a/COOP.md
+++ b/COOP.md
@@ -257,9 +257,16 @@ amq send --to codex --priority urgent --kind question --body "Blocked on API"
 
 ```bash
 amq drain --include-body                          # One-shot, silent when empty
-amq watch --timeout 60s                           # Block until message arrives
+amq watch --timeout 60s                           # Block until message arrives (only when no wake is live for you)
 amq list --new                                    # Peek without side effects
 ```
+
+If `amq wake` is running for you (`amq who` shows `notifier_live`), it already
+delivers a doorbell into your terminal. Do not also run `watch`, `monitor`, or a
+polling loop: a blocking wait holds your turn and the doorbell queues behind
+it. Receive with `amq drain --include-body` when the doorbell fires. The one
+exception is the supervisor recipe below, where the wake is notify-only
+(`--inject-mode none`) and `monitor` is the sole consumer.
 
 ### Reply (Auto Thread/Refs)
 

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -88,6 +88,7 @@ func runMonitor(args []string) error {
 	if err := validateKnownHandlesDeliveryRoot(deliveryRoot, common.Strict, me); err != nil {
 		return err
 	}
+	noteLiveWakeBeforeBlockingWait("monitor", root, me)
 	validator, err := newHeaderValidatorDeliveryRoot(deliveryRoot, common.Strict)
 	if err != nil {
 		return err

--- a/internal/cli/wait_wake_advisory.go
+++ b/internal/cli/wait_wake_advisory.go
@@ -1,0 +1,26 @@
+package cli
+
+// noteLiveWakeBeforeBlockingWait prints one stderr note when a blocking
+// arrival wait (watch, monitor) starts while a live injecting wake already
+// notifies this agent's terminal. Two arrival mechanisms for one agent are
+// redundant at best; at worst the harness blocks on the wait and the wake's
+// doorbell queues behind it (issue #717). A notify-only wake (mode none) is
+// the supervisor recipe, where monitor is the sole consumer, so it stays
+// silent. Advisory only: the wait proceeds either way.
+func noteLiveWakeBeforeBlockingWait(command, root, me string) {
+	inspection := inspectWakeLock(root, me)
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		return
+	}
+	mode := inspection.Lock.WakeMode
+	if mode == wakeInjectModeNone {
+		return
+	}
+	if mode == "" {
+		mode = "legacy"
+	}
+	_ = writeStderr(
+		"note: a live wake (pid %d, mode %s) already notifies this terminal; %s is redundant here. Receive with amq drain --include-body.\n",
+		inspection.PID, mode, command,
+	)
+}

--- a/internal/cli/wait_wake_advisory_test.go
+++ b/internal/cli/wait_wake_advisory_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #717: a blocking wait started while a live injecting wake already
+// notifies the terminal gets one advisory note naming drain as the remedy; a
+// notify-only wake (the supervisor recipe) gets none.
+func TestBlockingWaitNotesLiveInjectingWakeOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mode     string
+		wantNote bool
+	}{
+		{name: "inject-via wake", mode: wakeTargetInjectVia, wantNote: true},
+		{name: "notify-only wake", mode: wakeInjectModeNone, wantNote: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			writeWakeLockForTest(t, root, "codex", wakeLock{
+				PID:          4242,
+				TTY:          "unknown",
+				ProcessStart: "start-1",
+				BootID:       "boot-1",
+				Executable:   "/usr/bin/amq",
+				Args:         []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+				WakeMode:     tc.mode,
+			})
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{
+					PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+					Args: []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+				}
+			})
+			out := captureWakeStderr(t, func() { noteLiveWakeBeforeBlockingWait("watch", root, "codex") })
+			if got := strings.Contains(out, "already notifies this terminal"); got != tc.wantNote {
+				t.Fatalf("note emitted = %v, want %v; stderr=%q", got, tc.wantNote, out)
+			}
+			if tc.wantNote && !strings.Contains(out, "amq drain --include-body") {
+				t.Fatalf("note does not name the remedy: %q", out)
+			}
+		})
+	}
+}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -90,6 +90,7 @@ func runWatch(args []string) error {
 	if err := validateKnownHandlesDeliveryRoot(deliveryRoot, common.Strict, me); err != nil {
 		return err
 	}
+	noteLiveWakeBeforeBlockingWait("watch", root, me)
 	validator, err := newHeaderValidatorDeliveryRoot(deliveryRoot, common.Strict)
 	if err != nil {
 		return err

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -117,21 +117,21 @@ if command -v amq &> /dev/null; then
     if [ -n "$RESOLVED_ROOT" ]; then
         ENV_JSON=$(cd "$PROJECT_DIR" && amq env --me "$ME" --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || ENV_JSON=""
         PRESENCE_JSON=$(amq presence list --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || PRESENCE_JSON="[]"
-        WHO_JSON=$(amq who --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || WHO_JSON="[]"
+        WAKE_JSON=$(amq wake check --me "$ME" --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || WAKE_JSON="{}"
         # Count unread via pipe to avoid passing large JSON as argv
         INBOX_COUNT=$(amq list --me "$ME" --root "$RESOLVED_ROOT" --new --json 2>>"$HOOK_LOG" \
             | python3 -c "import json,sys;print(len(json.load(sys.stdin)))" 2>>"$HOOK_LOG") || INBOX_COUNT=0
     else
         ENV_JSON=$(cd "$PROJECT_DIR" && amq env --me "$ME" --json 2>>"$HOOK_LOG") || ENV_JSON=""
         PRESENCE_JSON=$(amq presence list --json 2>>"$HOOK_LOG") || PRESENCE_JSON="[]"
-        WHO_JSON=$(amq who --json 2>>"$HOOK_LOG") || WHO_JSON="[]"
+        WAKE_JSON=$(amq wake check --me "$ME" --json 2>>"$HOOK_LOG") || WAKE_JSON="{}"
         # Count unread via pipe to avoid passing large JSON as argv
         INBOX_COUNT=$(amq list --me "$ME" --new --json 2>>"$HOOK_LOG" \
             | python3 -c "import json,sys;print(len(json.load(sys.stdin)))" 2>>"$HOOK_LOG") || INBOX_COUNT=0
     fi
 
     if [ -n "$ENV_JSON" ]; then
-        python3 - "$ME" "$ENV_JSON" "$PRESENCE_JSON" "$INBOX_COUNT" "$WHO_JSON" 2>>"$HOOK_LOG" <<'PYEOF' || true
+        python3 - "$ME" "$ENV_JSON" "$PRESENCE_JSON" "$INBOX_COUNT" "$WAKE_JSON" 2>>"$HOOK_LOG" <<'PYEOF' || true
 import json, sys
 from datetime import datetime, timezone, timedelta
 
@@ -164,19 +164,19 @@ try:
 
     peer_str = ",".join(f'{p["handle"]}({p["status"]})' for p in peers)
 
-    # Wake state for me: a live wake already delivers a doorbell into this
-    # terminal, so the model must not start watch/monitor/polling (issue #717).
+    # Wake state for me, from `amq wake check`: it answers for this exact
+    # (root, me) pair and reports the inject mode. A live INJECTING wake
+    # already delivers a doorbell into this terminal, so the model must not
+    # start watch/monitor/polling (issue #717). A notify-only wake (mode none)
+    # is the supervisor recipe, where monitor is the consumer.
+    wake_mode = ""
     wake_live = False
     try:
-        who = json.loads(sys.argv[5]) if len(sys.argv) > 5 else []
-        sessions = who if isinstance(who, list) else who.get("sessions", [])
-        for s in sessions:
-            if session and s.get("name") not in (session, ""):
-                continue
-            for a in s.get("agents", []):
-                if a.get("handle") == me and a.get("presence_source") == "notifier_live":
-                    wake_live = True
-    except (ValueError, TypeError, AttributeError):
+        wake = json.loads(sys.argv[5]) if len(sys.argv) > 5 else {}
+        if isinstance(wake, dict) and wake.get("live_wake"):
+            wake_mode = wake.get("wake_mode") or "legacy"
+            wake_live = wake_mode != "none"
+    except (ValueError, TypeError):
         pass
 
     # Line 1: identity + session
@@ -188,7 +188,7 @@ try:
         line1 += f" project={project}"
     if peer_str:
         line1 += f" peers={peer_str}"
-    line1 += f" wake={'live' if wake_live else 'none'}."
+    line1 += f" wake={'live(' + wake_mode + ')' if wake_live else 'none'}."
 
     parts = [line1]
     if unread:

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -117,19 +117,21 @@ if command -v amq &> /dev/null; then
     if [ -n "$RESOLVED_ROOT" ]; then
         ENV_JSON=$(cd "$PROJECT_DIR" && amq env --me "$ME" --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || ENV_JSON=""
         PRESENCE_JSON=$(amq presence list --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || PRESENCE_JSON="[]"
+        WHO_JSON=$(amq who --root "$RESOLVED_ROOT" --json 2>>"$HOOK_LOG") || WHO_JSON="[]"
         # Count unread via pipe to avoid passing large JSON as argv
         INBOX_COUNT=$(amq list --me "$ME" --root "$RESOLVED_ROOT" --new --json 2>>"$HOOK_LOG" \
             | python3 -c "import json,sys;print(len(json.load(sys.stdin)))" 2>>"$HOOK_LOG") || INBOX_COUNT=0
     else
         ENV_JSON=$(cd "$PROJECT_DIR" && amq env --me "$ME" --json 2>>"$HOOK_LOG") || ENV_JSON=""
         PRESENCE_JSON=$(amq presence list --json 2>>"$HOOK_LOG") || PRESENCE_JSON="[]"
+        WHO_JSON=$(amq who --json 2>>"$HOOK_LOG") || WHO_JSON="[]"
         # Count unread via pipe to avoid passing large JSON as argv
         INBOX_COUNT=$(amq list --me "$ME" --new --json 2>>"$HOOK_LOG" \
             | python3 -c "import json,sys;print(len(json.load(sys.stdin)))" 2>>"$HOOK_LOG") || INBOX_COUNT=0
     fi
 
     if [ -n "$ENV_JSON" ]; then
-        python3 - "$ME" "$ENV_JSON" "$PRESENCE_JSON" "$INBOX_COUNT" 2>>"$HOOK_LOG" <<'PYEOF' || true
+        python3 - "$ME" "$ENV_JSON" "$PRESENCE_JSON" "$INBOX_COUNT" "$WHO_JSON" 2>>"$HOOK_LOG" <<'PYEOF' || true
 import json, sys
 from datetime import datetime, timezone, timedelta
 
@@ -162,6 +164,21 @@ try:
 
     peer_str = ",".join(f'{p["handle"]}({p["status"]})' for p in peers)
 
+    # Wake state for me: a live wake already delivers a doorbell into this
+    # terminal, so the model must not start watch/monitor/polling (issue #717).
+    wake_live = False
+    try:
+        who = json.loads(sys.argv[5]) if len(sys.argv) > 5 else []
+        sessions = who if isinstance(who, list) else who.get("sessions", [])
+        for s in sessions:
+            if session and s.get("name") not in (session, ""):
+                continue
+            for a in s.get("agents", []):
+                if a.get("handle") == me and a.get("presence_source") == "notifier_live":
+                    wake_live = True
+    except (ValueError, TypeError, AttributeError):
+        pass
+
     # Line 1: identity + session
     if session:
         line1 = f"AMQ coop active: me={me} session={session}"
@@ -171,11 +188,13 @@ try:
         line1 += f" project={project}"
     if peer_str:
         line1 += f" peers={peer_str}"
-    line1 += "."
+    line1 += f" wake={'live' if wake_live else 'none'}."
 
     parts = [line1]
     if unread:
         parts.append(f"Inbox: {unread} unread message(s). Run: amq drain --me {me}")
+    if wake_live:
+        parts.append("A wake notifies this terminal: receive with amq drain --include-body when the doorbell fires. Do not run amq watch, amq monitor, or a polling loop; a blocking wait holds your turn and the doorbell queues behind it.")
     parts.append("Use amq send/reply/drain for peer coordination. Preserve thread IDs on replies.")
 
     preamble = "\n".join(parts)

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -579,10 +579,18 @@ amq send --to codex --body "Message"              # Send (uses AM_ROOT/AM_ME fro
 amq drain --include-body                          # Receive (one-shot, silent when empty)
 amq drain --session auth --include-body           # Deliberate sibling-session receive
 amq reply --id <msg_id> --body "Response"          # Reply in thread
-amq watch --timeout 60s                           # Block until message arrives
+amq watch --timeout 60s                           # Block until message arrives (only when no wake is live for you)
 amq list --new                                    # Peek without side effects
 amq send --to grok --body "hello"                 # Grok is a normal peer handle, like codex or claude
 ```
+
+**Under a live wake, drain is the only receive verb.** If `amq wake` is running
+for you (`amq who` shows `notifier_live`, or your session-start context says
+`wake=live`), it delivers a doorbell into your terminal. Do not run `watch`,
+`monitor`, or a background polling loop: a blocking wait holds your turn and
+the doorbell queues behind it. When the doorbell fires, run
+`amq drain --include-body` and act on it. The exception is a notify-only wake
+(`--inject-mode none`) paired with a `monitor` service, the supervisor recipe.
 
 ### Send with metadata
 ```bash

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -585,8 +585,9 @@ amq send --to grok --body "hello"                 # Grok is a normal peer handle
 ```
 
 **Under a live wake, drain is the only receive verb.** If `amq wake` is running
-for you (`amq who` shows `notifier_live`, or your session-start context says
-`wake=live`), it delivers a doorbell into your terminal. Do not run `watch`,
+for you (your session-start context says `wake=live(...)`, or
+`amq wake check --me <you> --json` reports `live_wake` true with a mode other
+than `none`), it delivers a doorbell into your terminal. Do not run `watch`,
 `monitor`, or a background polling loop: a blocking wait holds your turn and
 the doorbell queues behind it. When the doorbell fires, run
 `amq drain --include-body` and act on it. The exception is a notify-only wake


### PR DESCRIPTION
Fixes #717. Under a live injecting wake, `amq watch` and `amq monitor` print one stderr note naming `amq drain --include-body` as the remedy and proceed; a notify-only wake stays silent. The session-start hook asks `amq wake check` for the exact agent and root and reports `wake=live(<mode>)` or `wake=none`; when an injecting wake is live it tells the model not to start watch, monitor, or a polling loop. COOP.md, the amq-cli skill, and CLAUDE.md carry the same condition.

What the user can now do: an agent under a live wake is told, at session start and again if it tries, to receive with drain instead of blocking its turn on a redundant wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)