### PR TITLE
fix(coop): recover stale reboot state and bind Codex naming to process

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -76,8 +76,10 @@ TUI rename after AMQ finds one newly created session for the spawn directory.
 Codex resumes by name,
 for example `codex resume session1/codex`. Cursor `agent` resumes through its
 picker only; resume-by-name is unproven. Disable this with `--named=false`,
-`AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`. Existing names
-and resume or continue flags are preserved, including `codex resume` and
+`AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`. Codex naming
+checks for an existing name immediately before setting one. This is best effort:
+Codex has no atomic set-if-unnamed API, so a manual rename in the final read/set
+window can still race. Resume or continue flags are preserved, including `codex resume` and
 `agent --resume`. Committed managed launches apply the same policy to Claude
 fresh plans: `agents[].named` overrides top-level `named` (default true), and
 the ticket owns `--name`. Resume plans never add it. Codex, Cursor, and Grok

--- a/COOP.md
+++ b/COOP.md
@@ -64,8 +64,14 @@ amq coop exec grok
 
 Direct `coop exec` names sessions by default as `<session>/<handle>`, or as
 `<handle>` for a sessionless root. Claude and Pi receive the name as an argv
-flag. Codex and Cursor `agent` receive a best-effort TUI rename only after AMQ
-finds one newly created session for the spawn directory. Codex resumes by name,
+flag. For Codex, AMQ waits up to 90 seconds for the launched process to open its
+main user thread, then uses Codex's naming API and confirms the result. It does
+not type into the Codex terminal. Process and file identities must agree;
+macOS requires `lsof`, and Linux uses `/proc`. If naming is unavailable or
+ambiguous, AMQ prints the manual `/rename` command. This affects the CLI display
+name only, not the AMQ queue or session. Cursor `agent` receives a best-effort
+TUI rename after AMQ finds one newly created session for the spawn directory.
+Codex resumes by name,
 for example `codex resume session1/codex`. Cursor `agent` resumes through its
 picker only; resume-by-name is unproven. Disable this with `--named=false`,
 `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`. Existing names

--- a/COOP.md
+++ b/COOP.md
@@ -64,8 +64,10 @@ amq coop exec grok
 
 Direct `coop exec` names sessions by default as `<session>/<handle>`, or as
 `<handle>` for a sessionless root. Claude and Pi receive the name as an argv
-flag. For Codex, AMQ waits up to 90 seconds for the launched process to open its
-main user thread, then uses Codex's naming API and confirms the result. It does
+flag. For Codex, AMQ waits while the launched process is alive for its main
+user thread to persist (normally after the first user turn), then uses Codex's
+naming API and confirms the result. Idle time is not a naming failure; each
+discovery probe is bounded, and the helper exits when the CLI exits. It does
 not type into the Codex terminal. Process and file identities must agree;
 macOS requires `lsof`, and Linux uses `/proc`. If naming is unavailable or
 ambiguous, AMQ prints the manual `/rename` command. This affects the CLI display

--- a/README.md
+++ b/README.md
@@ -346,8 +346,11 @@ low-level path is intentionally required.
 
 Direct `coop exec` names the provider session by default as
 `<session>/<handle>` (or `<handle>` for a sessionless root). Claude and Pi
-receive the name in their argv. Codex and Cursor `agent` receive a best-effort
-TUI rename after AMQ verifies the newly created session. Codex supports direct
+receive the name in their argv. Codex receives its name through its native API
+after AMQ identifies the main thread opened by the launched process. If that
+cannot be confirmed, AMQ prints a manual `/rename` command; queue delivery is
+unaffected. Cursor `agent` receives a best-effort TUI rename after AMQ verifies
+the newly created session. Codex supports direct
 resume by name, for example `codex resume session1/codex`. Cursor `agent`
 resumes through its picker only; resume-by-name is unproven. Set
 `--named=false`, `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`

--- a/docs/wake-operations.md
+++ b/docs/wake-operations.md
@@ -33,6 +33,13 @@ conservative problem states:
 - `unverified`: AMQ cannot prove ownership or staleness. Startup fails closed
   and doctor preserves the lock for operator inspection.
 
+Stale-lock removal and staged-executable deletion use independent identity
+checks. If a stage no longer matches its saved file identity (for example,
+device numbering changed after a reboot), cleanup preserves that file and
+prints its path, while exact stale-lock removal can continue. Doctor also
+quarantines an abandoned restart record while preserving its unmatched stage
+when no wake lock exists. This does not authorize deleting the retained file.
+
 Wake-lock repair follows the session guard. A target outside the authenticated
 pinned base is inspected but not changed unless the command has an explicit
 root and `--ignore-session-pin`. A guard refusal is a structured doctor error;

--- a/internal/cli/codex_named_process_args_darwin.go
+++ b/internal/cli/codex_named_process_args_darwin.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func readCodexProcessArgs(pid int) ([]string, error) {
+	data, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 4 || len(data) > codexNamedMaxToolOutput {
+		return nil, errors.New("process arguments have an invalid size")
+	}
+	argc := int(binary.LittleEndian.Uint32(data[:4]))
+	if argc <= 0 || argc > 4096 {
+		return nil, fmt.Errorf("process argument count %d is invalid", argc)
+	}
+	data = data[4:]
+	end := bytes.IndexByte(data, 0)
+	if end < 0 {
+		return nil, errors.New("process executable path is unterminated")
+	}
+	data = bytes.TrimLeft(data[end+1:], "\x00")
+	args := make([]string, 0, argc)
+	for len(args) < argc && len(data) > 0 {
+		end = bytes.IndexByte(data, 0)
+		if end < 0 {
+			return nil, errors.New("process argument is unterminated")
+		}
+		args = append(args, string(data[:end]))
+		data = data[end+1:]
+	}
+	if len(args) != argc {
+		return nil, errors.New("process argument vector is incomplete")
+	}
+	return args, nil
+}

--- a/internal/cli/codex_named_process_args_linux.go
+++ b/internal/cli/codex_named_process_args_linux.go
@@ -14,7 +14,7 @@ func readCodexProcessArgs(pid int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	data, err := io.ReadAll(io.LimitReader(file, codexNamedMaxToolOutput+1))
 	if err != nil {
 		return nil, err

--- a/internal/cli/codex_named_process_args_linux.go
+++ b/internal/cli/codex_named_process_args_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strconv"
+)
+
+func readCodexProcessArgs(pid int) ([]string, error) {
+	file, err := os.Open("/proc/" + strconv.Itoa(pid) + "/cmdline")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, codexNamedMaxToolOutput+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > codexNamedMaxToolOutput {
+		return nil, errors.New("process arguments exceed the safety limit")
+	}
+	return splitProcCmdline(data), nil
+}

--- a/internal/cli/codex_named_process_unix.go
+++ b/internal/cli/codex_named_process_unix.go
@@ -22,15 +22,18 @@ import (
 )
 
 const (
-	codexNamedDiscoveryTimeout = 90 * time.Second
-	codexNamedRPCTimeout       = 10 * time.Second
-	codexNamedStopGrace        = 750 * time.Millisecond
-	codexNamedMaxMetadata      = 256 << 10
-	codexNamedMaxToolOutput    = 4 << 20
-	codexNamedMaxRPCMessage    = 1 << 20
+	codexNamedProbeTimeout  = 10 * time.Second
+	codexNamedRPCTimeout    = 10 * time.Second
+	codexNamedStopGrace     = 750 * time.Millisecond
+	codexNamedMaxMetadata   = 256 << 10
+	codexNamedMaxToolOutput = 4 << 20
+	codexNamedMaxRPCMessage = 1 << 20
 )
 
-var errCodexThreadNotReady = errors.New("codex thread is not yet persisted")
+var (
+	errCodexThreadNotReady    = errors.New("codex thread is not yet persisted")
+	errCodexNamingTargetEnded = errors.New("spawned Codex process ended")
+)
 
 var (
 	codexNamedDiscoveryPoll         = time.Second
@@ -133,11 +136,14 @@ func processInspectionReason(info wakeProcessInfo) string {
 
 func validateCodexNamingTarget(target codexNamingTarget) (bool, error) {
 	info := inspectCodexNamingProcess(target.PID)
-	if !info.Running || info.InspectError != nil {
+	if !info.Running && info.InspectError == nil {
+		return false, errCodexNamingTargetEnded
+	}
+	if !info.Running || info.InspectError != nil || info.StartToken == "" || info.BootID == "" {
 		return false, fmt.Errorf("spawned Codex process is unavailable: %s", processInspectionReason(info))
 	}
 	if info.StartToken != target.ProcessStart || info.BootID != target.BootID {
-		return false, errors.New("spawned Codex process identity changed")
+		return false, fmt.Errorf("%w: process identity changed", errCodexNamingTargetEnded)
 	}
 	executable := info.ExecutablePath
 	if executable == "" {
@@ -246,7 +252,9 @@ func locateCodexProcessThread(ctx context.Context, target codexNamingTarget) (co
 
 func waitForCodexProcessThread(ctx context.Context, target codexNamingTarget) (codexProcessThread, error) {
 	for {
-		thread, err := locateCodexProcessThreadForWait(ctx, target)
+		probeCtx, cancelProbe := context.WithTimeout(ctx, codexNamedProbeTimeout)
+		thread, err := locateCodexProcessThreadForWait(probeCtx, target)
+		cancelProbe()
 		if err == nil {
 			return thread, nil
 		}
@@ -637,9 +645,13 @@ func (sidecar *codexSidecar) call(ctx context.Context, request codexSidecarMessa
 }
 
 func runCodexNamedSidecar(name string, target codexNamingTarget) error {
-	discoveryCtx, cancelDiscovery := context.WithTimeout(context.Background(), codexNamedDiscoveryTimeout)
-	thread, err := waitForCodexProcessThread(discoveryCtx, target)
-	cancelDiscovery()
+	// Codex defers persistence until the first user turn. An idle composer has
+	// no naming target yet, regardless of how long it has been open. Each probe
+	// is bounded, and process identity checks end the wait when this CLI exits.
+	thread, err := waitForCodexProcessThread(context.Background(), target)
+	if errors.Is(err, errCodexNamingTargetEnded) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cli/codex_named_process_unix.go
+++ b/internal/cli/codex_named_process_unix.go
@@ -688,14 +688,24 @@ func setCodexThreadNameIfEmpty(ctx context.Context, sidecar *codexSidecar, threa
 	if err := revalidate(); err != nil {
 		return err
 	}
+	// Ownership discovery can be slow. Preserve a name set during that probe
+	// by reading again immediately before mutation. Codex has no conditional
+	// set-name operation, so the final read/set pair is still best effort.
+	currentName, err = readCodexThreadName(ctx, sidecar, thread, 3)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(currentName) != "" {
+		return nil
+	}
 	params, _ := json.Marshal(map[string]string{"threadId": thread.ThreadID, "name": name})
-	if _, err := sidecar.call(ctx, codexSidecarMessage{JSONRPC: "2.0", ID: 3, Method: "thread/name/set", Params: params}); err != nil {
+	if _, err := sidecar.call(ctx, codexSidecarMessage{JSONRPC: "2.0", ID: 4, Method: "thread/name/set", Params: params}); err != nil {
 		return fmt.Errorf("set Codex thread name: %w", err)
 	}
 	if err := revalidate(); err != nil {
 		return err
 	}
-	actual, err := readCodexThreadName(ctx, sidecar, thread, 4)
+	actual, err := readCodexThreadName(ctx, sidecar, thread, 5)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/codex_named_process_unix.go
+++ b/internal/cli/codex_named_process_unix.go
@@ -1,0 +1,726 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	codexNamedDiscoveryTimeout = 90 * time.Second
+	codexNamedRPCTimeout       = 10 * time.Second
+	codexNamedStopGrace        = 750 * time.Millisecond
+	codexNamedMaxMetadata      = 256 << 10
+	codexNamedMaxToolOutput    = 4 << 20
+	codexNamedMaxRPCMessage    = 1 << 20
+)
+
+var errCodexThreadNotReady = errors.New("codex thread is not yet persisted")
+
+var (
+	codexNamedDiscoveryPoll         = time.Second
+	inspectCodexNamingProcess       = inspectWakeProcessPlatform
+	locateCodexProcessThreadForWait = locateCodexProcessThread
+	startCodexNamingSidecar         = startCodexSidecar
+)
+
+type codexNamingTarget struct {
+	PID               int
+	ProcessStart      string
+	BootID            string
+	InitialExecutable string
+	InitialIdentity   codexFileIdentity
+	ProviderBinary    string
+	ProviderIdentity  codexFileIdentity
+}
+
+type codexFileIdentity struct {
+	Device uint64
+	Inode  uint64
+}
+
+type codexOpenRollout struct {
+	HolderPID int
+	Path      string
+	Identity  codexFileIdentity
+}
+
+type codexProcessThread struct {
+	ThreadID    string
+	RolloutPath string
+	Identity    codexFileIdentity
+}
+
+type codexSessionMeta struct {
+	Type    string `json:"type"`
+	Payload struct {
+		ID           string          `json:"id"`
+		Source       json.RawMessage `json:"source"`
+		ThreadSource string          `json:"thread_source"`
+	} `json:"payload"`
+}
+
+func captureCodexNamingTarget(providerBinary string) (codexNamingTarget, error) {
+	providerBinary, err := filepath.Abs(providerBinary)
+	if err != nil {
+		return codexNamingTarget{}, fmt.Errorf("resolve Codex executable: %w", err)
+	}
+	providerBinary = filepath.Clean(providerBinary)
+	providerIdentity, err := fileIdentity(providerBinary)
+	if err != nil {
+		return codexNamingTarget{}, fmt.Errorf("inspect Codex executable %q: %w", providerBinary, err)
+	}
+	info := inspectCodexNamingProcess(os.Getpid())
+	if !info.Running || info.InspectError != nil || info.StartToken == "" || info.BootID == "" {
+		return codexNamingTarget{}, fmt.Errorf("capture coop exec process identity: %s", processInspectionReason(info))
+	}
+	initialExecutable := info.ExecutablePath
+	if initialExecutable == "" {
+		initialExecutable = info.Executable
+	}
+	if initialExecutable == "" {
+		return codexNamingTarget{}, errors.New("capture coop exec executable: path is unavailable")
+	}
+	initialExecutable, err = filepath.Abs(initialExecutable)
+	if err != nil {
+		return codexNamingTarget{}, fmt.Errorf("resolve coop exec executable: %w", err)
+	}
+	initialIdentity, err := fileIdentity(initialExecutable)
+	if err != nil {
+		return codexNamingTarget{}, fmt.Errorf("inspect coop exec executable %q: %w", initialExecutable, err)
+	}
+	return codexNamingTarget{
+		PID:               os.Getpid(),
+		ProcessStart:      info.StartToken,
+		BootID:            info.BootID,
+		InitialExecutable: filepath.Clean(initialExecutable),
+		InitialIdentity:   initialIdentity,
+		ProviderBinary:    providerBinary,
+		ProviderIdentity:  providerIdentity,
+	}, nil
+}
+
+func processInspectionReason(info wakeProcessInfo) string {
+	if !info.Running {
+		return "process is not running"
+	}
+	if info.InspectError != nil {
+		return info.InspectError.Error()
+	}
+	if info.StartToken == "" {
+		return "process start is unavailable"
+	}
+	if info.BootID == "" {
+		return "boot identity is unavailable"
+	}
+	return "process identity is incomplete"
+}
+
+func validateCodexNamingTarget(target codexNamingTarget) (bool, error) {
+	info := inspectCodexNamingProcess(target.PID)
+	if !info.Running || info.InspectError != nil {
+		return false, fmt.Errorf("spawned Codex process is unavailable: %s", processInspectionReason(info))
+	}
+	if info.StartToken != target.ProcessStart || info.BootID != target.BootID {
+		return false, errors.New("spawned Codex process identity changed")
+	}
+	executable := info.ExecutablePath
+	if executable == "" {
+		executable = info.Executable
+	}
+	actualID, err := fileIdentity(executable)
+	if err != nil {
+		return false, fmt.Errorf("inspect spawned Codex executable: %w", err)
+	}
+	if actualID == target.InitialIdentity {
+		return false, nil
+	}
+	providerID, err := fileIdentity(target.ProviderBinary)
+	if err != nil {
+		return false, fmt.Errorf("reinspect Codex executable: %w", err)
+	}
+	if providerID != target.ProviderIdentity {
+		return false, errors.New("pinned Codex executable identity changed")
+	}
+	if actualID == target.ProviderIdentity {
+		return true, nil
+	}
+	base := strings.ToLower(filepath.Base(executable))
+	if base != "node" && base != "nodejs" {
+		return false, fmt.Errorf("spawned process executable %q is not the pinned Codex binary", executable)
+	}
+	args, err := readCodexProcessArgs(target.PID)
+	if err != nil {
+		return false, fmt.Errorf("inspect Codex Node launcher arguments: %w", err)
+	}
+	for _, arg := range args[1:] {
+		if !filepath.IsAbs(arg) {
+			continue
+		}
+		argID, statErr := fileIdentity(arg)
+		if statErr == nil && argID == target.ProviderIdentity {
+			return true, nil
+		}
+	}
+	return false, errors.New("codex Node launcher does not contain the pinned executable path")
+}
+
+func locateCodexProcessThread(ctx context.Context, target codexNamingTarget) (codexProcessThread, error) {
+	ready, err := validateCodexNamingTarget(target)
+	if err != nil {
+		return codexProcessThread{}, err
+	}
+	if !ready {
+		return codexProcessThread{}, errCodexThreadNotReady
+	}
+	parents, err := codexProcessParents(ctx)
+	if err != nil {
+		return codexProcessThread{}, err
+	}
+	pids := codexDescendantPIDs(target.PID, parents)
+	seen := make(map[codexFileIdentity]codexProcessThread)
+	for _, pid := range pids {
+		before := inspectCodexNamingProcess(pid)
+		if !before.Running || before.InspectError != nil || before.StartToken == "" || before.BootID == "" {
+			continue
+		}
+		rollouts, err := codexOpenRolloutsForPID(ctx, pid)
+		if err != nil {
+			return codexProcessThread{}, err
+		}
+		afterParents, err := codexProcessParents(ctx)
+		if err != nil {
+			return codexProcessThread{}, err
+		}
+		after := inspectCodexNamingProcess(pid)
+		parentChanged := pid != target.PID && parents[pid] != afterParents[pid]
+		if !after.Running || after.InspectError != nil || after.StartToken != before.StartToken || after.BootID != before.BootID || parentChanged || !codexPIDDescendsFrom(pid, target.PID, afterParents) {
+			continue
+		}
+		for _, rollout := range rollouts {
+			meta, err := readCodexSessionMeta(rollout.Path, rollout.Identity)
+			if err != nil || !isCodexRootUserThread(meta) {
+				continue
+			}
+			candidate := codexProcessThread{ThreadID: meta.Payload.ID, RolloutPath: rollout.Path, Identity: rollout.Identity}
+			if prior, ok := seen[rollout.Identity]; ok && prior != candidate {
+				return codexProcessThread{}, errors.New("one open Codex rollout produced inconsistent metadata")
+			}
+			seen[rollout.Identity] = candidate
+		}
+	}
+	if readyAgain, err := validateCodexNamingTarget(target); err != nil || !readyAgain {
+		if err != nil {
+			return codexProcessThread{}, err
+		}
+		return codexProcessThread{}, errors.New("spawned Codex process changed during rollout discovery")
+	}
+	candidates := make([]codexProcessThread, 0, len(seen))
+	for _, candidate := range seen {
+		candidates = append(candidates, candidate)
+	}
+	switch len(candidates) {
+	case 0:
+		return codexProcessThread{}, errCodexThreadNotReady
+	case 1:
+		return candidates[0], nil
+	default:
+		return codexProcessThread{}, fmt.Errorf("%d root user Codex rollouts are open in the spawned process tree", len(candidates))
+	}
+}
+
+func waitForCodexProcessThread(ctx context.Context, target codexNamingTarget) (codexProcessThread, error) {
+	for {
+		thread, err := locateCodexProcessThreadForWait(ctx, target)
+		if err == nil {
+			return thread, nil
+		}
+		if !errors.Is(err, errCodexThreadNotReady) {
+			return codexProcessThread{}, err
+		}
+		timer := time.NewTimer(codexNamedDiscoveryPoll)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return codexProcessThread{}, fmt.Errorf("wait for spawned Codex rollout: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func revalidateCodexProcessThread(ctx context.Context, target codexNamingTarget, expected codexProcessThread) error {
+	actual, err := locateCodexProcessThread(ctx, target)
+	if err != nil {
+		return fmt.Errorf("revalidate spawned Codex thread ownership: %w", err)
+	}
+	if actual != expected {
+		return errors.New("spawned Codex thread ownership changed")
+	}
+	return nil
+}
+
+func isCodexRootUserThread(meta codexSessionMeta) bool {
+	if meta.Type != "session_meta" || strings.TrimSpace(meta.Payload.ID) == "" || meta.Payload.ThreadSource != "user" {
+		return false
+	}
+	var source string
+	return json.Unmarshal(meta.Payload.Source, &source) == nil && source == "cli"
+}
+
+func readCodexSessionMeta(path string, expected codexFileIdentity) (codexSessionMeta, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return codexSessionMeta{}, err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return codexSessionMeta{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return codexSessionMeta{}, errors.New("codex rollout is not a regular file")
+	}
+	actual, err := fileIdentityFromInfo(info)
+	if err != nil || actual != expected {
+		return codexSessionMeta{}, errors.New("codex rollout path no longer names the open file")
+	}
+	limited := io.LimitReader(file, codexNamedMaxMetadata+1)
+	line, err := bufio.NewReader(limited).ReadBytes('\n')
+	if len(line) > codexNamedMaxMetadata {
+		return codexSessionMeta{}, errors.New("codex session metadata exceeds the size limit")
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return codexSessionMeta{}, err
+	}
+	var meta codexSessionMeta
+	if err := json.Unmarshal(bytes.TrimSpace(line), &meta); err != nil || meta.Type != "session_meta" {
+		return codexSessionMeta{}, errors.New("invalid Codex session metadata")
+	}
+	return meta, nil
+}
+
+func codexProcessParents(ctx context.Context) (map[int]int, error) {
+	cmd := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=")
+	var output boundedOutput
+	output.limit = codexNamedMaxToolOutput
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("inspect Codex process ancestry: %w", ctx.Err())
+		}
+		return nil, fmt.Errorf("inspect Codex process ancestry: %w", err)
+	}
+	parents := make(map[int]int)
+	for _, line := range strings.Split(output.String(), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		ppid, ppidErr := strconv.Atoi(fields[1])
+		if pidErr == nil && ppidErr == nil && pid > 0 && ppid >= 0 {
+			parents[pid] = ppid
+		}
+	}
+	return parents, nil
+}
+
+func codexDescendantPIDs(rootPID int, parents map[int]int) []int {
+	children := make(map[int][]int)
+	for pid, ppid := range parents {
+		children[ppid] = append(children[ppid], pid)
+	}
+	result := []int{rootPID}
+	seen := map[int]bool{rootPID: true}
+	for index := 0; index < len(result); index++ {
+		for _, child := range children[result[index]] {
+			if !seen[child] {
+				seen[child] = true
+				result = append(result, child)
+			}
+		}
+	}
+	return result
+}
+
+func codexPIDDescendsFrom(pid, rootPID int, parents map[int]int) bool {
+	if pid == rootPID {
+		return true
+	}
+	seen := make(map[int]bool)
+	for pid > 0 && !seen[pid] {
+		seen[pid] = true
+		pid = parents[pid]
+		if pid == rootPID {
+			return true
+		}
+	}
+	return false
+}
+
+func codexOpenRolloutsForPID(ctx context.Context, pid int) ([]codexOpenRollout, error) {
+	if runtime.GOOS == "linux" {
+		return codexLinuxOpenRollouts(pid)
+	}
+	return codexDarwinOpenRollouts(ctx, pid)
+}
+
+func codexLinuxOpenRollouts(pid int) ([]codexOpenRollout, error) {
+	fdRoot := filepath.Join("/proc", strconv.Itoa(pid), "fd")
+	entries, err := os.ReadDir(fdRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("scan Codex process descriptors: %w", err)
+	}
+	if len(entries) > 4096 {
+		return nil, errors.New("codex process descriptor count exceeds the safety limit")
+	}
+	var rollouts []codexOpenRollout
+	for _, entry := range entries {
+		fdPath := filepath.Join(fdRoot, entry.Name())
+		path, err := os.Readlink(fdPath)
+		if err != nil || !isCodexRolloutPath(path) {
+			continue
+		}
+		fdInfo, err := os.Stat(fdPath)
+		if err != nil {
+			continue
+		}
+		fdID, err := fileIdentityFromInfo(fdInfo)
+		if err != nil {
+			continue
+		}
+		pathID, err := fileIdentity(path)
+		if err != nil || pathID != fdID {
+			continue
+		}
+		rollouts = append(rollouts, codexOpenRollout{HolderPID: pid, Path: path, Identity: fdID})
+	}
+	return rollouts, nil
+}
+
+func codexDarwinOpenRollouts(ctx context.Context, pid int) ([]codexOpenRollout, error) {
+	cmd := exec.CommandContext(ctx, "lsof", "-a", "-p", strconv.Itoa(pid), "-FnfDi")
+	var output boundedOutput
+	output.limit = codexNamedMaxToolOutput
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("inspect Codex process descriptors with lsof: %w", err)
+	}
+	var rollouts []codexOpenRollout
+	var fd, path string
+	var device, inode uint64
+	flush := func() {
+		if fd == "" || path == "" || device == 0 || inode == 0 || !isCodexRolloutPath(path) {
+			return
+		}
+		if _, err := strconv.Atoi(strings.TrimRight(fd, "rwu")); err != nil {
+			return
+		}
+		identity, err := fileIdentity(path)
+		if err == nil && identity == (codexFileIdentity{Device: device, Inode: inode}) {
+			rollouts = append(rollouts, codexOpenRollout{HolderPID: pid, Path: path, Identity: identity})
+		}
+	}
+	for _, line := range strings.Split(output.String(), "\n") {
+		if strings.HasPrefix(line, "f") {
+			flush()
+			fd, path, device, inode = strings.TrimPrefix(line, "f"), "", 0, 0
+			continue
+		}
+		if len(line) < 2 {
+			continue
+		}
+		switch line[0] {
+		case 'D':
+			device, _ = strconv.ParseUint(line[1:], 0, 64)
+		case 'i':
+			inode, _ = strconv.ParseUint(line[1:], 10, 64)
+		case 'n':
+			path = line[1:]
+		}
+	}
+	flush()
+	return rollouts, nil
+}
+
+func isCodexRolloutPath(path string) bool {
+	return filepath.IsAbs(path) && strings.HasPrefix(filepath.Base(path), "rollout-") && strings.HasSuffix(path, ".jsonl")
+}
+
+func fileIdentity(path string) (codexFileIdentity, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return codexFileIdentity{}, err
+	}
+	return fileIdentityFromInfo(info)
+}
+
+func fileIdentityFromInfo(info os.FileInfo) (codexFileIdentity, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil || stat.Ino == 0 {
+		return codexFileIdentity{}, errors.New("file identity is unavailable")
+	}
+	return codexFileIdentity{Device: uint64(stat.Dev), Inode: uint64(stat.Ino)}, nil
+}
+
+type boundedOutput struct {
+	bytes.Buffer
+	limit int
+}
+
+func (output *boundedOutput) Write(data []byte) (int, error) {
+	if output.Len()+len(data) > output.limit {
+		remaining := output.limit - output.Len()
+		if remaining > 0 {
+			_, _ = output.Buffer.Write(data[:remaining])
+		}
+		return remaining, errors.New("command output exceeds the safety limit")
+	}
+	return output.Buffer.Write(data)
+}
+
+type codexSidecarMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type codexSidecar struct {
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	responses <-chan codexSidecarMessage
+	readErr   <-chan error
+	wait      <-chan error
+	done      chan struct{}
+	doneOnce  sync.Once
+	closeOnce sync.Once
+}
+
+func startCodexSidecar(binary string) (*codexSidecar, error) {
+	cmd := exec.Command(binary, "app-server", "--listen", "stdio://")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stderr = io.Discard
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open Codex sidecar input: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open Codex sidecar output: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start Codex naming sidecar: %w", err)
+	}
+	responses := make(chan codexSidecarMessage)
+	readErr := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(responses)
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 64<<10), codexNamedMaxRPCMessage)
+		for scanner.Scan() {
+			var message codexSidecarMessage
+			if json.Unmarshal(scanner.Bytes(), &message) == nil {
+				select {
+				case responses <- message:
+				case <-done:
+					return
+				}
+			}
+		}
+		readErr <- scanner.Err()
+	}()
+	wait := make(chan error, 1)
+	go func() { wait <- cmd.Wait() }()
+	return &codexSidecar{cmd: cmd, stdin: stdin, responses: responses, readErr: readErr, wait: wait, done: done}, nil
+}
+
+func (sidecar *codexSidecar) close() {
+	sidecar.doneOnce.Do(func() { close(sidecar.done) })
+	sidecar.closeOnce.Do(func() {
+		_ = sidecar.stdin.Close()
+		select {
+		case <-sidecar.wait:
+			return
+		case <-time.After(codexNamedStopGrace):
+		}
+		_ = syscall.Kill(-sidecar.cmd.Process.Pid, syscall.SIGTERM)
+		select {
+		case <-sidecar.wait:
+			return
+		case <-time.After(codexNamedStopGrace):
+		}
+		_ = syscall.Kill(-sidecar.cmd.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-sidecar.wait:
+		case <-time.After(codexNamedStopGrace):
+		}
+	})
+}
+
+func (sidecar *codexSidecar) send(ctx context.Context, request codexSidecarMessage) error {
+	stopClose := context.AfterFunc(ctx, sidecar.close)
+	defer stopClose()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	data, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(sidecar.stdin, "%s\n", data); err != nil {
+		return fmt.Errorf("send Codex naming request: %w", err)
+	}
+	return nil
+}
+
+func (sidecar *codexSidecar) call(ctx context.Context, request codexSidecarMessage) (json.RawMessage, error) {
+	stopClose := context.AfterFunc(ctx, sidecar.close)
+	defer stopClose()
+	if err := sidecar.send(ctx, request); err != nil {
+		return nil, err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case err := <-sidecar.readErr:
+			if err != nil {
+				return nil, fmt.Errorf("read Codex naming response: %w", err)
+			}
+			return nil, errors.New("codex naming sidecar closed its output")
+		case response, ok := <-sidecar.responses:
+			if !ok {
+				return nil, errors.New("codex naming sidecar closed its output")
+			}
+			if response.ID != request.ID {
+				continue
+			}
+			if response.Error != nil {
+				return nil, errors.New(response.Error.Message)
+			}
+			return response.Result, nil
+		}
+	}
+}
+
+func runCodexNamedSidecar(name string, target codexNamingTarget) error {
+	discoveryCtx, cancelDiscovery := context.WithTimeout(context.Background(), codexNamedDiscoveryTimeout)
+	thread, err := waitForCodexProcessThread(discoveryCtx, target)
+	cancelDiscovery()
+	if err != nil {
+		return err
+	}
+	rpcCtx, cancelRPC := context.WithTimeout(context.Background(), codexNamedRPCTimeout)
+	defer cancelRPC()
+	sidecar, err := startCodexNamingSidecar(target.ProviderBinary)
+	if err != nil {
+		return err
+	}
+	defer sidecar.close()
+	initialize := codexSidecarMessage{JSONRPC: "2.0", ID: 1, Method: "initialize", Params: json.RawMessage(`{"clientInfo":{"name":"amq","title":"AMQ","version":"1"},"capabilities":{}}`)}
+	if _, err := sidecar.call(rpcCtx, initialize); err != nil {
+		return fmt.Errorf("initialize Codex naming sidecar: %w", err)
+	}
+	if err := sidecar.send(rpcCtx, codexSidecarMessage{JSONRPC: "2.0", Method: "initialized", Params: json.RawMessage(`{}`)}); err != nil {
+		return err
+	}
+	return setCodexThreadNameIfEmpty(rpcCtx, sidecar, thread, name, func() error {
+		return revalidateCodexProcessThread(rpcCtx, target, thread)
+	})
+}
+
+func setCodexThreadNameIfEmpty(ctx context.Context, sidecar *codexSidecar, thread codexProcessThread, name string, revalidate func() error) error {
+	if err := revalidate(); err != nil {
+		return err
+	}
+	currentName, err := readCodexThreadName(ctx, sidecar, thread, 2)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(currentName) != "" {
+		return nil
+	}
+	if err := revalidate(); err != nil {
+		return err
+	}
+	params, _ := json.Marshal(map[string]string{"threadId": thread.ThreadID, "name": name})
+	if _, err := sidecar.call(ctx, codexSidecarMessage{JSONRPC: "2.0", ID: 3, Method: "thread/name/set", Params: params}); err != nil {
+		return fmt.Errorf("set Codex thread name: %w", err)
+	}
+	if err := revalidate(); err != nil {
+		return err
+	}
+	actual, err := readCodexThreadName(ctx, sidecar, thread, 4)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(actual) != name {
+		return errors.New("codex naming sidecar did not confirm the requested name")
+	}
+	return nil
+}
+
+func readCodexThreadName(ctx context.Context, sidecar *codexSidecar, thread codexProcessThread, requestID int) (string, error) {
+	params, _ := json.Marshal(map[string]any{"threadId": thread.ThreadID, "includeTurns": false})
+	result, err := sidecar.call(ctx, codexSidecarMessage{JSONRPC: "2.0", ID: requestID, Method: "thread/read", Params: params})
+	if err != nil {
+		return "", fmt.Errorf("read Codex thread: %w", err)
+	}
+	var response struct {
+		Thread struct {
+			ID   string  `json:"id"`
+			Name *string `json:"name"`
+			Path *string `json:"path"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", fmt.Errorf("decode Codex thread: %w", err)
+	}
+	if response.Thread.ID != thread.ThreadID {
+		return "", errors.New("codex sidecar returned a different thread")
+	}
+	if response.Thread.Path == nil || *response.Thread.Path != thread.RolloutPath {
+		return "", errors.New("codex sidecar returned a different rollout path")
+	}
+	identity, err := fileIdentity(*response.Thread.Path)
+	if err != nil || identity != thread.Identity {
+		return "", errors.New("codex sidecar rollout path identity changed")
+	}
+	if response.Thread.Name == nil {
+		return "", nil
+	}
+	return *response.Thread.Name, nil
+}

--- a/internal/cli/codex_named_process_unix_test.go
+++ b/internal/cli/codex_named_process_unix_test.go
@@ -130,6 +130,61 @@ func TestWaitForCodexProcessThreadRetriesDelayedPersistence(t *testing.T) {
 	}
 }
 
+// An untouched composer is a valid session state, not a naming failure.
+// Exercise the real wait loop through idle probes and a verified process exit.
+func TestCodexNamingWaitsForIdleComposerAndStopsWhenProcessEnds(t *testing.T) {
+	oldLocate, oldPoll, oldStart := locateCodexProcessThreadForWait, codexNamedDiscoveryPoll, startCodexNamingSidecar
+	t.Cleanup(func() {
+		locateCodexProcessThreadForWait, codexNamedDiscoveryPoll, startCodexNamingSidecar = oldLocate, oldPoll, oldStart
+	})
+	codexNamedDiscoveryPoll = time.Millisecond
+	calls := 0
+	locateCodexProcessThreadForWait = func(ctx context.Context, _ codexNamingTarget) (codexProcessThread, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > codexNamedProbeTimeout {
+			t.Fatal("discovery probe has no bounded deadline")
+		}
+		calls++
+		if calls < 4 {
+			return codexProcessThread{}, errCodexThreadNotReady
+		}
+		return codexProcessThread{}, errCodexNamingTargetEnded
+	}
+	startCodexNamingSidecar = func(string) (*codexSidecar, error) {
+		t.Fatal("idle composer caused a naming mutation")
+		return nil, errors.New("unexpected")
+	}
+	if err := runCodexNamedSidecar("session1/codex", codexNamingTarget{}); err != nil {
+		t.Fatalf("normal idle-then-exit produced a warning: %v", err)
+	}
+	if calls != 4 {
+		t.Fatalf("discovery calls = %d, want 4", calls)
+	}
+}
+
+func TestCodexNamingStopsOnVerifiedExitButReportsInspectionFailure(t *testing.T) {
+	oldInspect := inspectCodexNamingProcess
+	t.Cleanup(func() { inspectCodexNamingProcess = oldInspect })
+	for _, tc := range []struct {
+		name  string
+		info  wakeProcessInfo
+		ended bool
+	}{
+		{name: "exited", info: wakeProcessInfo{}, ended: true},
+		{name: "reused PID", info: wakeProcessInfo{Running: true, StartToken: "replacement", BootID: "boot"}, ended: true},
+		{name: "inspection failed", info: wakeProcessInfo{InspectError: errors.New("permission denied")}},
+		{name: "missing identity", info: wakeProcessInfo{Running: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inspectCodexNamingProcess = func(int) wakeProcessInfo { return tc.info }
+			_, err := validateCodexNamingTarget(codexNamingTarget{PID: 42, ProcessStart: "original", BootID: "boot"})
+			if err == nil || errors.Is(err, errCodexNamingTargetEnded) != tc.ended {
+				t.Fatalf("validation = %v, want ended=%v", err, tc.ended)
+			}
+		})
+	}
+}
+
 func TestRunCodexNamedSidecarDoesNotStartRPCOnAmbiguousRoots(t *testing.T) {
 	oldLocate := locateCodexProcessThreadForWait
 	oldStart := startCodexNamingSidecar

--- a/internal/cli/codex_named_process_unix_test.go
+++ b/internal/cli/codex_named_process_unix_test.go
@@ -59,6 +59,13 @@ func TestReadCodexSessionMetaRejectsChangedFileIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Hold the original inode alive across replacement: a freed inode may be
+	// reused for the new file, which would make the identities agree.
+	held, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = held.Close() }()
 	if err := os.Remove(path); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/codex_named_process_unix_test.go
+++ b/internal/cli/codex_named_process_unix_test.go
@@ -244,6 +244,17 @@ func TestCodexSidecarCallDeadlineInterruptsBlockedRead(t *testing.T) {
 }
 
 func TestCodexNamedSidecarProtocolSmokeUsesSyntheticStore(t *testing.T) {
+	for _, concurrentRename := range []bool{false, true} {
+		name := "unnamed thread"
+		if concurrentRename {
+			name = "manual rename during ownership probe"
+		}
+		t.Run(name, func(t *testing.T) { testCodexNativeNaming(t, concurrentRename) })
+	}
+}
+
+func testCodexNativeNaming(t *testing.T, concurrentRename bool) {
+	t.Helper()
 	codex, err := exec.LookPath("codex")
 	if err != nil {
 		t.Skip("codex executable is unavailable")
@@ -315,23 +326,32 @@ func TestCodexNamedSidecarProtocolSmokeUsesSyntheticStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	thread := codexProcessThread{ThreadID: threadID, RolloutPath: rollout, Identity: rolloutIdentity}
+	wantName, wantRevalidations := "session1/codex", 3
+	if concurrentRename {
+		wantName, wantRevalidations = "user-custom-name", 2
+	}
 	revalidations := 0
 	if err := setCodexThreadNameIfEmpty(ctx, sidecar, thread, "session1/codex", func() error {
 		revalidations++
+		if concurrentRename && revalidations == 2 {
+			params, _ := json.Marshal(map[string]string{"threadId": thread.ThreadID, "name": wantName})
+			_, err := sidecar.call(ctx, codexSidecarMessage{JSONRPC: "2.0", ID: 99, Method: "thread/name/set", Params: params})
+			return err
+		}
 		return nil
 	}); err != nil {
 		t.Fatalf("setCodexThreadNameIfEmpty: %v", err)
 	}
-	if revalidations != 3 {
-		t.Fatalf("ownership revalidations = %d, want 3", revalidations)
+	if revalidations != wantRevalidations {
+		t.Fatalf("ownership revalidations = %d, want %d", revalidations, wantRevalidations)
 	}
-	if name, err := readCodexThreadName(ctx, sidecar, thread, 4); err != nil || name != "session1/codex" {
+	if name, err := readCodexThreadName(ctx, sidecar, thread, 4); err != nil || name != wantName {
 		t.Fatalf("updated thread name = %q, err=%v", name, err)
 	}
 	if err := setCodexThreadNameIfEmpty(ctx, sidecar, thread, "replacement", func() error { return nil }); err != nil {
 		t.Fatalf("preserve existing name: %v", err)
 	}
-	if name, err := readCodexThreadName(ctx, sidecar, thread, 5); err != nil || name != "session1/codex" {
+	if name, err := readCodexThreadName(ctx, sidecar, thread, 5); err != nil || name != wantName {
 		t.Fatalf("preserved thread name = %q, err=%v", name, err)
 	}
 }

--- a/internal/cli/codex_named_process_unix_test.go
+++ b/internal/cli/codex_named_process_unix_test.go
@@ -1,0 +1,305 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestReadCodexSessionMetaFiltersRootUserCLIThread(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		data string
+		read bool
+		root bool
+	}{
+		{name: "user cli", data: `{"type":"session_meta","payload":{"id":"thread-1","source":"cli","thread_source":"user"}}` + "\n", read: true, root: true},
+		{name: "subagent object", data: `{"type":"session_meta","payload":{"id":"thread-2","source":{"subagent":{}},"thread_source":"subagent"}}` + "\n", read: true},
+		{name: "wrong event", data: `{"type":"response_item","payload":{"id":"thread-3"}}` + "\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "rollout-test.jsonl")
+			if err := os.WriteFile(path, []byte(test.data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			identity, err := fileIdentity(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			meta, err := readCodexSessionMeta(path, identity)
+			if (err == nil) != test.read {
+				t.Fatalf("readCodexSessionMeta error = %v, want success=%v", err, test.read)
+			}
+			if err != nil {
+				return
+			}
+			if got := isCodexRootUserThread(meta); got != test.root {
+				t.Fatalf("isCodexRootUserThread = %v, want %v", got, test.root)
+			}
+		})
+	}
+}
+
+func TestReadCodexSessionMetaRejectsChangedFileIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-test.jsonl")
+	data := []byte(`{"type":"session_meta","payload":{"id":"thread-1","source":"cli","thread_source":"user"}}` + "\n")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fileIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readCodexSessionMeta(path, identity); err == nil || !strings.Contains(err.Error(), "no longer names") {
+		t.Fatalf("readCodexSessionMeta error = %v, want identity refusal", err)
+	}
+}
+
+func TestReadCodexSessionMetaIsBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-test.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", codexNamedMaxMetadata+1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fileIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readCodexSessionMeta(path, identity); err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("readCodexSessionMeta error = %v, want bounded refusal", err)
+	}
+}
+
+func TestReadCodexSessionMetaRejectsFIFOWithoutBlocking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-test.jsonl")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fileIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	if _, err := readCodexSessionMeta(path, identity); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("readCodexSessionMeta error = %v, want non-regular refusal", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("FIFO refusal took %s", elapsed)
+	}
+}
+
+func TestWaitForCodexProcessThreadRetriesDelayedPersistence(t *testing.T) {
+	oldLocate := locateCodexProcessThreadForWait
+	oldPoll := codexNamedDiscoveryPoll
+	t.Cleanup(func() {
+		locateCodexProcessThreadForWait = oldLocate
+		codexNamedDiscoveryPoll = oldPoll
+	})
+	codexNamedDiscoveryPoll = time.Millisecond
+	calls := 0
+	want := codexProcessThread{ThreadID: "thread-1", RolloutPath: "/synthetic/rollout.jsonl"}
+	locateCodexProcessThreadForWait = func(context.Context, codexNamingTarget) (codexProcessThread, error) {
+		calls++
+		if calls < 3 {
+			return codexProcessThread{}, errCodexThreadNotReady
+		}
+		return want, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := waitForCodexProcessThread(ctx, codexNamingTarget{})
+	if err != nil {
+		t.Fatalf("waitForCodexProcessThread: %v", err)
+	}
+	if got != want || calls != 3 {
+		t.Fatalf("result = %#v after %d calls, want %#v after 3", got, calls, want)
+	}
+}
+
+func TestRunCodexNamedSidecarDoesNotStartRPCOnAmbiguousRoots(t *testing.T) {
+	oldLocate := locateCodexProcessThreadForWait
+	oldStart := startCodexNamingSidecar
+	t.Cleanup(func() {
+		locateCodexProcessThreadForWait = oldLocate
+		startCodexNamingSidecar = oldStart
+	})
+	locateCodexProcessThreadForWait = func(context.Context, codexNamingTarget) (codexProcessThread, error) {
+		return codexProcessThread{}, errors.New("2 root user Codex rollouts are open")
+	}
+	started := false
+	startCodexNamingSidecar = func(string) (*codexSidecar, error) {
+		started = true
+		return nil, errors.New("unexpected")
+	}
+	err := runCodexNamedSidecar("session1/codex", codexNamingTarget{})
+	if err == nil || !strings.Contains(err.Error(), "2 root user") {
+		t.Fatalf("runCodexNamedSidecar error = %v, want ambiguity", err)
+	}
+	if started {
+		t.Fatal("naming RPC started after ambiguous root discovery")
+	}
+}
+
+func TestValidateCodexNamingTargetRejectsReplacedProcess(t *testing.T) {
+	oldInspect := inspectCodexNamingProcess
+	t.Cleanup(func() { inspectCodexNamingProcess = oldInspect })
+	inspectCodexNamingProcess = func(int) wakeProcessInfo {
+		return wakeProcessInfo{Running: true, StartToken: "replacement", BootID: "boot"}
+	}
+	_, err := validateCodexNamingTarget(codexNamingTarget{PID: 42, ProcessStart: "original", BootID: "boot"})
+	if err == nil || !strings.Contains(err.Error(), "identity changed") {
+		t.Fatalf("validateCodexNamingTarget error = %v, want replacement refusal", err)
+	}
+}
+
+func TestCodexSidecarCallDeadlineInterruptsBlockedRead(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "codex-hang")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntrap '' TERM\nsleep 30\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sidecar, err := startCodexSidecar(script)
+	if err != nil {
+		t.Fatalf("startCodexSidecar: %v", err)
+	}
+	defer sidecar.close()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = sidecar.call(ctx, codexSidecarMessage{JSONRPC: "2.0", ID: 1, Method: "initialize", Params: json.RawMessage(`{}`)})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("sidecar.call error = %v, want deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > 3*time.Second {
+		t.Fatalf("blocked sidecar read returned after %s", elapsed)
+	}
+}
+
+func TestCodexNamedSidecarProtocolSmokeUsesSyntheticStore(t *testing.T) {
+	codex, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skip("codex executable is unavailable")
+	}
+	sqlite, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("sqlite3 executable is unavailable")
+	}
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+
+	initializeCodexStoreForTest(t, codex)
+	threadID := "019d0000-0000-7000-8000-000000000001"
+	rolloutDir := filepath.Join(home, "sessions", "2026", "09", "05")
+	if err := os.MkdirAll(rolloutDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rollout := filepath.Join(rolloutDir, "rollout-2026-09-05T12-00-00-"+threadID+".jsonl")
+	meta := map[string]any{
+		"timestamp": "2026-09-05T12:00:00Z",
+		"ordinal":   0,
+		"type":      "session_meta",
+		"payload": map[string]any{
+			"session_id":        threadID,
+			"id":                threadID,
+			"timestamp":         "2026-09-05T12:00:00Z",
+			"cwd":               "/tmp/amq-synthetic-project",
+			"originator":        "codex-tui",
+			"cli_version":       "test",
+			"source":            "cli",
+			"thread_source":     "user",
+			"model_provider":    "openai",
+			"base_instructions": map[string]any{"text": "synthetic"},
+			"history_mode":      "legacy",
+			"context_window":    map[string]any{"window_id": "019d0000-0000-7000-8000-000000000002"},
+			"git": map[string]any{
+				"commit_hash":    "synthetic",
+				"branch":         "synthetic",
+				"repository_url": "synthetic",
+			},
+		},
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userEvent := []byte(`{"timestamp":"2026-09-05T12:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"synthetic"}]}}` + "\n")
+	data = append(append(data, '\n'), userEvent...)
+	if err := os.WriteFile(rollout, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	quote := func(value string) string { return strings.ReplaceAll(value, "'", "''") }
+	statement := "INSERT INTO threads(id,rollout_path,created_at,updated_at,source,model_provider,cwd,title,sandbox_policy,approval_mode,has_user_event,cli_version,thread_source,preview,recency_at,recency_at_ms,name) VALUES('" +
+		quote(threadID) + "','" + quote(rollout) + "',1770000000,1770000000,'cli','openai','/tmp/amq-synthetic-project','','{}','never',1,'test','user','synthetic',1770000000,1770000000000,NULL);"
+	if output, err := exec.Command(sqlite, filepath.Join(home, "state_5.sqlite"), statement).CombinedOutput(); err != nil {
+		t.Fatalf("insert synthetic Codex thread: %v: %s", err, output)
+	}
+
+	sidecar, err := startCodexSidecar(codex)
+	if err != nil {
+		t.Fatalf("startCodexSidecar: %v", err)
+	}
+	defer sidecar.close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	initializeCodexSidecarForTest(t, ctx, sidecar)
+	rolloutIdentity, err := fileIdentity(rollout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	thread := codexProcessThread{ThreadID: threadID, RolloutPath: rollout, Identity: rolloutIdentity}
+	revalidations := 0
+	if err := setCodexThreadNameIfEmpty(ctx, sidecar, thread, "session1/codex", func() error {
+		revalidations++
+		return nil
+	}); err != nil {
+		t.Fatalf("setCodexThreadNameIfEmpty: %v", err)
+	}
+	if revalidations != 3 {
+		t.Fatalf("ownership revalidations = %d, want 3", revalidations)
+	}
+	if name, err := readCodexThreadName(ctx, sidecar, thread, 4); err != nil || name != "session1/codex" {
+		t.Fatalf("updated thread name = %q, err=%v", name, err)
+	}
+	if err := setCodexThreadNameIfEmpty(ctx, sidecar, thread, "replacement", func() error { return nil }); err != nil {
+		t.Fatalf("preserve existing name: %v", err)
+	}
+	if name, err := readCodexThreadName(ctx, sidecar, thread, 5); err != nil || name != "session1/codex" {
+		t.Fatalf("preserved thread name = %q, err=%v", name, err)
+	}
+}
+
+func initializeCodexStoreForTest(t *testing.T, codex string) {
+	t.Helper()
+	sidecar, err := startCodexSidecar(codex)
+	if err != nil {
+		t.Fatalf("start initial Codex sidecar: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	initializeCodexSidecarForTest(t, ctx, sidecar)
+	cancel()
+	sidecar.close()
+}
+
+func initializeCodexSidecarForTest(t *testing.T, ctx context.Context, sidecar *codexSidecar) {
+	t.Helper()
+	request := codexSidecarMessage{JSONRPC: "2.0", ID: 1, Method: "initialize", Params: json.RawMessage(`{"clientInfo":{"name":"amq-test","title":"AMQ Test","version":"1"},"capabilities":{}}`)}
+	if _, err := sidecar.call(ctx, request); err != nil {
+		t.Fatalf("initialize Codex sidecar: %v", err)
+	}
+	if err := sidecar.send(ctx, codexSidecarMessage{JSONRPC: "2.0", Method: "initialized", Params: json.RawMessage(`{}`)}); err != nil {
+		t.Fatalf("send initialized: %v", err)
+	}
+}

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -585,7 +585,7 @@ func validateKnownHandlesFromAgents(agents []string, loadErr error, strict bool,
 	if strict {
 		return errors.New(msg)
 	}
-	_ = writeStderr("warning: %s\n", msg)
+	_ = writeStderr("warning: %s; verify the handle with 'amq who --json' because the message may not be read\n", msg)
 	return nil
 }
 

--- a/internal/cli/coop_exec_named_store_unix.go
+++ b/internal/cli/coop_exec_named_store_unix.go
@@ -7,24 +7,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 const (
-	// state_5 is Codex's current state schema generation. A different file is
-	// an unknown store and must not be used for automatic naming.
-	codexStateFilename           = "state_5.sqlite"
-	codexThreadsQuery            = "SELECT cwd, name, title, rollout_path FROM threads"
-	codexRolloutTimestampLayout  = "2006-01-02T15-04-05"
 	coopNamedStoreClockSlack     = 2 * time.Second
 	coopNamedTUIReadbackInterval = 500 * time.Millisecond
 )
@@ -32,12 +24,10 @@ const (
 var (
 	coopNamedTUIReadbackTimeout = 5 * time.Second
 	coopNamedReadbackSleep      = time.Sleep
-	runCodexSQLiteQuery         = runCodexSQLiteQueryProcess
 )
 
 type coopNamedStoreCandidate struct {
 	storePath string
-	key       string
 	name      string
 	modTime   time.Time
 }
@@ -49,8 +39,6 @@ type coopNamedStoreReader interface {
 
 func coopNamedStoreReaderFor(binary string) (coopNamedStoreReader, bool) {
 	switch launch.ProviderForExecutable(binary) {
-	case launch.CodexProvider:
-		return codexNamedStoreReader{}, true
 	case launch.CursorProvider:
 		return cursorNamedStoreReader{}, true
 	default:
@@ -67,149 +55,6 @@ func selectCoopNamedStoreCandidate(candidates []coopNamedStoreCandidate, descrip
 	default:
 		return coopNamedStoreCandidate{}, fmt.Errorf("%d new %s store candidates are ambiguous", len(candidates), description)
 	}
-}
-
-type codexThreadRow struct {
-	CWD         string `json:"cwd"`
-	Name        string `json:"name"`
-	Title       string `json:"title"`
-	RolloutPath string `json:"rollout_path"`
-}
-
-type codexNamedStoreReader struct{}
-
-func (codexNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamedStoreCandidate, error) {
-	dbPath, err := codexStatePath()
-	if err != nil {
-		return coopNamedStoreCandidate{}, err
-	}
-	rows, err := readCodexThreadRows(dbPath)
-	if err != nil {
-		return coopNamedStoreCandidate{}, err
-	}
-	windowStart := execStart.Add(-coopNamedStoreClockSlack)
-	candidates := make([]coopNamedStoreCandidate, 0, 1)
-	for _, row := range rows {
-		if row.CWD != cwd || row.RolloutPath == "" {
-			continue
-		}
-		info, statErr := os.Stat(row.RolloutPath)
-		if statErr != nil {
-			if errors.Is(statErr, fs.ErrNotExist) {
-				continue
-			}
-			return coopNamedStoreCandidate{}, fmt.Errorf("stat Codex rollout %q: %w", row.RolloutPath, statErr)
-		}
-		createdAt, ok := codexRolloutCreationTime(row.RolloutPath, execStart.Location())
-		if !ok || createdAt.Before(windowStart) {
-			continue
-		}
-		candidates = append(candidates, coopNamedStoreCandidate{
-			storePath: dbPath,
-			key:       row.RolloutPath,
-			name:      row.Name,
-			modTime:   info.ModTime(),
-		})
-	}
-	return selectCoopNamedStoreCandidate(candidates, "Codex thread")
-}
-
-func codexRolloutCreationTime(path string, location *time.Location) (time.Time, bool) {
-	base := filepath.Base(path)
-	const prefix = "rollout-"
-	if !strings.HasPrefix(base, prefix) || !strings.HasSuffix(base, ".jsonl") {
-		return time.Time{}, false
-	}
-	stampStart := len(prefix)
-	stampEnd := stampStart + len(codexRolloutTimestampLayout)
-	if len(base) <= stampEnd || base[stampEnd] != '-' {
-		return time.Time{}, false
-	}
-	createdAt, err := time.ParseInLocation(codexRolloutTimestampLayout, base[stampStart:stampEnd], location)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return createdAt, true
-}
-
-func (codexNamedStoreReader) readName(candidate coopNamedStoreCandidate) (string, error) {
-	rows, err := readCodexThreadRows(candidate.storePath)
-	if err != nil {
-		return "", err
-	}
-	var name string
-	found := 0
-	for _, row := range rows {
-		if row.RolloutPath != candidate.key {
-			continue
-		}
-		name = row.Name
-		found++
-	}
-	if found != 1 {
-		return "", fmt.Errorf("codex rollout %q has %d matching rows", candidate.key, found)
-	}
-	if strings.TrimSpace(name) != "" {
-		return name, nil
-	}
-	// Codex versions before the explicit thread-name field persisted /rename
-	// in title. Keep that legacy store readable without treating generated
-	// titles as an existing explicit name before injection.
-	for _, row := range rows {
-		if row.RolloutPath == candidate.key {
-			return row.Title, nil
-		}
-	}
-	return "", nil
-}
-
-func codexStatePath() (string, error) {
-	home := strings.TrimSpace(os.Getenv("CODEX_HOME"))
-	if home == "" {
-		var err error
-		home, err = os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolve Codex home: %w", err)
-		}
-	}
-	if home == "" {
-		return "", errors.New("codex home is empty")
-	}
-	return filepath.Join(home, codexStateFilename), nil
-}
-
-func readCodexThreadRows(dbPath string) ([]codexThreadRow, error) {
-	data, err := runCodexSQLiteQuery(dbPath)
-	if err != nil {
-		return nil, err
-	}
-	var rows []codexThreadRow
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&rows); err != nil {
-		return nil, fmt.Errorf("decode Codex thread store: %w", err)
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return nil, errors.New("decode Codex thread store: multiple JSON values")
-		}
-		return nil, fmt.Errorf("decode Codex thread store: %w", err)
-	}
-	return rows, nil
-}
-
-func runCodexSQLiteQueryProcess(dbPath string) ([]byte, error) {
-	cmd := exec.Command("sqlite3", "-readonly", "-json", dbPath, codexThreadsQuery)
-	data, err := cmd.Output()
-	if err == nil {
-		return data, nil
-	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && len(exitErr.Stderr) != 0 {
-		return nil, fmt.Errorf("sqlite3 query failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
-	}
-	return nil, fmt.Errorf("run sqlite3 query: %w", err)
 }
 
 type cursorChatMeta struct {

--- a/internal/cli/coop_exec_named_store_unix_test.go
+++ b/internal/cli/coop_exec_named_store_unix_test.go
@@ -3,7 +3,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -14,10 +13,6 @@ import (
 	"testing"
 	"time"
 )
-
-func codexTestRolloutPath(dir string, createdAt time.Time, suffix string) string {
-	return filepath.Join(dir, "rollout-"+createdAt.Format(codexRolloutTimestampLayout)+"-"+suffix+".jsonl")
-}
 
 func TestCoopNamedSessionLabel(t *testing.T) {
 	for _, test := range []struct {
@@ -104,201 +99,6 @@ func TestResolveCoopNamedEnabledUsesLaunchConfig(t *testing.T) {
 	got, err := resolveCoopNamedEnabled(false, true)
 	if err != nil || got {
 		t.Fatalf("launch config off switch = %v, %v", got, err)
-	}
-}
-
-func TestCodexNamedStoreReaderUsesReadOnlyStoreAndFiltersWindow(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("CODEX_HOME", home)
-	start := time.Now()
-	rollout := codexTestRolloutPath(home, start, "test")
-	if err := os.WriteFile(rollout, []byte("{}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	oldQuery := runCodexSQLiteQuery
-	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
-	var gotDB string
-	runCodexSQLiteQuery = func(dbPath string) ([]byte, error) {
-		gotDB = dbPath
-		return []byte(`[{
-  "cwd": "` + cwd + `",
-  "name": "",
-  "rollout_path": "` + rollout + `"
-}]`), nil
-	}
-	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
-	if err != nil {
-		t.Fatalf("locate Codex candidate: %v", err)
-	}
-	if candidate.storePath != filepath.Join(home, codexStateFilename) || candidate.key != rollout {
-		t.Fatalf("candidate = %#v", candidate)
-	}
-	if gotDB != candidate.storePath {
-		t.Fatalf("sqlite database = %q, want %q", gotDB, candidate.storePath)
-	}
-	second := codexTestRolloutPath(home, start, "second")
-	runCodexSQLiteQuery = func(string) ([]byte, error) {
-		return []byte(`[{"cwd":"` + cwd + `","name":"","title":"feature/codex","rollout_path":"` + rollout + `"},{"cwd":"` + cwd + `","name":"other","rollout_path":"` + second + `"}]`), nil
-	}
-	if got, err := (codexNamedStoreReader{}).readName(candidate); err != nil || got != "feature/codex" {
-		t.Fatalf("legacy Codex title readback = %q, %v", got, err)
-	}
-
-	runCodexSQLiteQuery = func(string) ([]byte, error) {
-		return []byte(`[{
-  "cwd": "` + cwd + `",
-  "name": "",
-  "rollout_path": "` + rollout + `"
-}, {
-  "cwd": "` + cwd + `",
-  "name": "other",
-  "rollout_path": "` + second + `"
-}]`), nil
-	}
-	if err := os.WriteFile(second, []byte("{}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := (codexNamedStoreReader{}).locate(cwd, start); err == nil || !strings.Contains(err.Error(), "ambiguous") {
-		t.Fatalf("multiple candidates error = %v", err)
-	}
-}
-
-func TestCodexNamedStoreReaderSkipsCWDAndOldRollouts(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("CODEX_HOME", home)
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	start := time.Now()
-	current := codexTestRolloutPath(home, start, "current")
-	other := codexTestRolloutPath(home, start, "other")
-	old := codexTestRolloutPath(home, start.Add(-3*time.Second), "old")
-	for _, path := range []string{current, other, old} {
-		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-	oldTime := time.Now()
-	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
-		t.Fatal(err)
-	}
-	rows, err := json.Marshal([]codexThreadRow{
-		{CWD: cwd, RolloutPath: current},
-		{CWD: filepath.Join(home, "other-cwd"), RolloutPath: other},
-		{CWD: cwd, RolloutPath: old},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	oldQuery := runCodexSQLiteQuery
-	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
-	runCodexSQLiteQuery = func(string) ([]byte, error) { return rows, nil }
-	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
-	if err != nil {
-		t.Fatalf("locate filtered Codex candidate: %v", err)
-	}
-	if candidate.key != current {
-		t.Fatalf("candidate = %#v, want current rollout", candidate)
-	}
-}
-
-func TestCodexNamedStoreReaderAcceptsClockSlackButFiltersOlderRollouts(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("CODEX_HOME", home)
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	start := time.Now()
-	withinCreated := start.Add(-time.Second)
-	oldCreated := start.Add(-3 * time.Second)
-	within := codexTestRolloutPath(home, withinCreated, "within")
-	old := codexTestRolloutPath(home, oldCreated, "old")
-	for _, path := range []string{within, old} {
-		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-	withinTime := time.Now()
-	oldTime := withinTime
-	if err := os.Chtimes(within, withinTime, withinTime); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
-		t.Fatal(err)
-	}
-	rows, err := json.Marshal([]codexThreadRow{
-		{CWD: cwd, RolloutPath: within},
-		{CWD: cwd, RolloutPath: old},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	oldQuery := runCodexSQLiteQuery
-	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
-	runCodexSQLiteQuery = func(string) ([]byte, error) { return rows, nil }
-	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
-	if err != nil {
-		t.Fatalf("locate Codex candidate with clock slack: %v", err)
-	}
-	if candidate.key != within {
-		t.Fatalf("candidate = %#v, want rollout within clock slack", candidate)
-	}
-}
-
-func TestCodexNamedStoreReaderMissingSQLiteIsUnknown(t *testing.T) {
-	t.Setenv("CODEX_HOME", t.TempDir())
-	t.Setenv("PATH", t.TempDir())
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = (codexNamedStoreReader{}).locate(cwd, time.Now())
-	if err == nil || !strings.Contains(err.Error(), "sqlite3") {
-		t.Fatalf("missing sqlite3 error = %v", err)
-	}
-}
-
-func TestRunCodexSQLiteQueryProcessUsesFixedReadOnlyQuery(t *testing.T) {
-	dir := t.TempDir()
-	argsPath := filepath.Join(dir, "args")
-	script := filepath.Join(dir, "sqlite3")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$AMQ_TEST_SQLITE_ARGS\"\nprintf '[]\\n'\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", dir)
-	t.Setenv("AMQ_TEST_SQLITE_ARGS", argsPath)
-	dbPath := filepath.Join(dir, "database with spaces")
-	data, err := runCodexSQLiteQueryProcess(dbPath)
-	if err != nil {
-		t.Fatalf("run sqlite3 query: %v", err)
-	}
-	if string(data) != "[]\n" {
-		t.Fatalf("sqlite3 output = %q", data)
-	}
-	args, err := os.ReadFile(argsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "-readonly\n-json\n" + dbPath + "\n" + codexThreadsQuery + "\n"
-	if string(args) != want {
-		t.Fatalf("sqlite3 args = %q, want %q", args, want)
-	}
-}
-
-func TestReadCodexThreadRowsRejectsSchemaMismatch(t *testing.T) {
-	oldQuery := runCodexSQLiteQuery
-	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
-	runCodexSQLiteQuery = func(string) ([]byte, error) {
-		return []byte(`[{"cwd":"cwd","name":"name","rollout_path":"rollout","unexpected":true}]`), nil
-	}
-	if _, err := readCodexThreadRows("ignored"); err == nil || !strings.Contains(err.Error(), "unknown field") {
-		t.Fatalf("schema mismatch error = %v", err)
 	}
 }
 
@@ -537,55 +337,6 @@ func TestRunCoopNamedTUIUnknownStoreSkipsInjection(t *testing.T) {
 	})
 	if err != nil || injections != 0 || !strings.Contains(stderr, "store unavailable") {
 		t.Fatalf("unknown store: err=%v injections=%d stderr=%q", err, injections, stderr)
-	}
-}
-
-func TestRunCoopNamedInjectMissingSQLiteSkipsInjection(t *testing.T) {
-	t.Setenv("CODEX_HOME", t.TempDir())
-	t.Setenv("PATH", t.TempDir())
-	oldInject := coopNamedTTYInject
-	t.Cleanup(func() { coopNamedTTYInject = oldInject })
-	injections := 0
-	coopNamedTTYInject = func(string, string) error {
-		injections++
-		return nil
-	}
-	reader := codexNamedStoreReader{}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, stderr, err := captureEnvOutput(t, func() error {
-		return runCoopNamedTUI(&reader, "feature/codex", "codex", cwd, time.Now())
-	})
-	if err != nil || injections != 0 || !strings.Contains(stderr, "manually") {
-		t.Fatalf("missing sqlite3: err=%v injections=%d stderr=%q", err, injections, stderr)
-	}
-}
-
-func TestCodexNamedStoreReaderLive(t *testing.T) {
-	if os.Getenv("AMQ_CODEX_LIVE") != "1" {
-		t.Skip("set AMQ_CODEX_LIVE=1 to run the scratch Codex session proof")
-	}
-	codex, err := exec.LookPath("codex")
-	if err != nil {
-		t.Skipf("codex is unavailable: %v", err)
-	}
-	home := t.TempDir()
-	cwd := t.TempDir()
-	start := time.Now()
-	cmd := exec.Command(codex, "exec", "--skip-git-repo-check", "--json", "Reply with exactly OK")
-	cmd.Dir = cwd
-	cmd.Env = append(os.Environ(), "CODEX_HOME="+home)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("scratch Codex session: %v\n%s", err, output)
-	}
-	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
-	if err != nil {
-		t.Fatalf("read scratch Codex store: %v", err)
-	}
-	if _, err := (codexNamedStoreReader{}).readName(candidate); err != nil {
-		t.Fatalf("read scratch Codex name: %v", err)
 	}
 }
 

--- a/internal/cli/coop_exec_named_unix.go
+++ b/internal/cli/coop_exec_named_unix.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 const coopNamedTUIStartupDelay = 3 * time.Second
@@ -42,15 +44,33 @@ func startCoopNamedTUIInjectorProcess(name, cmdName string, execStart time.Time)
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(
+	args := []string{
 		amqBin,
 		"--no-update-check",
 		"coop",
 		"named-inject",
 		"--name", name,
-		"--binary", filepath.Base(cmdName),
+		"--binary", cmdName,
 		"--exec-start-ns", strconv.FormatInt(execStart.UnixNano(), 10),
-	)
+	}
+	if launch.ProviderForExecutable(cmdName) == launch.CodexProvider {
+		target, err := captureCodexNamingTarget(cmdName)
+		if err != nil {
+			return err
+		}
+		args = append(args,
+			"--parent-pid", strconv.Itoa(target.PID),
+			"--parent-process-start", target.ProcessStart,
+			"--parent-boot-id", target.BootID,
+			"--parent-executable", target.InitialExecutable,
+			"--parent-executable-device", strconv.FormatUint(target.InitialIdentity.Device, 10),
+			"--parent-executable-inode", strconv.FormatUint(target.InitialIdentity.Inode, 10),
+			"--provider-binary", target.ProviderBinary,
+			"--provider-binary-device", strconv.FormatUint(target.ProviderIdentity.Device, 10),
+			"--provider-binary-inode", strconv.FormatUint(target.ProviderIdentity.Inode, 10),
+		)
+	}
+	cmd := exec.Command(args[0], args[1:]...)
 	// Leave stdin/stdout on the null device so the helper does not steal the
 	// agent's TTY fds. Injection opens the controlling terminal via /dev/tty.
 	cmd.Stdin = nil
@@ -82,6 +102,15 @@ func runCoopNamedInject(args []string) error {
 	binaryFlag := fs.String("binary", "", "Spawned CLI binary basename")
 	delayFlag := fs.Duration("startup-delay", coopNamedTUIStartupDelay, "Delay before terminal injection")
 	execStartFlag := fs.Int64("exec-start-ns", 0, "Internal coop exec start timestamp")
+	parentPIDFlag := fs.Int("parent-pid", os.Getppid(), "Internal spawned CLI PID")
+	parentProcessStartFlag := fs.String("parent-process-start", "", "Internal spawned CLI process start token")
+	parentBootIDFlag := fs.String("parent-boot-id", "", "Internal spawned CLI boot identity")
+	parentExecutableFlag := fs.String("parent-executable", "", "Internal pre-exec AMQ executable")
+	parentExecutableDeviceFlag := fs.Uint64("parent-executable-device", 0, "Internal pre-exec AMQ executable device")
+	parentExecutableInodeFlag := fs.Uint64("parent-executable-inode", 0, "Internal pre-exec AMQ executable inode")
+	providerBinaryFlag := fs.String("provider-binary", "", "Internal resolved provider executable")
+	providerBinaryDeviceFlag := fs.Uint64("provider-binary-device", 0, "Internal provider executable device")
+	providerBinaryInodeFlag := fs.Uint64("provider-binary-inode", 0, "Internal provider executable inode")
 	usage := func() {
 		_ = writeStderr("usage: amq coop named-inject --name <session/name> --binary <basename>\n")
 	}
@@ -100,10 +129,11 @@ func runCoopNamedInject(args []string) error {
 	if err := validateCoopNamedSessionLabel(name); err != nil {
 		return UsageError("--name: %v", err)
 	}
-	binaryBase := strings.TrimSpace(*binaryFlag)
-	if binaryBase == "" {
+	binaryPath := strings.TrimSpace(*binaryFlag)
+	if binaryPath == "" {
 		return UsageError("--binary is required")
 	}
+	binaryBase := filepath.Base(binaryPath)
 	if coopNamedModeFor(binaryBase) != coopNamedModeTUI {
 		return UsageError("--binary %q does not use coop named terminal injection", binaryBase)
 	}
@@ -113,6 +143,28 @@ func runCoopNamedInject(args []string) error {
 	}
 	if *delayFlag > 0 {
 		coopNamedStartupSleep(*delayFlag)
+	}
+	if launch.ProviderForExecutable(binaryBase) == launch.CodexProvider {
+		target := codexNamingTarget{
+			PID:               *parentPIDFlag,
+			ProcessStart:      strings.TrimSpace(*parentProcessStartFlag),
+			BootID:            strings.TrimSpace(*parentBootIDFlag),
+			InitialExecutable: strings.TrimSpace(*parentExecutableFlag),
+			InitialIdentity:   codexFileIdentity{Device: *parentExecutableDeviceFlag, Inode: *parentExecutableInodeFlag},
+			ProviderBinary:    strings.TrimSpace(*providerBinaryFlag),
+			ProviderIdentity:  codexFileIdentity{Device: *providerBinaryDeviceFlag, Inode: *providerBinaryInodeFlag},
+		}
+		if target.PID <= 0 || target.ProcessStart == "" || target.BootID == "" ||
+			target.InitialExecutable == "" || !filepath.IsAbs(target.InitialExecutable) || filepath.Clean(target.InitialExecutable) != target.InitialExecutable ||
+			target.InitialIdentity.Device == 0 || target.InitialIdentity.Inode == 0 ||
+			target.ProviderBinary == "" || !filepath.IsAbs(target.ProviderBinary) || filepath.Clean(target.ProviderBinary) != target.ProviderBinary ||
+			target.ProviderIdentity.Device == 0 || target.ProviderIdentity.Inode == 0 {
+			return UsageError("Codex named-inject requires complete parent process identity and provider binary")
+		}
+		if err := runCodexNamedSidecar(name, target); err != nil {
+			_ = writeStderr("%s\n", coopNamedTUIManualReminder(name, binaryBase, err.Error()))
+		}
+		return nil
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -148,7 +200,7 @@ func validateCoopNamedSessionLabel(name string) error {
 
 func coopNamedTUIManualReminder(name, binaryBase, reason string) string {
 	return fmt.Sprintf(
-		"warning: cannot confirm %s CLI session %q (%s); enter %q manually",
+		"warning: unable to set or confirm the %s CLI display name %q (%s); this affects only the CLI display name; enter %q manually",
 		filepath.Base(binaryBase), name, reason, coopNamedTUICommand(binaryBase, name),
 	)
 }

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -729,7 +729,7 @@ func runCoopExec(args []string) error {
 	// root has no session prefix and therefore uses only the agent handle.
 	namedLabel := coopNamedSessionLabel(sessionIdentity, agentHandle)
 	execStart := time.Now()
-	agentArgs, err = applyCoopNamedBeforeExecAt(namedEnabled, cmdName, agentArgs, namedLabel, execStart)
+	agentArgs, err = applyCoopNamedBeforeExecAt(namedEnabled, binaryPath, agentArgs, namedLabel, execStart)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -41,7 +41,9 @@ func prepareCoopWakeLock(root, agent string, yes bool, remedy string) (retErr er
 		return fmt.Errorf("wake lock for %s names a running process proven not to be this wake; refusing to signal or remove it; lock: %s; root: %s; reason: %s; inspect with %s", agent, inspection.LockPath, inspection.Root, inspection.Reason, wakeCheckRemedy(inspection.Root, inspection.Agent).String())
 	}
 	if inspection.Status == wakeLockStale {
-		// This returns before stale owner-bound recovery advice is rendered below.
+		if wakeLockHasOwnerMarkers(inspection) {
+			return coopWakeStartupConflictError(inspection, nil)
+		}
 		if err := removeCoopWakeLockIfUnchangedInDir(agentDir, inspection); err != nil {
 			return fmt.Errorf("remove exact stale wake lock: %w", err)
 		}

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -329,10 +329,11 @@ func TestPrepareCoopWakeLockLiveAuthoritativeRefusesWithoutMutation(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
+	processRunning := true
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		return wakeProcessInfo{
 			PID:        pid,
-			Running:    true,
+			Running:    processRunning,
 			StartToken: owner.ProcessStart,
 			BootID:     owner.BootID,
 			Executable: wakeArgs[0],
@@ -394,6 +395,15 @@ func TestPrepareCoopWakeLockLiveAuthoritativeRefusesWithoutMutation(t *testing.T
 	}
 
 	ownerState = wakeOwnerDead
+	processRunning = false
+	err = prepareCoopWakeLock(root, "codex", true, "unused")
+	wantRecovery := wakeRecoverOwnerCommand(root, "codex")
+	if err == nil || !strings.Contains(err.Error(), wantRecovery) ||
+		!strings.Contains(err.Error(), "then retry") ||
+		strings.Contains(err.Error(), "'amq wake recover-owner --me codex'") {
+		t.Fatalf("stale authoritative wake result = %v, want actionable %q remedy", err, wantRecovery)
+	}
+	processRunning = true
 	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
 		t.Fatalf("dead-owner authoritative wake blocked automatic takeover: %v", err)
 	}

--- a/internal/cli/cross_project_test.go
+++ b/internal/cli/cross_project_test.go
@@ -513,6 +513,66 @@ func TestCrossProjectSendReportsIncompleteMailboxCauseAndPeerRepair(t *testing.T
 	}
 }
 
+func TestCrossProjectSendReportsMovedPeerRootAndConfigRepair(t *testing.T) {
+	clearSendMailboxTestEnv(t)
+	srcProjectDir := t.TempDir()
+	srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	missingPeer := filepath.Join(t.TempDir(), "moved-peer", ".agent-mail")
+	rcData, err := json.Marshal(map[string]any{
+		"root":    ".agent-mail",
+		"project": "source",
+		"peers":   map[string]string{"peer": missingPeer},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcPath := filepath.Join(srcProjectDir, ".amqrc")
+	if err := os.WriteFile(rcPath, rcData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runSend([]string{"--root", srcRoot, "--me", "alice", "--to", "bob", "--project", "peer", "--body", "no delivery root"})
+	if err == nil {
+		t.Fatal("send to missing peer root succeeded")
+	}
+	for _, want := range []string{`selected peer "peer"`, missingPeer, "peers map", rcPath, `fix the "peer" path`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("peer root error missing %q: %v", want, err)
+		}
+	}
+	// Follow the remedy and retry: changing the selected peer path must deliver
+	// to that peer's mirrored session without changing the source queue.
+	peerBase := filepath.Join(t.TempDir(), ".agent-mail")
+	peerSession := filepath.Join(peerBase, "collab")
+	if err := fsq.EnsureAgentDirs(peerSession, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	var repaired map[string]any
+	if err := json.Unmarshal(rcData, &repaired); err != nil {
+		t.Fatal(err)
+	}
+	repaired["peers"] = map[string]string{"peer": peerBase}
+	repairedData, err := json.Marshal(repaired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rcPath, repairedData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureEnvStdout(t, func() error {
+		return runSend([]string{"--root", srcRoot, "--me", "alice", "--to", "bob", "--project", "peer", "--body", "repaired peer route"})
+	}); err != nil {
+		t.Fatalf("send after suggested peer repair: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(peerSession, "agents", "bob", "inbox", "new"))
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("delivery after repair: entries=%d err=%v", len(entries), err)
+	}
+}
+
 func TestCrossProjectRepairCommandUsesSessionConfigAuthorityWhenBaseHasNoConfig(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("exact printed command execution uses the POSIX test shell")

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -436,7 +436,7 @@ func resolveEnvConfigWithSource(rootFlag, meFlag string) (string, rootSource, st
 		if insideGit {
 			return "", "", "", noEligibleRootInGitError(gitTop)
 		}
-		return "", "", "", fmt.Errorf("cannot determine root: no .amqrc found, no .agent-mail/ directory, AM_ROOT not set, and no global config (~/.amqrc or AMQ_GLOBAL_ROOT)")
+		return "", "", "", fmt.Errorf("cannot determine root: no .amqrc found, no .agent-mail/ directory, AM_ROOT not set, and no global config (~/.amqrc or AMQ_GLOBAL_ROOT); from your terminal, run 'amq setup --project-root \"$PWD\"' to configure this project; for an existing queue, set AMQ_GLOBAL_ROOT to its path")
 	}
 
 	// Canonicalize the winning root before pin validation, JSON/shell output,

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -705,7 +705,7 @@ func TestResolveEnvConfigInvalidAmqrcWithAutoDetect(t *testing.T) {
 }
 
 func TestResolveEnvConfigNoConfig(t *testing.T) {
-	root := t.TempDir()
+	root := setupProjectFixture(t, "codex")
 
 	// Isolate from the developer's real global config: a ~/.amqrc or
 	// AMQ_GLOBAL_ROOT on the machine would make resolution succeed.
@@ -729,6 +729,24 @@ func TestResolveEnvConfigNoConfig(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cannot determine root") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+	for _, want := range []string{"from your terminal", "amq setup --project-root \"$PWD\""} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("no-root error missing recovery instruction %q: %v", want, err)
+		}
+	}
+	// Exercise the printed terminal command, accepting its prompted defaults.
+	// A preview/-y suggestion without the required first-setup flags is a loop.
+	setupIsTerminal = func() bool { return true }
+	restoreInput := withStdin(t, "\n\n\nyes\n")
+	defer restoreInput()
+	if _, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"--project-root", root})
+	}); err != nil {
+		t.Fatalf("suggested setup: %v", err)
+	}
+	if got, _, err := resolveEnvConfig("", ""); err != nil || got == "" {
+		t.Fatalf("env after suggested recovery: root=%q err=%v", got, err)
 	}
 }
 

--- a/internal/cli/route.go
+++ b/internal/cli/route.go
@@ -209,11 +209,12 @@ func resolveRouteSource(fromRoot, meFlag string) (sourceRoot, me string, err err
 }
 
 type deliveryRoutePlan struct {
-	DeliveryRoot  string
-	PeerBaseRoot  string
-	SourceProject string
-	TargetProject string
-	TargetSession string
+	DeliveryRoot     string
+	PeerBaseRoot     string
+	SourceConfigPath string
+	SourceProject    string
+	TargetProject    string
+	TargetSession    string
 }
 
 type deliveryRouteOptions struct {
@@ -234,6 +235,7 @@ func planDeliveryRoute(sourceRoot, targetProject, targetSession string, opts del
 		if err != nil {
 			return plan, federationSourceProjectError(sourceRoot)
 		}
+		plan.SourceConfigPath = routeConfig.Path
 		sourceProject, err := requireFederationSourceProject(routeConfig, sourceRoot)
 		if err != nil {
 			return plan, err
@@ -254,12 +256,18 @@ func planDeliveryRoute(sourceRoot, targetProject, targetSession string, opts del
 			plan.TargetSession = normalized
 			plan.DeliveryRoot, err = resolveSessionRoot(peerBaseRoot, plan.TargetSession)
 			if err != nil {
+				if !dirExists(peerBaseRoot) {
+					return plan, peerDeliveryRootError(plan, peerBaseRoot, err)
+				}
 				return plan, err
 			}
 		} else if opts.MirrorPeerSession && classifyRoot(sourceRoot) != "" {
 			plan.TargetSession = sessionName(sourceRoot)
 			plan.DeliveryRoot, err = resolveSessionRoot(peerBaseRoot, plan.TargetSession)
 			if err != nil {
+				if !dirExists(peerBaseRoot) {
+					return plan, peerDeliveryRootError(plan, peerBaseRoot, err)
+				}
 				return plan, err
 			}
 		} else {
@@ -285,6 +293,21 @@ func planDeliveryRoute(sourceRoot, targetProject, targetSession string, opts del
 	}
 
 	return plan, nil
+}
+
+func peerDeliveryRootError(plan deliveryRoutePlan, deliveryRoot string, cause error) error {
+	configPath := plan.SourceConfigPath
+	if configPath == "" {
+		configPath = "the selected source .amqrc"
+	}
+	return fmt.Errorf(
+		"cannot access selected peer %q delivery root %s: %w; check that the peer root exists and is accessible; if the peer moved, fix the %q path in the peers map of .amqrc at %s, then retry the command",
+		plan.TargetProject,
+		deliveryRoot,
+		cause,
+		plan.TargetProject,
+		configPath,
+	)
 }
 
 func requireFederationSourceProject(result amqrcResult, sourceRoot string) (string, error) {

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -121,6 +121,7 @@ func runSendWithAfterBodyRead(args []string, afterBodyRead func()) error {
 	// Determine delivery root: local, cross-session, or cross-project.
 	deliveryRoot := root
 	peerBaseRoot := ""
+	var routePlan deliveryRoutePlan
 	targetSession := strings.TrimSpace(*sessionFlag)
 	// Inline session from @project:session takes effect only when not overridden.
 	if targetSession == "" && inlineSession != "" {
@@ -232,7 +233,7 @@ func runSendWithAfterBodyRead(args []string, afterBodyRead func()) error {
 		sourceSession = fromSession
 	}
 	if targetProject != "" || targetSession != "" {
-		routePlan, err := planDeliveryRoute(sourceRoot, targetProject, targetSession, deliveryRouteOptions{
+		routePlan, err = planDeliveryRoute(sourceRoot, targetProject, targetSession, deliveryRouteOptions{
 			MirrorPeerSession: true,
 		})
 		if err != nil {
@@ -248,6 +249,9 @@ func runSendWithAfterBodyRead(args []string, afterBodyRead func()) error {
 	// capabilities below must prove it got these exact directories.
 	deliveryIdentity, err := fsq.SnapshotDeliveryRoot(deliveryRoot)
 	if err != nil {
+		if targetProject != "" && !dirExists(peerBaseRoot) {
+			return peerDeliveryRootError(routePlan, deliveryRoot, err)
+		}
 		return err
 	}
 	sourceIdentity := deliveryIdentity

--- a/internal/cli/send_mailbox_test.go
+++ b/internal/cli/send_mailbox_test.go
@@ -69,6 +69,9 @@ func TestSendCompletesUnknownDestinationMailboxInInitializedRoot(t *testing.T) {
 	if !strings.Contains(stderr, `warning: handle "clade" not in config.json`) {
 		t.Fatalf("unknown-handle warning changed: %q", stderr)
 	}
+	if !strings.Contains(stderr, "amq who --json") || !strings.Contains(stderr, "message may not be read") {
+		t.Fatalf("unknown-handle warning missing verification remedy: %q", stderr)
+	}
 	assertCompleteSendMailbox(t, root, "clade")
 
 	listed, _, err := captureEnvOutput(t, func() error {

--- a/internal/cli/wake_restart_bound_darwin.go
+++ b/internal/cli/wake_restart_bound_darwin.go
@@ -433,7 +433,7 @@ func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTim
 	}
 	if evidence != bound &&
 		(!allowNamespaceCTimeChange || !sameDarwinStagedWakeImageEvidence(evidence, bound)) {
-		return fmt.Errorf("refuse cleanup of changed Darwin wake restart stage")
+		return &wakeRestartStageIdentityError{path: stagePath}
 	}
 	confirmed, err := os.Lstat(stagePath)
 	if err != nil || !os.SameFile(lstat, confirmed) {

--- a/internal/cli/wake_restart_stage_diagnostic_unix.go
+++ b/internal/cli/wake_restart_stage_diagnostic_unix.go
@@ -206,7 +206,7 @@ func fixWakeRestartResidueWithoutLock(root, agent string) error {
 			}
 		} else if !exists {
 			return diagnosticErr
-		} else if err := reclaimWakeRestartStagePlatform(snapshot.Record); err != nil {
+		} else if err := reclaimWakeRestartStagePlatform(snapshot.Record); err != nil && !preserveChangedWakeRestartStage(err) {
 			return errors.Join(diagnosticErr, fmt.Errorf("reclaim wake restart stage before quarantine: %w", err))
 		}
 

--- a/internal/cli/wake_restart_stage_reclaim_unix.go
+++ b/internal/cli/wake_restart_stage_reclaim_unix.go
@@ -2,7 +2,30 @@
 
 package cli
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+type wakeRestartStageIdentityError struct {
+	path string
+}
+
+func (err *wakeRestartStageIdentityError) Error() string {
+	return fmt.Sprintf("refuse cleanup of changed Darwin wake restart stage %q", err.path)
+}
+
+// A dead wake's lock and its staged executable have independent identities.
+// Releasing the exact stale lock does not require authority to delete a stage
+// whose persisted identity no longer agrees (for example after a remount).
+func preserveChangedWakeRestartStage(err error) bool {
+	var changed *wakeRestartStageIdentityError
+	if !errors.As(err, &changed) {
+		return false
+	}
+	_ = writeStderr("warning: preserving restart stage %q: saved file identity no longer matches; wake cleanup will continue\n", changed.path)
+	return true
+}
 
 var reclaimWakeRestartStageForStaleLock = reclaimWakeRestartStagePlatform
 
@@ -27,12 +50,14 @@ func reclaimWakeRestartStateForLockRemovalAt(
 				"live wake restart successor handoff is preserved before lock removal",
 			)
 		}
-		if err := reclaimWakeRestartStageForStaleLock(record); err != nil {
+		if err := reclaimWakeRestartStageForStaleLock(record); err != nil &&
+			(lock.Status != wakeLockStale || !preserveChangedWakeRestartStage(err)) {
 			return fmt.Errorf("reclaim persisted wake restart stage: %w", err)
 		}
 		quarantine = &snapshot
 	}
-	if err := reclaimWakeRestartRunningImagePlatform(lock.Lock); err != nil {
+	if err := reclaimWakeRestartRunningImagePlatform(lock.Lock); err != nil &&
+		(lock.Status != wakeLockStale || !preserveChangedWakeRestartStage(err)) {
 		return fmt.Errorf("reclaim wake running stage before lock removal: %w", err)
 	}
 	if quarantine != nil {

--- a/internal/cli/wake_restart_stale_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stale_stage_darwin_test.go
@@ -1,0 +1,141 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression: the 2026-09-05 reboot report had a dead wake and an unchanged
+// staged executable whose device number differed from the persisted evidence.
+func TestStaleWakeReleasePreservesChangedDarwinStage(t *testing.T) {
+	for _, source := range []string{"running image", "persisted restart"} {
+		for _, mismatch := range []string{"device after reboot", "content identity"} {
+			for _, route := range []string{"coop", "doctor"} {
+				t.Run(source+"/"+mismatch+"/"+route, func(t *testing.T) {
+					fixture := newConsecutiveDarwinWakeRestartFixture(t)
+					evidence := fixture.currentEvidence
+					if mismatch == "device after reboot" {
+						evidence.Device++
+					} else {
+						evidence.SHA256 = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+					}
+					if source == "persisted restart" {
+						fixture.record.BoundImage = &evidence
+						fixture.record.Candidate.SHA256 = evidence.SHA256
+						if err := withWakeMutationScopeInDir(fixture.agentDir, func(scope *wakeMutationScope) error {
+							return writeWakeRestartRecordAt(scope, fixture.record)
+						}); err != nil {
+							t.Fatal(err)
+						}
+					} else if err := os.Remove(filepath.Join(filepath.Dir(fixture.lockPath), wakeRestartFileName)); err != nil {
+						t.Fatal(err)
+					}
+					lock := fixture.stale.Lock
+					lock.RunningImageEvidence = &evidence
+					writeWakeLockForTest(t, fixture.root, fixture.agent, lock)
+					before, err := os.Stat(evidence.ExecutionPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					// Releasing a stale lock must never relax stage deletion authority.
+					var changed *wakeRestartStageIdentityError
+					if err := cleanupDarwinWakeRestartStage(evidence, true); !errors.As(err, &changed) {
+						t.Fatalf("direct stage cleanup = %v, want identity refusal", err)
+					}
+					if route == "coop" {
+						if err := prepareCoopWakeLock(fixture.root, fixture.agent, true, "unused"); err != nil {
+							t.Fatalf("coop preflight: %v", err)
+						}
+					} else {
+						stale := inspectWakeLock(fixture.root, fixture.agent)
+						result := opsWakeLock{}
+						if err := fixStaleWakeLockForDoctor(fixture.root, fixture.agent, &stale, &result); err != nil || !result.Removed {
+							t.Fatalf("doctor removed=%v: %v", result.Removed, err)
+						}
+					}
+					if _, err := os.Lstat(fixture.lockPath); !os.IsNotExist(err) {
+						t.Fatalf("stale lock survived: %v", err)
+					}
+					after, err := os.Stat(evidence.ExecutionPath)
+					if err != nil || !os.SameFile(before, after) {
+						t.Fatalf("unmatched stage was not preserved: %v", err)
+					}
+					if actual, err := captureWakeImageEvidence(evidence.ExecutionPath, evidence.EmbeddedVersion); err != nil || !sameDarwinStagedWakeImageEvidence(actual, fixture.currentEvidence) {
+						t.Fatalf("preserved stage content changed: %v", err)
+					}
+					cleanup, err := acquireWakeLockWithOptionsInDir(fixture.agentDir, fixture.root, fixture.agent, wakeLockAcquireOptions{wakeMode: wakeInjectModeNone})
+					if err != nil {
+						t.Fatalf("fresh wake acquisition after stale removal: %v", err)
+					}
+					cleanup()
+				})
+			}
+		}
+	}
+}
+
+func TestChangedDarwinStageDoesNotReleaseUnverifiedWake(t *testing.T) {
+	fixture := newConsecutiveDarwinWakeRestartFixture(t)
+	evidence := fixture.currentEvidence
+	evidence.Device++
+	lock := fixture.stale.Lock
+	lock.RunningImageEvidence = &evidence
+	writeWakeLockForTest(t, fixture.root, fixture.agent, lock)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: true}
+	})
+	inspection := inspectWakeLock(fixture.root, fixture.agent)
+	if inspection.Status != wakeLockUnverified {
+		t.Fatalf("wake with unreadable running process identity: %s", inspection.Status)
+	}
+	if err := fixture.agentDir.withFD(func(fd int) error {
+		return reclaimWakeRestartStateForLockRemovalAt(fd, fixture.agentDir, inspection)
+	}); err == nil {
+		t.Fatal("unverified wake accepted changed stage")
+	}
+	if _, err := os.Stat(fixture.lockPath); err != nil {
+		t.Fatalf("unverified lock was removed: %v", err)
+	}
+}
+
+// The same identity mismatch also trapped doctor in a retry loop after the
+// lock disappeared but a persisted restart record remained.
+func TestDoctorPreservesChangedDarwinStageWithoutLock(t *testing.T) {
+	fixture := newConsecutiveDarwinWakeRestartFixture(t)
+	evidence := fixture.currentEvidence
+	evidence.Device++
+	fixture.record.BoundImage = &evidence
+	if err := withWakeMutationScopeInDir(fixture.agentDir, func(scope *wakeMutationScope) error {
+		return writeWakeRestartRecordAt(scope, fixture.record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fixture.lockPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixWakeRestartResidueWithoutLock(fixture.root, fixture.agent); err != nil {
+		t.Fatalf("doctor could not retire abandoned record: %v", err)
+	}
+	if _, err := os.Stat(evidence.ExecutionPath); err != nil {
+		t.Fatalf("changed stage was removed: %v", err)
+	}
+	entries, err := scanWakeQuarantine(fixture.root)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("retained restart evidence: entries=%v err=%v", entries, err)
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(fixture.lockPath), wakeRestartFileName)); !os.IsNotExist(err) {
+		t.Fatalf("abandoned record still active: %v", err)
+	}
+	if err := fixWakeRestartResidueWithoutLock(fixture.root, fixture.agent); err != nil {
+		t.Fatalf("repeated doctor fix entered a failure loop: %v", err)
+	}
+	cleanup, err := acquireWakeLockWithOptionsInDir(fixture.agentDir, fixture.root, fixture.agent, wakeLockAcquireOptions{wakeMode: wakeInjectModeNone})
+	if err != nil {
+		t.Fatalf("fresh wake acquisition: %v", err)
+	}
+	cleanup()
+}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -222,7 +222,9 @@ Without `--session` or `--root`, `coop exec` uses the declared `default_session`
 
 Direct `coop exec` names the provider session by default as
 `<session>/<handle>`, or as `<handle>` for a sessionless root. Claude and Pi
-get `--name`; Codex and Cursor `agent` get a best-effort TUI rename after the
+get `--name`; Codex uses its native naming API after process-bound thread
+discovery, with a manual `/rename` fallback that does not affect queue delivery.
+Cursor `agent` gets a best-effort TUI rename after the
 new session store is verified. Codex resumes by name, for example `codex resume
 session1/codex`. Cursor `agent` resumes through its picker only; resume-by-name
 is unproven. Existing names and `--resume`, `-r`, `--continue`, or `-c` flags

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -227,8 +227,10 @@ discovery, with a manual `/rename` fallback that does not affect queue delivery.
 Cursor `agent` gets a best-effort TUI rename after the
 new session store is verified. Codex resumes by name, for example `codex resume
 session1/codex`. Cursor `agent` resumes through its picker only; resume-by-name
-is unproven. Existing names and `--resume`, `-r`, `--continue`, or `-c` flags
-are preserved, including `codex resume` and `agent --resume`. Disable naming
+is unproven. Codex naming checks for an existing name immediately before setting
+one; preservation is best effort because the native API has no atomic
+set-if-unnamed operation. `--resume`, `-r`, `--continue`, or `-c` flags are
+preserved, including `codex resume` and `agent --resume`. Disable naming
 with `--named=false`, `AMQ_COOP_NAMED=0`, or
 `"named": false` in `.amq/launch.json`. Managed launches keep naming disabled
 until their provider-name contract is available; explicit `--named` remains


### PR DESCRIPTION
Recovers coop wake after reboot when the staged executable's device identity changed: stale-lock removal preserves the unmatched stage instead of failing, while stage deletion keeps exact-match authority. Binds Codex session naming to the spawned process (native API after process-bound thread discovery, idle-composer wait without a total deadline, fresh read before set preserving concurrent custom names). Adds actionable env/peer/owner remedies and executes each remedy in-test.

Commits: a2037ae, 3f14950, fde81d0. Reviews: Astra APPROVE (full delta), focused peer APPROVEs on each snapshot. Gates: exact-snapshot make ci exit 0 plus pre-push make ci green on push.