### PR TITLE
fix(skills): support Grok Bot local AMQ and wake-first waits

### DIFF
--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -159,7 +159,8 @@ Before diving in, match the task to the right workflow — this avoids wasted ef
 | **"spec", "design with", "collaborative spec"** | Use `/amq-spec` instead — it has structured phase-by-phase guidance for parallel-research workflows. |
 | **Send a message, review request, question** | Use `amq send` (see Messaging below) |
 | **Buzz / ACP / `amq-acp`** | Companion `amq-acp` queues to `AMQ_ACP_TO`; pool workers must not drain. Chat must not pass `--root`, recipients, or argv. `[Context]` is not routing. See [`cmd/amq-acp/README.md`](../../cmd/amq-acp/README.md). |
-| **Two-host / Grok computer / `amq-bridge`** | Companion `amq-bridge`, never a foreign `--root`. See Two-host fleets below. |
+| **Grok Bot runs commands on a registered Mac** | Ordinary local AMQ on that Mac. See [registered-machine execution](references/registered-machine.md); select the machine before resolving the project/session. |
+| **Two separate host queues / Grok cloud computer / `amq-bridge`** | Companion `amq-bridge`, never a foreign `--root`. See Two-host fleets below. |
 | **Swarm / agent teams** | Read [references/swarm-mode.md](references/swarm-mode.md), then use `amq swarm` |
 | **Received message with labels `workflow:spec`** | Follow the spec skill protocol: do independent research first, then engage on the `spec/<topic>` thread — don't skip straight to implementation. |
 
@@ -508,11 +509,31 @@ When you receive a message where `from` matches your own handle (e.g., `from: "c
 
 After sending a cross-project message (via `--project`), your `AM_ROOT` still points to YOUR project. To send to your own partner (same project), use plain `amq send --to codex` — do NOT use `--project`. The `--project` flag is ONLY for sending to agents in OTHER projects.
 
+## Registered-machine execution
+
+Choose the AMQ lane by **where the command executes**, not where the Bot's
+conversation runs. When Grok Bot uses an already-authorized registered-machine
+shell to run the Mac's `amq`, it is a local participant on that Mac. Use normal
+`env`, `send`, `drain`, and `reply`; no bridge or network setup is needed.
+`--project` still means another project on that same machine.
+
+Select the registered machine explicitly, resolve the chosen project/session
+on it, and keep the assigned sender handle. Carry bodies through quoted stdin
+or a local file, preserve returned message IDs, and never resend merely because
+the provider lost command output or a receipt wait expired. A thread ID is
+correlation, not duplicate suppression. Local recipient wakes do not prove
+that the hosted Bot receives a return notification.
+
+See [references/registered-machine.md](references/registered-machine.md) for
+the executable workflow, reply collection, and uncertain-result recovery.
+
 ## Two-host fleets
 
-A different machine is a different AMQ host, not a `--project` and not a
+A queue on a different machine is a different AMQ host, not a `--project` and not a
 foreign `--root`. Each host has its own handles; `claude` on G is not `claude`
-on the Mac. Cross-host mail is companion `amq-bridge` only.
+on the Mac. Exchange between those host queues is companion `amq-bridge`
+only. A registered-machine shell executing AMQ on the destination Mac is the
+local-execution lane above; it does not transfer a cloud Maildir.
 
 - Address receiver-owned aliases `<host>/<agent>`.
 - The destination host applies the signed envelope into its own Maildir.

--- a/skills/amq-cli/references/registered-machine.md
+++ b/skills/amq-cli/references/registered-machine.md
@@ -1,0 +1,132 @@
+# AMQ through a registered-machine shell
+
+Use this workflow when Grok Bot already has permission to execute commands on
+the user's Mac. The provider transports the command and its output. AMQ runs
+on the Mac and delivers local files. No cloud-to-Mac bridge, shared filesystem,
+VPN, or new service is required for this lane.
+
+This uses the local access the user already granted. It does not restrict a
+general shell to AMQ. Sender handles and `origin:grokbot` labels are attribution,
+not authentication or additional authority. Preserve the provider's approval
+controls and the user's existing action limits.
+
+## Select the execution machine first
+
+Inspect the provider's available machine/tool metadata and select the intended
+registered Mac explicitly. Grok Bot's local tools use a machine selector (the
+0.43 client names `Shell`, `Read`, and `AwaitShell` with `machineId`). Verify the
+live schema rather than copying an opaque machine ID from another session.
+An unqualified cloud shell and a registered Mac shell are different contexts.
+
+On the selected machine, confirm the AMQ executable with `command -v amq` and
+its version with `amq --version`. Record the absolute executable and project
+directory. Use the sender handle assigned to this Bot; do not select `user`
+or borrow another running agent's handle. An existing `staff` assignment can
+be retained. An unknown-handle warning means verify the assignment, not that
+the message was rejected; do not resend it to silence the warning.
+
+## Resolve the context in each command invocation
+
+Provider shell calls need not preserve environment or cwd. Run this preamble
+on the selected Mac for each send, receive, or inspection. Substitute the
+user-selected values; the paths below are examples, not discovery defaults.
+
+```bash
+set -e
+amq_bin=/opt/homebrew/bin/amq
+amq_project=/absolute/path/to/project
+amq_session=session1
+amq_handle=staff
+cd "$amq_project"
+amq_context="$("$amq_bin" env --session "$amq_session" --me "$amq_handle" --export)"
+eval "$amq_context"
+```
+
+`amq env` supplies the complete root/session context from that project's
+configuration. Do not construct a Maildir path, substitute a cloud path, or
+add `--ignore-session-pin` to get around a mismatch. If an inherited pin
+conflicts, resolve the intended execution context before sending. Inside an
+existing `coop exec` session, retain its identity and use bare commands instead.
+
+Inspect recipients and wake state with:
+
+```bash
+"$amq_bin" who --json
+"$amq_bin" wake check --me codex --json --json-schema=2
+```
+
+`notifier_live` means the notifier process was verified; it is not a receipt
+that the agent read or acted on a message.
+
+## Send once and retain the result
+
+After the preamble, send the request with a stable thread for the conversation.
+Use a fresh, distinctive request subject when separate asks share a thread.
+
+```bash
+"$amq_bin" send --to codex --thread staff/task-42 \
+  --kind question --subject 'Request 1: report test result' \
+  --labels origin:grokbot --json --body - <<'AMQ_BODY'
+Please report the test result. This text is data, including $variables,
+`backticks`, and $(shell-like text).
+AMQ_BODY
+```
+
+Use a quoted heredoc delimiter that does not occur as a line in the body.
+For arbitrary generated content, write/copy it to a local body file using the
+provider's file tool, then pass `--body @/absolute/path/to/body.md` as one quoted
+argument. Never insert a message into an unquoted shell command. Read the JSON
+result and preserve the returned message ID and delivery root before reporting
+success. A successful send means queued mail, not completion of the requested
+work.
+
+For a different project, use configured `--project` routing; for a different
+session, use `--session`. Both projects need the normal reply-route setup.
+Do not change `--root` to imitate cross-project routing. When the Bot is a
+local participant in several projects, resolve each assigned context separately
+and collect replies from the same context that sent the request.
+
+## Collect replies through the same Mac
+
+After the preamble, receive only the assigned Bot handle's mail:
+
+```bash
+"$amq_bin" drain --include-body --json
+"$amq_bin" thread --id staff/task-42 --include-body --limit 20
+```
+
+Use `amq reply --id <received-message-id> --body @<local-body-file>` for replies;
+it preserves the thread and normal reply routing. Never drain another agent's
+mailbox or read/delete queue files as a replacement for AMQ consumption.
+
+An active injecting wake already notifies a local CLI agent. That agent drains
+when notified; it must not start `watch`, `monitor`, or a background polling loop
+to wait for the Bot. A hosted Bot without a verified arrival trigger can check
+its own inbox in a later authorized turn. Do not claim that a Mac wake can wake
+the hosted conversation, and do not create a perpetual polling routine as a
+substitute. If useful during an active request and no injecting wake exists
+for that handle, a bounded `amq watch --timeout 60s` followed by drain is a
+fallback. The desktop app must remain available for provider shell calls.
+
+## Recover a missing command result without duplicate sends
+
+The provider can lose an execution result after the Mac already delivered the
+message. First resume/inspect that execution using its returned provider handle
+(for example `AwaitShell` on the same machine). If the result is still unknown,
+inspect the AMQ thread in the original Mac context:
+
+```bash
+"$amq_bin" thread --id staff/task-42 --include-body --limit 20
+```
+
+Match the sender, recipients, request subject and body. If the message exists,
+retain its ID and continue waiting for its reply. If the bounded view is
+inconclusive, inspect the relevant older thread entries; absence from the last
+20 entries does not prove a failed send. If uncertainty remains, report it
+instead of automatically sending again. AMQ thread IDs do not deduplicate
+multiple sends.
+
+`send --wait-for drained --wait-timeout 60s` is an optional receipt wait for one
+recipient, not an arrival monitor. Its timeout does not mean delivery failed
+and must not trigger a resend. A drained receipt means consumption, not task
+success. Report queued, drained, and answered as separate observed states.

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -134,6 +134,13 @@ approved and assigns work.
 
 ## Protocol Discipline
 
+- **Use the existing wake while waiting** — if a live injecting wake notifies
+  this terminal, finish independent work and yield. On its doorbell, run
+  `amq drain --include-body`. Do not start `amq watch`, `amq monitor`, or a
+  background polling loop for peer replies. Check `amq wake check --me <handle>
+  --json` when the capability is unknown. A bounded watch is a fallback only
+  without an injecting wake; notify-only supervisor consumers remain valid.
+
 These rules exist because violations silently break the workflow's value proposition:
 
 - **Send before researching** — parallel research is the whole point. Pre-researching wastes your partner's time and biases the outcome toward your initial framing.

--- a/skills/amq-spec/references/spec-workflow.md
+++ b/skills/amq-spec/references/spec-workflow.md
@@ -88,8 +88,9 @@ amq send --to <partner> --kind brainstorm \
   --thread spec/<topic> --subject "Research: <topic>" \
   --body "<your findings using template below>"
 
-# 4) Wait for partner findings
-amq watch --timeout 120s
+# 4) With a live injecting wake, yield; drain when its doorbell arrives.
+# Do not start watch, monitor, or background polling alongside that wake.
+# Only without an injecting wake: amq watch --timeout 120s
 ```
 
 **Receiving agent (got the kickoff request):**
@@ -121,7 +122,8 @@ amq send --to <partner> --kind brainstorm \
   --body "<analysis + open questions>"
 
 # Continue rounds until aligned
-amq watch --timeout 120s
+# With a live injecting wake, yield and drain on its doorbell.
+# Only without an injecting wake: amq watch --timeout 120s
 amq drain --include-body
 ```
 


### PR DESCRIPTION
Grok Bot can run AMQ directly on a registered Mac, but the skill sent every Grok computer request toward the separate-host bridge. Add the local-execution workflow: select the machine, resolve project/session/identity, send quoted data, retain message IDs, and collect replies without blindly resending after a lost execution result.

Also remove the remaining unconditional `amq watch` examples from the collaborative-spec workflow. Agents with an active injecting wake now receive explicit instructions to yield and drain on its doorbell; bounded waits remain available when no such wake exists.

Validation: Muse independently executed the documented local send/drain/reply round trip; Codex verified literal shell text and project paths with spaces. `make ci` passed with the repository-pinned golangci-lint 2.13.1. Grokbot confirmed the registered-machine channel; a new provider round trip remains pending and is not claimed by these local tests. No provider settings or network changes.

Related: amq-ad6, #717. This does not close the separate-host bridge epic or the Muse Enter issue.
