### PR TITLE
feat(remote): request core, endpoint, fake runtime, AMQ carrier and amq-remote CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__/
 
 # Added by ggshield
 .cache_ggshield
+/amq-remote

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq-keepalive ./cmd/amq-keepalive
 	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq-bridge ./cmd/amq-bridge
 	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq-acp ./cmd/amq-acp
+	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq-remote ./cmd/amq-remote
 
 test:
 	go test ./...

--- a/cmd/amq-remote/main.go
+++ b/cmd/amq-remote/main.go
@@ -189,6 +189,14 @@ func finish(w io.Writer, out any, asJSON bool, code int, err error) int {
 
 func printHuman(w io.Writer, out any) {
 	switch v := out.(type) {
+	case protocol.Reply:
+		printHuman(w, v.Snapshot)
+		if v.Outcome.Code != "" {
+			say(w, "outcome=%s\n", v.Outcome.Code)
+		}
+		if v.Outcome.Disposition != "" {
+			say(w, "cancel=%s\n", v.Outcome.Disposition)
+		}
 	case protocol.Snapshot:
 		say(w, "%s  %s", v.State, v.RequestRef)
 		if v.Code != "" {
@@ -442,11 +450,11 @@ func submit(args []string, stdin io.Reader) (any, int, error) {
 		NotAfter:  protocol.FormatTime(time.Now().Add(*window)),
 		Input:     &protocol.SubmitInput{Text: body, Busy: protocol.Busy(*busy), Deliver: protocol.Deliver(*deliver)},
 	}
-	snap, err := callSnapshot(stateDir, cmd)
+	rep, err := callReply(stateDir, cmd)
 	if err != nil {
 		return nil, 0, err
 	}
-	return snap, exitForReply(snap, false), nil
+	return rep, exitForOutcome(rep), nil
 }
 
 func inspectTarget(stateDir, target string) (protocol.Session, error) {
@@ -464,19 +472,30 @@ func inspectTarget(stateDir, target string) (protocol.Session, error) {
 	return s, nil
 }
 
-func callSnapshot(stateDir string, cmd *protocol.Command) (protocol.Snapshot, error) {
+func callReply(stateDir string, cmd *protocol.Command) (protocol.Reply, error) {
 	resp, err := ipc.Call(stateDir, ipc.Request{Command: cmd})
 	if err != nil {
-		return protocol.Snapshot{}, err
+		return protocol.Reply{}, err
 	}
 	if err := resp.AsError(); err != nil {
-		return protocol.Snapshot{}, err
+		return protocol.Reply{}, err
 	}
-	var snap protocol.Snapshot
-	if err := json.Unmarshal(resp.Reply, &snap); err != nil {
-		return protocol.Snapshot{}, err
+	var rep protocol.Reply
+	if err := json.Unmarshal(resp.Reply, &rep); err != nil {
+		return protocol.Reply{}, err
 	}
-	return snap, nil
+	return rep, nil
+}
+
+// exitForOutcome maps a request Reply to the exit code. An op-specific
+// Outcome.Code (request_conflict, already_resolved) is action-required and must
+// not exit 0 just because the snapshot state reads running/completed; otherwise
+// the exit follows the recorded state.
+func exitForOutcome(rep protocol.Reply) int {
+	if rep.Outcome.Code != "" {
+		return protocol.ExitCode(&protocol.Refusal{Code: rep.Outcome.Code})
+	}
+	return exitForReply(rep.Snapshot, false)
 }
 
 // exitForReply maps a snapshot to the exit code. submit and status report the
@@ -507,11 +526,11 @@ func status(args []string) (any, int, error) {
 	if err != nil {
 		return nil, protocol.ExitUsage, err
 	}
-	snap, err := callSnapshot(stateDir, &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpRequestGet, RequestRef: pos[0]})
+	rep, err := callReply(stateDir, &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpRequestGet, RequestRef: pos[0]})
 	if err != nil {
 		return nil, 0, err
 	}
-	return snap, exitForReply(snap, false), nil
+	return rep, exitForOutcome(rep), nil
 }
 
 func wait(args []string) (any, int, error) {
@@ -581,7 +600,7 @@ func cancel(args []string) (any, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	snap, err := callSnapshot(stateDir, &protocol.Command{
+	rep, err := callReply(stateDir, &protocol.Command{
 		Schema:     protocol.SchemaCommand,
 		Op:         protocol.OpRequestCancel,
 		RequestRef: ref,
@@ -592,7 +611,7 @@ func cancel(args []string) (any, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	return snap, 0, nil
+	return rep, exitForOutcome(rep), nil
 }
 
 func listRequests(args []string) (any, int, error) {

--- a/cmd/amq-remote/main.go
+++ b/cmd/amq-remote/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/remote/amqio"
+	"github.com/avivsinai/agent-message-queue/internal/remote/codex"
 	"github.com/avivsinai/agent-message-queue/internal/remote/core"
 	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
 	"github.com/avivsinai/agent-message-queue/internal/remote/ipc"
@@ -243,6 +244,9 @@ func serve(args []string, stdout, stderr io.Writer) (int, error) {
 	c := addCommon(fs)
 	me := fs.String("me", amqio.DefaultHandle, "endpoint mailbox handle in the root")
 	useFake := fs.Bool("fake", false, "register the deterministic fake runtime as target 'fake'")
+	codexSocket := fs.String("codex-socket", "", "unix socket of the running Codex app-server daemon; attaches its loaded threads")
+	codexThread := fs.String("codex-thread", "", "attach only this Codex thread id (with --codex-socket)")
+	codexApprove := fs.Bool("codex-approve", false, "advertise approve_tool for Codex threads (only after approval fanout is verified live)")
 	poll := fs.Duration("poll", 500*time.Millisecond, "AMQ import and reconciliation interval")
 	if err := fs.Parse(args); err != nil {
 		return protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%v", err)
@@ -269,6 +273,25 @@ func serve(args []string, stdout, stderr io.Writer) (int, error) {
 	}
 	if *useFake {
 		ep.Register(fake.New("fake", "e_1"))
+	}
+	if *codexSocket != "" {
+		codex.Version = version
+		threads := []string{*codexThread}
+		if *codexThread == "" {
+			threads, err = codex.LoadedThreads(*codexSocket)
+			if err != nil {
+				_ = ep.Close()
+				return 0, fmt.Errorf("list codex threads: %w", err)
+			}
+		}
+		for _, id := range threads {
+			att, err := codex.Attach(*codexSocket, id, codex.WithApprovals(*codexApprove))
+			if err != nil {
+				say(stderr, "codex thread %s: %v\n", id, err)
+				continue
+			}
+			ep.Register(att)
+		}
 	}
 	if err := ep.Reconcile(); err != nil {
 		_ = ep.Close()

--- a/cmd/amq-remote/main.go
+++ b/cmd/amq-remote/main.go
@@ -1,0 +1,656 @@
+// Command amq-remote is the AMQ Remote companion: an endpoint that attaches to
+// running harness sessions and a CLI that submits, follows, and cancels
+// requests against it. It is a companion beside amq, like amq-bridge and
+// amq-keepalive; amq itself gains no socket. See docs/adr-remote-control.md.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/amqio"
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
+	"github.com/avivsinai/agent-message-queue/internal/remote/ipc"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+var version = "dev"
+
+// stateDirName is the extension directory under the AMQ root that the
+// endpoint owns. amq cleanup never touches extension data.
+const stateDirName = "extensions/remote"
+
+const usageText = `Usage: amq-remote <command> [options]
+
+Attach to a running harness session from another client. A request has an
+identity and a result; every reply is a snapshot of that request.
+
+Commands:
+  serve                    Run the endpoint for this root (foreground)
+  sessions                 List shared runtimes and their capabilities
+  inspect TARGET           Current state of one runtime
+  submit TARGET            Submit one work request; prints its receipt
+  status REQUEST_REF       Current recorded snapshot
+  wait REQUEST_REF         Wait for that request's outcome
+  cancel REQUEST_REF       Cancel that exact request
+  requests                 Recent local request records
+  doctor                   Diagnose the endpoint chain
+  version                  Print the version
+
+Common options:
+  --root DIR    AMQ root (default: AM_ROOT)
+  --json        Machine-readable output on stdout; diagnostics on stderr
+
+Exit codes: 0 ok · 1 work failed or cancelled · 2 usage · 3 not found ·
+4 timeout · 5 context mismatch · 6 action required (busy, unsupported,
+unshared, expired, uncertain) · 130 interrupted
+`
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+type common struct {
+	root string
+	json bool
+}
+
+func addCommon(fs *flag.FlagSet) *common {
+	c := &common{}
+	fs.StringVar(&c.root, "root", os.Getenv("AM_ROOT"), "AMQ root directory (default AM_ROOT)")
+	fs.BoolVar(&c.json, "json", false, "emit JSON")
+	return c
+}
+
+func (c *common) stateDir() (string, error) {
+	if c.root == "" {
+		return "", protocol.Refuse(protocol.CodeInvalid, "--root or AM_ROOT is required")
+	}
+	if !filepath.IsAbs(c.root) {
+		return "", protocol.Refuse(protocol.CodeInvalid, "--root must be absolute")
+	}
+	return filepath.Join(c.root, stateDirName), nil
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		say(stderr, "%s", usageText)
+		return protocol.ExitUsage
+	}
+	switch args[0] {
+	case "-v", "--version", "version":
+		say(stdout, "amq-remote %s\n", version)
+		return 0
+	}
+	cmd, rest := args[0], args[1:]
+	var err error
+	var out any
+	var code int
+	switch cmd {
+	case "serve":
+		code, err = serve(rest, stdout, stderr)
+		return finish(stderr, nil, false, code, err)
+	case "sessions":
+		out, code, err = clientSimple(rest, protocol.OpSessionList, "")
+	case "inspect":
+		out, code, err = clientSimple(rest, protocol.OpSessionInspect, "TARGET")
+	case "submit":
+		out, code, err = submit(rest, stdin)
+	case "status":
+		out, code, err = status(rest)
+	case "wait":
+		out, code, err = wait(rest)
+	case "cancel":
+		out, code, err = cancel(rest)
+	case "requests":
+		out, code, err = listRequests(rest)
+	case "doctor":
+		out, code, err = doctor(rest)
+	default:
+		say(stderr, "unknown command %q\n%s", cmd, usageText)
+		return protocol.ExitUsage
+	}
+	wantJSON := hasFlag(rest, "json")
+	return finish(stdout, out, wantJSON, code, err)
+}
+
+// parseInterleaved accepts flags before or after positional arguments, the
+// way the other amq companions do, and returns the positionals in order.
+func parseInterleaved(fs *flag.FlagSet, args []string) ([]string, error) {
+	var positionals []string
+	for {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		rest := fs.Args()
+		if len(rest) == 0 {
+			return positionals, nil
+		}
+		positionals = append(positionals, rest[0])
+		args = rest[1:]
+	}
+}
+
+func say(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...)
+}
+
+func hasFlag(args []string, name string) bool {
+	for _, a := range args {
+		if a == "--"+name || a == "-"+name || strings.HasPrefix(a, "--"+name+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// finish prints the reply and maps the outcome to the AMQ exit contract.
+func finish(w io.Writer, out any, asJSON bool, code int, err error) int {
+	if err != nil {
+		if asJSON {
+			body := map[string]any{"error": err.Error()}
+			var r *protocol.Refusal
+			if errors.As(err, &r) {
+				body["code"] = string(r.Code)
+			}
+			_ = json.NewEncoder(w).Encode(body)
+		} else {
+			fmt.Fprintln(os.Stderr, "amq-remote:", err)
+		}
+		if code != 0 {
+			return code
+		}
+		return protocol.ExitCode(err)
+	}
+	if out != nil {
+		if asJSON {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(out)
+		} else {
+			printHuman(w, out)
+		}
+	}
+	return code
+}
+
+func printHuman(w io.Writer, out any) {
+	switch v := out.(type) {
+	case protocol.Snapshot:
+		say(w, "%s  %s", v.State, v.RequestRef)
+		if v.Code != "" {
+			say(w, "  code=%s", v.Code)
+		}
+		if v.NativeRun != nil {
+			say(w, "  run=%s", *v.NativeRun)
+		}
+		say(w, "\n")
+		if v.Result != nil {
+			say(w, "%s\n", v.Result.Text)
+			if v.Result.Truncated {
+				say(w, "%s\n", "[truncated; full result stays with the harness]")
+			}
+		}
+	case []protocol.Session:
+		for _, s := range v {
+			printSession(w, s)
+		}
+	case protocol.Session:
+		printSession(w, v)
+	default:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+	}
+}
+
+func printSession(w io.Writer, s protocol.Session) {
+	caps := []string{}
+	if s.Capabilities.Submit {
+		caps = append(caps, "submit")
+	}
+	if s.Capabilities.CancelRequest {
+		caps = append(caps, "cancel")
+	}
+	if s.Capabilities.Steer {
+		caps = append(caps, "steer")
+	}
+	if s.Capabilities.ApproveTool {
+		caps = append(caps, "approve")
+	}
+	if s.Capabilities.AnswerQuestion {
+		caps = append(caps, "answer")
+	}
+	say(w, "%-24s %-8s %-8s %-8s epoch=%s caps=%s\n", s.TargetID, s.Harness, s.Attachment, s.Status, s.Epoch, strings.Join(caps, ","))
+}
+
+// serve runs the endpoint: store, attachments, IPC socket, AMQ import loop.
+func serve(args []string, stdout, stderr io.Writer) (int, error) {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	c := addCommon(fs)
+	me := fs.String("me", amqio.DefaultHandle, "endpoint mailbox handle in the root")
+	useFake := fs.Bool("fake", false, "register the deterministic fake runtime as target 'fake'")
+	poll := fs.Duration("poll", 500*time.Millisecond, "AMQ import and reconciliation interval")
+	if err := fs.Parse(args); err != nil {
+		return protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%v", err)
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return protocol.ExitUsage, err
+	}
+	store, err := requests.Open(stateDir)
+	if err != nil {
+		return 0, err
+	}
+	var carrier *amqio.Carrier
+	ep := core.New(core.Config{Store: store, Publish: func(s protocol.Snapshot, origin map[string]string) error {
+		if carrier == nil {
+			return nil
+		}
+		return carrier.Publish(s, origin)
+	}})
+	carrier, err = amqio.New(c.root, *me, ep)
+	if err != nil {
+		_ = store.Close()
+		return 0, err
+	}
+	if *useFake {
+		ep.Register(fake.New("fake", "e_1"))
+	}
+	if err := ep.Reconcile(); err != nil {
+		_ = ep.Close()
+		return 0, fmt.Errorf("reconcile: %w", err)
+	}
+	server, err := ipc.Listen(stateDir, ep)
+	if err != nil {
+		_ = ep.Close()
+		return 0, err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	say(stdout, "amq-remote %s serving root=%s handle=%s socket=%s targets=%d\n", version, c.root, *me, server.Path(), len(ep.Targets()))
+	go func() {
+		t := time.NewTicker(*poll)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if _, err := carrier.ImportOnce(); err != nil {
+					say(stderr, "import: %v\n", err)
+				}
+				if err := ep.Tick(); err != nil {
+					say(stderr, "tick: %v\n", err)
+				}
+			}
+		}
+	}()
+	err = server.Serve(ctx)
+	if cerr := ep.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
+	return 0, err
+}
+
+func clientSimple(args []string, op protocol.Op, positional string) (any, int, error) {
+	fs := flag.NewFlagSet(string(op), flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	pos, err := parseInterleaved(fs, args)
+	if err != nil {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%v", err)
+	}
+	cmd := &protocol.Command{Schema: protocol.SchemaCommand, Op: op}
+	if positional != "" {
+		if len(pos) != 1 {
+			return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%s is required", positional)
+		}
+		cmd.TargetID = pos[0]
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	resp, err := ipc.Call(stateDir, ipc.Request{Command: cmd})
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := resp.AsError(); err != nil {
+		return nil, 0, err
+	}
+	if op == protocol.OpSessionList {
+		var out []protocol.Session
+		if err := json.Unmarshal(resp.Reply, &out); err != nil {
+			return nil, 0, err
+		}
+		return out, 0, nil
+	}
+	var out protocol.Session
+	if err := json.Unmarshal(resp.Reply, &out); err != nil {
+		return nil, 0, err
+	}
+	return out, 0, nil
+}
+
+func submit(args []string, stdin io.Reader) (any, int, error) {
+	fs := flag.NewFlagSet("submit", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	text := fs.String("text", "", "prompt text")
+	textFile := fs.String("text-file", "", "read prompt text from a file")
+	useStdin := fs.Bool("stdin", false, "read prompt text from stdin")
+	busy := fs.String("busy", string(protocol.BusyReject), "reject or queue when the runtime is busy")
+	deliver := fs.String("deliver", string(protocol.DeliverTurn), "turn or steer")
+	requestID := fs.String("request-id", "", "caller-supplied UUID so a retry reconciles instead of resubmitting")
+	window := fs.Duration("admit-within", 2*time.Minute, "latest admission time relative to now (max 24h)")
+	pos, err := parseInterleaved(fs, args)
+	if err != nil {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%v", err)
+	}
+	if len(pos) != 1 {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "TARGET is required")
+	}
+	sources := 0
+	for _, set := range []bool{*text != "", *textFile != "", *useStdin} {
+		if set {
+			sources++
+		}
+	}
+	if sources != 1 {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "exactly one of --text, --text-file, --stdin is required")
+	}
+	body := *text
+	switch {
+	case *textFile != "":
+		data, err := os.ReadFile(*textFile)
+		if err != nil {
+			return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "read --text-file: %v", err)
+		}
+		body = string(data)
+	case *useStdin:
+		data, err := io.ReadAll(io.LimitReader(stdin, protocol.MaxInputBytes+1))
+		if err != nil {
+			return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "read stdin: %v", err)
+		}
+		body = string(data)
+	}
+	if strings.TrimSpace(body) == "" {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "prompt is empty")
+	}
+	if *window <= 0 || *window > 24*time.Hour {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "--admit-within must be within (0, 24h]")
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	target := pos[0]
+	session, err := inspectTarget(stateDir, target)
+	if err != nil {
+		return nil, 0, err
+	}
+	id := *requestID
+	if id == "" {
+		id, err = newUUID()
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	cmd := &protocol.Command{
+		Schema:    protocol.SchemaCommand,
+		Op:        protocol.OpRequestSubmit,
+		RequestID: id,
+		TargetID:  target,
+		Epoch:     session.Epoch,
+		NotAfter:  protocol.FormatTime(time.Now().Add(*window)),
+		Input:     &protocol.SubmitInput{Text: body, Busy: protocol.Busy(*busy), Deliver: protocol.Deliver(*deliver)},
+	}
+	snap, err := callSnapshot(stateDir, cmd)
+	if err != nil {
+		return nil, 0, err
+	}
+	return snap, exitForReply(snap, false), nil
+}
+
+func inspectTarget(stateDir, target string) (protocol.Session, error) {
+	resp, err := ipc.Call(stateDir, ipc.Request{Command: &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpSessionInspect, TargetID: target}})
+	if err != nil {
+		return protocol.Session{}, err
+	}
+	if err := resp.AsError(); err != nil {
+		return protocol.Session{}, err
+	}
+	var s protocol.Session
+	if err := json.Unmarshal(resp.Reply, &s); err != nil {
+		return protocol.Session{}, err
+	}
+	return s, nil
+}
+
+func callSnapshot(stateDir string, cmd *protocol.Command) (protocol.Snapshot, error) {
+	resp, err := ipc.Call(stateDir, ipc.Request{Command: cmd})
+	if err != nil {
+		return protocol.Snapshot{}, err
+	}
+	if err := resp.AsError(); err != nil {
+		return protocol.Snapshot{}, err
+	}
+	var snap protocol.Snapshot
+	if err := json.Unmarshal(resp.Reply, &snap); err != nil {
+		return protocol.Snapshot{}, err
+	}
+	return snap, nil
+}
+
+// exitForReply maps a snapshot to the exit code. submit and status report the
+// recorded state: a still-running request is success for them, a rejected or
+// uncertain one is action required. wait uses ExitForState directly.
+func exitForReply(snap protocol.Snapshot, waiting bool) int {
+	if waiting {
+		return protocol.ExitForState(snap.State)
+	}
+	switch snap.State {
+	case protocol.StateRejected, protocol.StateUncertain:
+		return protocol.ExitActionRequired
+	case protocol.StateFailed, protocol.StateCancelled:
+		return protocol.ExitError
+	}
+	return protocol.ExitSuccess
+}
+
+func status(args []string) (any, int, error) {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	pos, perr := parseInterleaved(fs, args)
+	if perr != nil || len(pos) != 1 {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "REQUEST_REF is required")
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	snap, err := callSnapshot(stateDir, &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpRequestGet, RequestRef: pos[0]})
+	if err != nil {
+		return nil, 0, err
+	}
+	return snap, exitForReply(snap, false), nil
+}
+
+func wait(args []string) (any, int, error) {
+	fs := flag.NewFlagSet("wait", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	timeout := fs.Duration("timeout", 0, "give up after this long; the work continues (0 = no limit)")
+	pos, perr := parseInterleaved(fs, args)
+	if perr != nil || len(pos) != 1 {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "REQUEST_REF is required")
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	type outcome struct {
+		resp *ipc.Response
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		resp, err := ipc.Call(stateDir, ipc.Request{Wait: &ipc.WaitRequest{RequestRef: pos[0], TimeoutMS: timeout.Milliseconds()}})
+		done <- outcome{resp, err}
+	}()
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	defer signal.Stop(sig)
+	select {
+	case <-sig:
+		return nil, protocol.ExitInterrupted, protocol.Refuse(protocol.CodeUnsupported, "wait interrupted; the request keeps running")
+	case o := <-done:
+		if o.err != nil {
+			return nil, 0, o.err
+		}
+		if err := o.resp.AsError(); err != nil {
+			return nil, 0, err
+		}
+		var snap protocol.Snapshot
+		if err := json.Unmarshal(o.resp.Reply, &snap); err != nil {
+			return nil, 0, err
+		}
+		if o.resp.TimedOut {
+			return snap, protocol.ExitTimeout, nil
+		}
+		return snap, exitForReply(snap, true), nil
+	}
+}
+
+func cancel(args []string) (any, int, error) {
+	fs := flag.NewFlagSet("cancel", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	pos, perr := parseInterleaved(fs, args)
+	if perr != nil || len(pos) != 1 {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "REQUEST_REF is required")
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	ref := pos[0]
+	_, targetID, _, err := protocol.DecodeRef(ref)
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	session, err := inspectTarget(stateDir, targetID)
+	if err != nil {
+		return nil, 0, err
+	}
+	snap, err := callSnapshot(stateDir, &protocol.Command{
+		Schema:     protocol.SchemaCommand,
+		Op:         protocol.OpRequestCancel,
+		RequestRef: ref,
+		TargetID:   targetID,
+		Epoch:      session.Epoch,
+		NotAfter:   protocol.FormatTime(time.Now().Add(2 * time.Minute)),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return snap, 0, nil
+}
+
+func listRequests(args []string) (any, int, error) {
+	fs := flag.NewFlagSet("requests", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	limit := fs.Int("limit", 20, "most recent records to show")
+	if err := fs.Parse(args); err != nil {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%v", err)
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	store, err := requests.OpenReadOnly(stateDir)
+	if err != nil {
+		return nil, 0, err
+	}
+	recs, err := store.List()
+	if err != nil {
+		return nil, 0, err
+	}
+	if *limit > 0 && len(recs) > *limit {
+		recs = recs[len(recs)-*limit:]
+	}
+	out := make([]protocol.Snapshot, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.Snapshot)
+	}
+	return out, 0, nil
+}
+
+func doctor(args []string) (any, int, error) {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	c := addCommon(fs)
+	if err := fs.Parse(args); err != nil {
+		return nil, protocol.ExitUsage, protocol.Refuse(protocol.CodeInvalid, "%v", err)
+	}
+	stateDir, err := c.stateDir()
+	if err != nil {
+		return nil, protocol.ExitUsage, err
+	}
+	report := map[string]any{"root": c.root, "state_dir": stateDir, "socket": ipc.SocketPath(stateDir)}
+	code := 0
+	if _, err := os.Stat(stateDir); err != nil {
+		report["endpoint"] = "no state directory; run `amq-remote serve` once"
+		return report, protocol.ExitActionRequired, nil
+	}
+	resp, err := ipc.Call(stateDir, ipc.Request{Command: &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpSessionList}})
+	switch {
+	case err != nil:
+		report["endpoint"] = "not reachable: " + err.Error()
+		code = protocol.ExitActionRequired
+	case resp.AsError() != nil:
+		report["endpoint"] = "refused session.list: " + resp.AsError().Error()
+		code = protocol.ExitActionRequired
+	default:
+		var sessions []protocol.Session
+		_ = json.Unmarshal(resp.Reply, &sessions)
+		report["endpoint"] = "reachable"
+		report["targets"] = len(sessions)
+	}
+	if store, err := requests.OpenReadOnly(stateDir); err == nil {
+		if recs, err := store.List(); err == nil {
+			counts := map[string]int{}
+			for _, r := range recs {
+				counts[string(r.State)]++
+			}
+			report["records"] = counts
+		}
+	}
+	return report, code, nil
+}
+
+func newUUID() (string, error) {
+	var b [16]byte
+	if _, err := io.ReadFull(randReader, b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/cmd/amq-remote/rand.go
+++ b/cmd/amq-remote/rand.go
@@ -1,0 +1,5 @@
+package main
+
+import "crypto/rand"
+
+var randReader = rand.Reader

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -49,6 +50,16 @@ type DirectChildExistsError struct {
 
 func (e *DirectChildExistsError) Error() string {
 	return fmt.Sprintf("direct child %q already exists", e.Name)
+}
+
+// SetSyncDirFaultForTest replaces this root's directory-sync implementation
+// with fn (nil restores the platform sync). Existing fsq tests reach the
+// unexported field directly; this exported hook exists for out-of-package
+// regression tests (amqio) that must force a CommittedDurabilityError from a
+// committed delivery. Install it right after OpenDeliveryRoot, before any
+// delivery, and keep it deterministic (no sleeps, no goroutines).
+func (r *DeliveryRoot) SetSyncDirFaultForTest(fn func(dir string) error) {
+	r.syncDirForTest = fn
 }
 
 // beforeCreateDirectChildExclusiveForTest runs after VerifyBase and before
@@ -442,7 +453,7 @@ func (r *DeliveryRoot) EnsureRootDirs() error {
 		return err
 	}
 	for _, dir := range []string{"agents", "threads", "meta"} {
-		if err := r.root.MkdirAll(dir, 0o700); err != nil {
+		if err := r.mkdirAllSynced(dir); err != nil {
 			return err
 		}
 	}
@@ -459,7 +470,7 @@ func (r *DeliveryRoot) EnsureAgentDirs(agent string) error {
 		return err
 	}
 	for _, leaf := range requiredMailboxLeaves {
-		if err := r.root.MkdirAll(MailboxRootRelativePath(agent, leaf), 0o700); err != nil {
+		if err := r.mkdirAllSynced(MailboxRootRelativePath(agent, leaf)); err != nil {
 			return err
 		}
 	}
@@ -479,7 +490,7 @@ func (r *DeliveryRoot) EnsureAgentDir(agent string, leaf MailboxLeaf) error {
 	if err := r.VerifyBase(); err != nil {
 		return err
 	}
-	return r.root.MkdirAll(MailboxRootRelativePath(agent, leaf), 0o700)
+	return r.mkdirAllSynced(MailboxRootRelativePath(agent, leaf))
 }
 
 // LayoutState classifies a pinned root's top-level queue layout.
@@ -571,6 +582,56 @@ func (r *DeliveryRoot) DisplayPath(name string) string {
 func (r *DeliveryRoot) dirExists(name string) bool {
 	info, err := r.root.Stat(name)
 	return err == nil && info.IsDir()
+}
+
+// mkdirAllSynced creates dir and any missing ancestors through the pinned
+// root, then fsyncs every directory level this call created. Delivery writes
+// fsync the message file and its leaf directory; without also syncing the
+// newly created ancestors, a crash right after a first-contact delivery can
+// still lose the whole mailbox tree along with the message it committed.
+// Pre-existing levels are not re-synced: this call introduced nothing below
+// them. A failed ancestor sync is reported as a plain error (nothing has been
+// committed at the leaf yet, so the caller's staging cleanup still applies).
+func (r *DeliveryRoot) mkdirAllSynced(dir string) error {
+	missing, err := r.firstMissingAncestor(dir)
+	if err != nil {
+		return err
+	}
+	if missing == "" {
+		return nil
+	}
+	if err := r.root.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	for d := dir; ; d = filepath.Dir(d) {
+		if err := r.syncDir(d); err != nil {
+			return fmt.Errorf("sync created ancestor %s: %w", d, err)
+		}
+		if d == missing {
+			return nil
+		}
+	}
+}
+
+// firstMissingAncestor walks from dir toward the pinned root and returns the
+// shallowest missing level (the topmost ancestor that does not exist yet), or
+// "" when every level already exists.
+func (r *DeliveryRoot) firstMissingAncestor(dir string) (string, error) {
+	missing := ""
+	current := dir
+	for {
+		if _, err := r.root.Stat(current); err == nil {
+			return missing, nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("stat %s: %w", current, err)
+		}
+		missing = current
+		parent := filepath.Dir(current)
+		if parent == current {
+			return missing, nil
+		}
+		current = parent
+	}
 }
 
 // CreateExclusiveFile writes a root-relative regular file and refuses if the

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -76,6 +76,29 @@ var requiredMailboxLeaves = [...]MailboxLeaf{
 	MailboxReceipts,
 }
 
+// firstMissingAncestorAmbient walks from dir toward the filesystem root and
+// returns the shallowest missing level (the topmost ancestor that does not
+// exist yet), or "" when every level already exists.
+// Companion to DeliveryRoot.firstMissingAncestor for the ambient-path layout
+// helpers that run before a capability is opened.
+func firstMissingAncestorAmbient(dir string) (string, error) {
+	missing := ""
+	current := dir
+	for {
+		if _, err := os.Stat(current); err == nil {
+			return missing, nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("stat %s: %w", current, err)
+		}
+		missing = current
+		parent := filepath.Dir(current)
+		if parent == current {
+			return missing, nil
+		}
+		current = parent
+	}
+}
+
 // RequiredMailboxLeaves returns the one ordered mailbox-layout contract.
 func RequiredMailboxLeaves() []MailboxLeaf {
 	leaves := make([]MailboxLeaf, len(requiredMailboxLeaves))
@@ -149,8 +172,26 @@ func EnsureAgentDirs(root, agent string) error {
 		return err
 	}
 	for _, leaf := range requiredMailboxLeaves {
-		if err := os.MkdirAll(AgentMailboxPath(root, agent, leaf), 0o700); err != nil {
+		dir := AgentMailboxPath(root, agent, leaf)
+		missing, err := firstMissingAncestorAmbient(dir)
+		if err != nil {
 			return err
+		}
+		if missing == "" {
+			continue
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		// Sync every level this call created so a crash cannot lose the
+		// mailbox tree below a newly provisioned agent directory.
+		for d := dir; ; d = filepath.Dir(d) {
+			if err := SyncDir(d); err != nil {
+				return fmt.Errorf("sync created ancestor %s: %w", d, err)
+			}
+			if d == missing {
+				break
+			}
 		}
 	}
 	return nil

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -1,0 +1,127 @@
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// mkdirAllSynced and the ambient EnsureAgentDirs helper must sync the leaf of
+// the newly created mailbox tree first and then each remaining created level
+// up to the shallowest missing ancestor. firstMissingAncestor reports the
+// shallowest missing level, so an implementation that walks up from it (or
+// starts there) never reaches the leaf and either loops forever or skips the
+// sync that protects the newly committed message file.
+func TestMkdirAllSyncedCoversEveryCreatedLevelDownToLeaf(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	var synced []string
+	root.syncDirForTest = func(dir string) error {
+		rel, relErr := filepath.Rel(base, dir)
+		if relErr != nil {
+			rel = dir
+		}
+		synced = append(synced, rel)
+		return nil
+	}
+
+	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
+		t.Fatalf("mkdirAllSynced: %v", err)
+	}
+
+	want := map[string]bool{
+		filepath.Join("agents", "agent-a", "inbox", "cur"): false,
+		filepath.Join("agents", "agent-a", "inbox"):        false,
+		filepath.Join("agents", "agent-a"):                 false,
+		"agents":                                           false,
+	}
+	if len(synced) != len(want) {
+		t.Fatalf("synced %d directories (%v), want %d", len(synced), synced, len(want))
+	}
+	for _, dir := range synced {
+		seen, ok := want[dir]
+		if !ok {
+			t.Fatalf("unexpected directory synced: %s (all: %v)", dir, synced)
+		}
+		if seen {
+			t.Fatalf("directory synced more than once: %s (all: %v)", dir, synced)
+		}
+		want[dir] = true
+	}
+	if synced[0] != filepath.Join("agents", "agent-a", "inbox", "cur") {
+		t.Fatalf("leaf must be synced first, got %v", synced)
+	}
+}
+
+// The ambient EnsureAgentDirs helper shares firstMissingAncestorAmbient and
+// must terminate: before the descend-from-leaf fix it fsynced up from the
+// shallowest missing level and never broke, hanging any caller.
+func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversCreatedLevels(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+
+	calls := atomic.Int64{}
+	restore := syncDirAmbientSwapForTest(func(dir string) error {
+		calls.Add(1)
+		if calls.Load() > 32 {
+			t.Errorf("ambient sync exceeded expected level count (infinite loop?): %d calls", calls.Load())
+			return errors.New("sync loop guard")
+		}
+		return nil
+	})
+	defer restore()
+
+	if err := EnsureAgentDirs(root, "agent-b"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	// First leaf creates agent-b + inbox + tmp = 3 synced levels (agents is
+	// pre-created by EnsureRootDirs); outbox/sent and dlq/tmp add one extra
+	// level each; the remaining leaves already have their parents. So the
+	// total is len(leaves) + 4 created levels, leaf-first, never repeating.
+	leaves := RequiredMailboxLeaves()
+	if got := calls.Load(); got != int64(len(leaves)+4) {
+		t.Fatalf("ambient sync calls = %d, want %d", got, len(leaves)+4)
+	}
+	for _, leaf := range leaves {
+		info, err := os.Stat(AgentMailboxPath(root, "agent-b", leaf))
+		if err != nil || !info.IsDir() {
+			t.Fatalf("leaf %s not created: info=%v err=%v", leaf, info, err)
+		}
+	}
+}
+
+// A failed sync on a created level is a plain error (nothing committed at the
+// leaf yet), not a swallowed success.
+func TestMkdirAllSyncedReportsFailedAncestorSync(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	failure := errors.New("sync ancestor failed")
+	root.syncDirForTest = func(dir string) error { return failure }
+
+	err = root.mkdirAllSynced(filepath.Join("agents", "agent-c", "inbox", "cur"))
+	if !errors.Is(err, failure) {
+		t.Fatalf("mkdirAllSynced error = %v, want wrapped %v", err, failure)
+	}
+}

--- a/internal/fsq/sync_unix.go
+++ b/internal/fsq/sync_unix.go
@@ -8,8 +8,22 @@ import (
 	"syscall"
 )
 
+// syncDirAmbientForTest swaps the implementation behind the ambient-path
+// SyncDir calls. nil restores the platform sync. It returns the restore func.
+// Existing in-package tests may also reach the variable directly.
+var syncDirAmbientForTest func(dir string) error
+
+func syncDirAmbientSwapForTest(fn func(dir string) error) (restore func()) {
+	prev := syncDirAmbientForTest
+	syncDirAmbientForTest = fn
+	return func() { syncDirAmbientForTest = prev }
+}
+
 // SyncDir fsyncs a directory to ensure directory entries are durable.
 func SyncDir(dir string) error {
+	if syncDirAmbientForTest != nil {
+		return syncDirAmbientForTest(dir)
+	}
 	file, err := os.Open(dir)
 	if err != nil {
 		return err

--- a/internal/fsq/sync_windows.go
+++ b/internal/fsq/sync_windows.go
@@ -2,7 +2,22 @@
 
 package fsq
 
+// syncDirAmbientForTest swaps the implementation behind the ambient-path
+// SyncDir calls; nil means the no-op platform sync. Windows syncs are no-ops,
+// so the hook only matters for tests that count or fault calls.
+var syncDirAmbientForTest func(dir string) error
+
+func syncDirAmbientSwapForTest(fn func(dir string) error) (restore func()) {
+	prev := syncDirAmbientForTest
+	syncDirAmbientForTest = fn
+	return func() { syncDirAmbientForTest = prev }
+}
+
 // SyncDir is a no-op on Windows.
-func SyncDir(_ string) error {
+func SyncDir(dir string) error {
+	if syncDirAmbientForTest != nil {
+		return syncDirAmbientForTest(dir)
+	}
+	_ = dir
 	return nil
 }

--- a/internal/remote/amqio/amqio.go
+++ b/internal/remote/amqio/amqio.go
@@ -157,11 +157,14 @@ func (c *Carrier) importOne(root *fsq.DeliveryRoot, name string) error {
 		return nil
 	}
 	// Reply once here for: every refusal; every non-request op; and a request
-	// op that carries an op-specific Outcome (request_conflict, already
-	// resolved) which does not travel as a published revision (Pro B09: the
-	// caller must still learn the outcome).
+	// op that carries an op-specific Outcome which does not travel as a
+	// published revision (Pro B09: the caller must still learn the outcome).
+	// The signal is a Code OR a Disposition: a no-op terminal cancel carries a
+	// disposition with an empty code and never publishes a revision, so keying
+	// on Code alone silently dropped its reply.
 	isRequestOp := cmd != nil && (cmd.Op == protocol.OpRequestSubmit || cmd.Op == protocol.OpRequestCancel)
-	if herr != nil || !isRequestOp || outcome.Code != "" {
+	hasOutcomeSignal := outcome.Code != "" || outcome.Disposition != ""
+	if herr != nil || !isRequestOp || hasOutcomeSignal {
 		if err := c.reply(root, origin, "remote reply", reply, herr); err != nil {
 			return err
 		}

--- a/internal/remote/amqio/amqio.go
+++ b/internal/remote/amqio/amqio.go
@@ -1,0 +1,248 @@
+// Package amqio is the AMQ carrier for the remote endpoint: it imports
+// commands from the endpoint's own handle mailbox and publishes replies and
+// request revisions back as ordinary AMQ messages. It never drains a message
+// before the endpoint has handled it, and it never deletes.
+package amqio
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+)
+
+// DefaultHandle is the endpoint's mailbox handle in the root.
+const DefaultHandle = "remote"
+
+// Labels the carrier puts on every message it writes.
+const (
+	LabelRemote   = "remote"
+	labelRefPfx   = "request_ref:"
+	labelRevPfx   = "revision:"
+	subjectPrefix = "remote request "
+)
+
+// Carrier binds one endpoint to one AMQ root and handle.
+type Carrier struct {
+	root     string
+	me       string
+	identity fsq.DeliveryRootIdentity
+	ep       *core.Endpoint
+	now      func() time.Time
+}
+
+// New prepares the endpoint mailbox under root and returns the carrier.
+func New(root, me string, ep *core.Endpoint) (*Carrier, error) {
+	if err := fsq.ValidateHandle(me); err != nil {
+		return nil, protocol.Refuse(protocol.CodeInvalid, "endpoint handle: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, me); err != nil {
+		return nil, fmt.Errorf("prepare mailbox for %s: %w", me, err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	return &Carrier{root: root, me: me, identity: identity, ep: ep, now: time.Now}, nil
+}
+
+// Handle is the endpoint's mailbox handle.
+func (c *Carrier) Handle() string { return c.me }
+
+// SourceHost derives the authenticated creator host of a command from the
+// message header. The handle is attribution inside this root; a cross-project
+// sender keeps its project so two same-named handles never share a key.
+func SourceHost(h format.Header) string {
+	host := "amq:" + h.From
+	if h.FromProject != "" {
+		host += "@" + h.FromProject
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '.', r == ':', r == '-':
+			return r
+		}
+		return '-'
+	}, host)
+}
+
+// ImportOnce reads every message in the endpoint's inbox/new, hands each
+// command to the endpoint, and only then claims the message into cur with a
+// drained receipt. A message the endpoint refuses is still claimed, with the
+// refusal in the receipt detail and a reply to the sender.
+func (c *Carrier) ImportOnce() (int, error) {
+	root, err := fsq.OpenDeliveryRoot(c.root, c.identity)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := root.ReadDir(filepath.Join("agents", c.me, "inbox", "new"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") && !strings.HasPrefix(e.Name(), ".") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	n := 0
+	for _, name := range names {
+		if err := c.importOne(root, name); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
+}
+
+func (c *Carrier) importOne(root *fsq.DeliveryRoot, name string) error {
+	path := filepath.Join(c.root, "agents", c.me, "inbox", "new", name)
+	msg, err := format.ReadMessageFile(path)
+	if err != nil {
+		// Unparseable serialization belongs to the DLQ path owned by amq
+		// read/drain; the endpoint leaves it in new for that tooling.
+		return nil
+	}
+	detail := "remote command handled"
+	cmd, derr := protocol.DecodeCommand([]byte(strings.TrimSpace(msg.Body)))
+	origin := map[string]string{
+		"carrier":       "amq",
+		"from":          msg.Header.From,
+		"thread":        msg.Header.Thread,
+		"msg_id":        msg.Header.ID,
+		"reply_to":      msg.Header.ReplyTo,
+		"reply_project": msg.Header.ReplyProject,
+	}
+	var reply any
+	var herr error
+	if derr != nil {
+		herr = derr
+	} else {
+		reply, herr = c.ep.Handle(cmd, core.Source{Host: SourceHost(msg.Header), Origin: origin})
+	}
+	if herr != nil {
+		detail = "remote command refused: " + herr.Error()
+	}
+	// request.* replies travel as revisions through Publish; every other op
+	// and every refusal is answered once, here.
+	if herr != nil || (cmd != nil && cmd.Op != protocol.OpRequestSubmit && cmd.Op != protocol.OpRequestCancel) {
+		if err := c.reply(root, origin, "remote reply", reply, herr); err != nil {
+			return err
+		}
+	}
+	if err := fsq.MoveNewToCur(root, c.me, name); err != nil {
+		var committed *fsq.CommittedDurabilityError
+		if !errors.As(err, &committed) {
+			return fmt.Errorf("claim %s: %w", name, err)
+		}
+	}
+	rc := receipt.New(msg.Header.ID, msg.Header.Thread, msg.Header.From, c.me, receipt.StageDrained, detail)
+	return receipt.EmitDeliveryRoot(root, rc)
+}
+
+// Publish implements core.Publisher for records that arrived over AMQ. Local
+// CLI records have no AMQ origin and are read back over IPC instead.
+func (c *Carrier) Publish(snap protocol.Snapshot, origin map[string]string) error {
+	if origin == nil || origin["carrier"] != "amq" {
+		return nil
+	}
+	root, err := fsq.OpenDeliveryRoot(c.root, c.identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return c.reply(root, origin, subjectPrefix+string(snap.State), snap, nil)
+}
+
+func (c *Carrier) reply(root *fsq.DeliveryRoot, origin map[string]string, subject string, body any, refusal error) error {
+	to := origin["from"]
+	if to == "" || fsq.ValidateHandle(to) != nil {
+		return nil
+	}
+	now := c.now()
+	id, err := format.NewMessageID(now)
+	if err != nil {
+		return err
+	}
+	labels := []string{LabelRemote}
+	context := map[string]any{}
+	var text []byte
+	switch {
+	case refusal != nil:
+		code := protocol.Code("error")
+		var r *protocol.Refusal
+		if errors.As(refusal, &r) {
+			code = r.Code
+		}
+		context["remote_error"] = map[string]string{"code": string(code), "message": refusal.Error()}
+		text, _ = json.MarshalIndent(context["remote_error"], "", "  ")
+		subject = "remote reply refused"
+	default:
+		if snap, ok := body.(protocol.Snapshot); ok {
+			labels = append(labels, labelRefPfx+snap.RequestRef, fmt.Sprintf("%s%d", labelRevPfx, snap.Revision))
+		}
+		text, err = json.MarshalIndent(body, "", "  ")
+		if err != nil {
+			return err
+		}
+		context["remote"] = json.RawMessage(text)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      id,
+			From:    c.me,
+			To:      []string{to},
+			Thread:  origin["thread"],
+			Subject: subject,
+			Created: now.UTC().Format(time.RFC3339Nano),
+			Refs:    refsFrom(origin),
+			Kind:    "status",
+			Labels:  labels,
+			Context: context,
+		},
+		Body: string(text),
+	}
+	if msg.Header.Thread == "" {
+		msg.Header.Thread = "p2p/" + orderedPair(c.me, to)
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		return err
+	}
+	_, err = fsq.DeliverToInboxes(root, []string{to}, id+".md", data)
+	var committed *fsq.CommittedDurabilityError
+	if err != nil && !errors.As(err, &committed) {
+		return err
+	}
+	return nil
+}
+
+func refsFrom(origin map[string]string) []string {
+	if id := origin["msg_id"]; id != "" {
+		return []string{id}
+	}
+	return nil
+}
+
+func orderedPair(a, b string) string {
+	if a > b {
+		a, b = b, a
+	}
+	return a + "__" + b
+}

--- a/internal/remote/amqio/amqio.go
+++ b/internal/remote/amqio/amqio.go
@@ -146,9 +146,22 @@ func (c *Carrier) importOne(root *fsq.DeliveryRoot, name string) error {
 		// command whose record may not exist.
 		return nil
 	}
-	// request.* replies travel as revisions through Publish; every other op
-	// and every refusal is answered once, here.
-	if herr != nil || (cmd != nil && cmd.Op != protocol.OpRequestSubmit && cmd.Op != protocol.OpRequestCancel) {
+	// A request-op reply carries an Outcome. A transient storage failure means
+	// the record could not be persisted, so leave the command in new for the
+	// next import rather than draining it without a durable record (Pro B09).
+	var outcome protocol.Outcome
+	if rep, ok := reply.(protocol.Reply); ok {
+		outcome = rep.Outcome
+	}
+	if outcome.Code == protocol.CodeStorageFull {
+		return nil
+	}
+	// Reply once here for: every refusal; every non-request op; and a request
+	// op that carries an op-specific Outcome (request_conflict, already
+	// resolved) which does not travel as a published revision (Pro B09: the
+	// caller must still learn the outcome).
+	isRequestOp := cmd != nil && (cmd.Op == protocol.OpRequestSubmit || cmd.Op == protocol.OpRequestCancel)
+	if herr != nil || !isRequestOp || outcome.Code != "" {
 		if err := c.reply(root, origin, "remote reply", reply, herr); err != nil {
 			return err
 		}

--- a/internal/remote/amqio/amqio.go
+++ b/internal/remote/amqio/amqio.go
@@ -135,8 +135,16 @@ func (c *Carrier) importOne(root *fsq.DeliveryRoot, name string) error {
 	} else {
 		reply, herr = c.ep.Handle(cmd, core.Source{Host: SourceHost(msg.Header), Origin: origin})
 	}
+	var refusal *protocol.Refusal
+	typed := herr == nil || errors.As(herr, &refusal)
 	if herr != nil {
 		detail = "remote command refused: " + herr.Error()
+	}
+	if !typed {
+		// The endpoint could not say whether a record exists. Leave the
+		// message in new so the next import retries it; never drain a
+		// command whose record may not exist.
+		return nil
 	}
 	// request.* replies travel as revisions through Publish; every other op
 	// and every refusal is answered once, here.

--- a/internal/remote/amqio/amqio_test.go
+++ b/internal/remote/amqio/amqio_test.go
@@ -1,0 +1,113 @@
+package amqio
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// TestImportCommandAndPublishResult is the AMQ carrier happy path: a peer
+// handle sends a request.submit as an ordinary message, the endpoint imports
+// it, the message is claimed into cur with a receipt, and the running and
+// completed revisions come back to the sender as messages in the same thread.
+func TestImportCommandAndPublishResult(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []string{"codex", DefaultHandle} {
+		if err := fsq.EnsureAgentDirs(root, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := requests.Open(filepath.Join(root, "extensions", "remote"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	var carrier *Carrier
+	ep := core.New(core.Config{Store: store, Publish: func(s protocol.Snapshot, origin map[string]string) error {
+		return carrier.Publish(s, origin)
+	}})
+	carrier, err = New(root, DefaultHandle, ep)
+	if err != nil {
+		t.Fatalf("carrier: %v", err)
+	}
+	rt := fake.New("fake", "e_1")
+	ep.Register(rt)
+	t.Cleanup(func() { _ = ep.Close() })
+
+	body := `{"schema":"amq.remote.command/1","op":"request.submit","request_id":"11111111-1111-4111-8111-111111111301","target_id":"fake","epoch":"e_1","not_after":"` + protocol.FormatTime(time.Now().Add(time.Minute)) + `","input":{"text":"review the diff"}}`
+	now := time.Now()
+	id, err := format.NewMessageID(now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := format.Message{Header: format.Header{Schema: format.CurrentSchema, ID: id, From: "codex", To: []string{DefaultHandle}, Thread: "p2p/codex__remote", Subject: "submit", Created: now.UTC().Format(time.RFC3339Nano), Kind: "todo"}, Body: body}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	droot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fsq.DeliverToInboxes(droot, []string{DefaultHandle}, id+".md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	_ = droot.Close()
+
+	n, err := carrier.ImportOnce()
+	if err != nil || n != 1 {
+		t.Fatalf("import: n=%d err=%v", n, err)
+	}
+	if entries, _ := os.ReadDir(fsq.AgentInboxNew(root, DefaultHandle)); len(entries) != 0 {
+		t.Fatalf("command still in new: %d", len(entries))
+	}
+	if entries, _ := os.ReadDir(fsq.AgentInboxCur(root, DefaultHandle)); len(entries) != 1 {
+		t.Fatalf("command not claimed into cur: %d", len(entries))
+	}
+	if entries, _ := os.ReadDir(fsq.AgentReceipts(root, DefaultHandle)); len(entries) != 1 {
+		t.Fatalf("no drained receipt: %d", len(entries))
+	}
+
+	rt.Complete("11111111-1111-4111-8111-111111111301", "two defects")
+
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	states := map[string]bool{}
+	for _, e := range entries {
+		m, err := format.ReadMessageFile(filepath.Join(fsq.AgentInboxNew(root, "codex"), e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.Header.Thread != "p2p/codex__remote" || !strings.HasPrefix(m.Header.Subject, subjectPrefix) {
+			t.Fatalf("unexpected reply header: %+v", m.Header)
+		}
+		states[strings.TrimPrefix(m.Header.Subject, subjectPrefix)] = true
+	}
+	if !states["running"] || !states["completed"] {
+		t.Fatalf("expected running and completed revisions, got %v", states)
+	}
+	rec, ok, err := store.Get(requests.Key{CreatorHost: "amq:codex", TargetID: "fake", RequestID: "11111111-1111-4111-8111-111111111301"})
+	if err != nil || !ok {
+		t.Fatalf("record: ok=%v err=%v", ok, err)
+	}
+	if rec.State != protocol.StateCompleted || rec.PublishedRevision != rec.Revision {
+		t.Fatalf("record not completed and published: %+v", rec.Snapshot)
+	}
+}

--- a/internal/remote/amqio/amqio_test.go
+++ b/internal/remote/amqio/amqio_test.go
@@ -111,3 +111,67 @@ func TestImportCommandAndPublishResult(t *testing.T) {
 		t.Fatalf("record not completed and published: %+v", rec.Snapshot)
 	}
 }
+
+// TestImportLeavesCommandOnPlainError proves the carrier leaves a command in
+// new (no claim, no drained receipt) when Handle returns a plain, non-Refusal
+// error, so a command whose record may not exist is retried rather than lost.
+func TestImportLeavesCommandOnPlainError(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []string{"codex", DefaultHandle} {
+		if err := fsq.EnsureAgentDirs(root, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stateDir := filepath.Join(root, "extensions", "remote")
+	store, err := requests.Open(stateDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	var carrier *Carrier
+	ep := core.New(core.Config{Store: store, Publish: func(s protocol.Snapshot, o map[string]string) error { return carrier.Publish(s, o) }})
+	carrier, err = New(root, DefaultHandle, ep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := fake.New("fake", "e_1")
+	ep.Register(rt)
+	t.Cleanup(func() { _ = ep.Close() })
+
+	// Deliver a valid submit command by mail.
+	body := `{"schema":"amq.remote.command/1","op":"request.submit","request_id":"11111111-1111-4111-8111-1111111111e1","target_id":"fake","epoch":"e_1","not_after":"` + protocol.FormatTime(time.Now().Add(time.Minute)) + `","input":{"text":"x"}}`
+	now := time.Now()
+	id, _ := format.NewMessageID(now)
+	msg := format.Message{Header: format.Header{Schema: format.CurrentSchema, ID: id, From: "codex", To: []string{DefaultHandle}, Thread: "p2p/codex__remote", Subject: "submit", Created: now.UTC().Format(time.RFC3339Nano), Kind: "todo"}, Body: body}
+	data, _ := msg.Marshal()
+	identity, _ := fsq.SnapshotDeliveryRoot(root)
+	droot, _ := fsq.OpenDeliveryRoot(root, identity)
+	if _, err := fsq.DeliverToInboxes(droot, []string{DefaultHandle}, id+".md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	_ = droot.Close()
+
+	// Corrupt the on-disk record for this exact key so submit's store.Get
+	// fails to decode it and returns a plain (non-Refusal) error, the class
+	// the review found the carrier would wrongly drain.
+	hostDir := filepath.Join(stateDir, "v1", "requests", "amq:codex")
+	if err := os.MkdirAll(hostDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostDir, "fake__11111111-1111-4111-8111-1111111111e1.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatalf("import returned error: %v", err)
+	}
+	// The command must remain in new for retry; no record, no drained receipt.
+	if entries, _ := os.ReadDir(fsq.AgentInboxNew(root, DefaultHandle)); len(entries) != 1 {
+		t.Fatalf("command drained despite a plain store error: new has %d", len(entries))
+	}
+	if entries, _ := os.ReadDir(fsq.AgentReceipts(root, DefaultHandle)); len(entries) != 0 {
+		t.Fatalf("drained receipt emitted despite no record: %d", len(entries))
+	}
+}

--- a/internal/remote/amqio/amqio_test.go
+++ b/internal/remote/amqio/amqio_test.go
@@ -244,3 +244,66 @@ func TestImportConflictRepliesToSender(t *testing.T) {
 		t.Fatalf("conflicting submit did not reply to sender with the outcome (entries %d, baseline %d, sawConflict %v)", len(entries), baseline, sawConflict)
 	}
 }
+
+// TestImportNoopCancelRepliesToSender pins Pro/amit-pi's Q4 finding: a no-op
+// terminal cancel carries an Outcome disposition with an empty Code and never
+// publishes a revision, so the carrier must still reply to the sender.
+func TestImportNoopCancelRepliesToSender(t *testing.T) {
+	root := t.TempDir()
+	_ = fsq.EnsureRootDirs(root)
+	for _, h := range []string{"codex", DefaultHandle} {
+		_ = fsq.EnsureAgentDirs(root, h)
+	}
+	store, err := requests.Open(filepath.Join(root, "extensions", "remote"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var carrier *Carrier
+	ep := core.New(core.Config{Store: store, Publish: func(s protocol.Snapshot, o map[string]string) error { return carrier.Publish(s, o) }})
+	carrier, err = New(root, DefaultHandle, ep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := fake.New("fake", "e_1")
+	ep.Register(rt)
+	t.Cleanup(func() { _ = ep.Close() })
+
+	id := "11111111-1111-4111-8111-1111111111ca"
+	deliverSubmit(t, root, id, "work")
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatal(err)
+	}
+	rt.Complete(id, "done") // record is now terminal
+	baseline, _ := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+
+	// Deliver a cancel for the already-terminal record -> noop_already_terminal.
+	ref := protocol.EncodeRef("amq:codex", "fake", id)
+	body := `{"schema":"amq.remote.command/1","op":"request.cancel","request_ref":"` + ref + `","target_id":"fake","epoch":"e_1","not_after":"` + protocol.FormatTime(time.Now().Add(time.Minute)) + `"}`
+	now := time.Now()
+	mid, _ := format.NewMessageID(now)
+	msg := format.Message{Header: format.Header{Schema: format.CurrentSchema, ID: mid, From: "codex", To: []string{DefaultHandle}, Thread: "p2p/codex__remote", Subject: "cancel", Created: now.UTC().Format(time.RFC3339Nano), Kind: "todo"}, Body: body}
+	data, _ := msg.Marshal()
+	identity, _ := fsq.SnapshotDeliveryRoot(root)
+	droot, _ := fsq.OpenDeliveryRoot(root, identity)
+	if _, err := fsq.DeliverToInboxes(droot, []string{DefaultHandle}, mid+".md", data); err != nil {
+		t.Fatal(err)
+	}
+	_ = droot.Close()
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	sawNoop := false
+	for _, e := range entries {
+		m, err := format.ReadMessageFile(filepath.Join(fsq.AgentInboxNew(root, "codex"), e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(m.Body, string(protocol.CancelNoopTerminal)) {
+			sawNoop = true
+		}
+	}
+	if len(entries) <= len(baseline) || !sawNoop {
+		t.Fatalf("no-op terminal cancel did not reply to sender (entries %d, baseline %d, sawNoop %v)", len(entries), len(baseline), sawNoop)
+	}
+}

--- a/internal/remote/amqio/amqio_test.go
+++ b/internal/remote/amqio/amqio_test.go
@@ -175,3 +175,72 @@ func TestImportLeavesCommandOnPlainError(t *testing.T) {
 		t.Fatalf("drained receipt emitted despite no record: %d", len(entries))
 	}
 }
+
+// deliverSubmit is a test helper: it delivers a request.submit for id with the
+// given text into the endpoint handle's inbox.
+func deliverSubmit(t *testing.T, root, id, text string) {
+	t.Helper()
+	body := `{"schema":"amq.remote.command/1","op":"request.submit","request_id":"` + id + `","target_id":"fake","epoch":"e_1","not_after":"` + protocol.FormatTime(time.Now().Add(time.Minute)) + `","input":{"text":"` + text + `"}}`
+	now := time.Now()
+	mid, _ := format.NewMessageID(now)
+	msg := format.Message{Header: format.Header{Schema: format.CurrentSchema, ID: mid, From: "codex", To: []string{DefaultHandle}, Thread: "p2p/codex__remote", Subject: "submit", Created: now.UTC().Format(time.RFC3339Nano), Kind: "todo"}, Body: body}
+	data, _ := msg.Marshal()
+	identity, _ := fsq.SnapshotDeliveryRoot(root)
+	droot, _ := fsq.OpenDeliveryRoot(root, identity)
+	if _, err := fsq.DeliverToInboxes(droot, []string{DefaultHandle}, mid+".md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	_ = droot.Close()
+}
+
+// TestImportConflictRepliesToSender reproduces Pro B09's suppressed-reply hole:
+// a request op that yields an op-specific Outcome (request_conflict) does not
+// travel as a published revision, so the carrier must still reply to the sender
+// with that outcome rather than silently claiming the command.
+func TestImportConflictRepliesToSender(t *testing.T) {
+	root := t.TempDir()
+	_ = fsq.EnsureRootDirs(root)
+	for _, h := range []string{"codex", DefaultHandle} {
+		_ = fsq.EnsureAgentDirs(root, h)
+	}
+	store, err := requests.Open(filepath.Join(root, "extensions", "remote"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var carrier *Carrier
+	ep := core.New(core.Config{Store: store, Publish: func(s protocol.Snapshot, o map[string]string) error { return carrier.Publish(s, o) }})
+	carrier, err = New(root, DefaultHandle, ep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ep.Register(fake.New("fake", "e_1"))
+	t.Cleanup(func() { _ = ep.Close() })
+
+	id := "11111111-1111-4111-8111-1111111111c9"
+	deliverSubmit(t, root, id, "first")
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatal(err)
+	}
+	// clear the sender's inbox of the running-revision replies so we isolate the conflict reply
+	firstReplies, _ := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	baseline := len(firstReplies)
+
+	deliverSubmit(t, root, id, "different bytes")
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	sawConflict := false
+	for _, e := range entries {
+		m, err := format.ReadMessageFile(filepath.Join(fsq.AgentInboxNew(root, "codex"), e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(m.Body, string(protocol.CodeRequestConflict)) {
+			sawConflict = true
+		}
+	}
+	if len(entries) <= baseline || !sawConflict {
+		t.Fatalf("conflicting submit did not reply to sender with the outcome (entries %d, baseline %d, sawConflict %v)", len(entries), baseline, sawConflict)
+	}
+}

--- a/internal/remote/codex/attachment.go
+++ b/internal/remote/codex/attachment.go
@@ -38,17 +38,22 @@ type run struct {
 	key          requests.Key
 	epoch        string
 	turnID       string
-	queued       bool
 	state        protocol.State
 	text         strings.Builder
 	errText      string
 	local        bool
 	interaction  *protocol.Interaction
 	approvalReqs map[string]json.RawMessage
-	// confirmed closes when the userMessage item carrying this run's
-	// clientUserMessageId is observed, proving turn/start accepted our text
-	// rather than joining a turn started in the race window and dropping it.
-	confirmed chan struct{}
+	// confirmed (the bool) is the durable ownership flag every consumer reads:
+	// until the userMessage item carrying this run's clientUserMessageId is
+	// observed, the run is TENTATIVE and must not be cancelled, attributed, or
+	// reported admitted. confirmedCh closes once, to release a waiting Submit.
+	confirmed   bool
+	confirmedCh chan struct{}
+	// cancelPending records a cancel that arrived while tentative, to be
+	// delivered when the run confirms.
+	cancelPending bool
+	queued        bool
 }
 
 // Attachment is one running Codex thread reached through the shared
@@ -236,7 +241,7 @@ func (a *Attachment) Submit(req core.BoundRequest) (core.Admission, error) {
 		if err := a.call("turn/steer", map[string]any{"threadId": a.threadID, "expectedTurnId": activeTurn, "input": input, "clientUserMessageId": req.Key.RequestID}, nil); err != nil {
 			return refusal(err), nil
 		}
-		r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, turnID: activeTurn, approvalReqs: map[string]json.RawMessage{}}
+		r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, turnID: activeTurn, confirmed: true, approvalReqs: map[string]json.RawMessage{}}
 		a.mu.Lock()
 		a.runs[req.Key] = r
 		a.byClientID[req.Key.RequestID] = r
@@ -262,7 +267,7 @@ func (a *Attachment) Submit(req core.BoundRequest) (core.Admission, error) {
 
 	// Idle turn/start. Register the run first so onItem can confirm our
 	// userMessage, then call unlocked, then require confirmation.
-	r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, approvalReqs: map[string]json.RawMessage{}, confirmed: make(chan struct{})}
+	r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, approvalReqs: map[string]json.RawMessage{}, confirmedCh: make(chan struct{})}
 	a.mu.Lock()
 	a.runs[req.Key] = r
 	a.byClientID[req.Key.RequestID] = r
@@ -284,15 +289,17 @@ func (a *Attachment) Submit(req core.BoundRequest) (core.Admission, error) {
 	a.mu.Lock()
 	if r.turnID == "" {
 		r.turnID = res.Turn.ID
-		a.byTurn[res.Turn.ID] = r
+		// byTurn is NOT bound here: the returned turn id may belong to a turn
+		// started in the race window that dropped our text. It is bound only
+		// when confirmRun sees our own userMessage item.
 	}
 	a.activeTurn = res.Turn.ID
 	a.status = "busy"
-	confirmed := r.confirmed
+	confirmedCh := r.confirmedCh
 	a.mu.Unlock()
 
 	select {
-	case <-confirmed:
+	case <-confirmedCh:
 		return core.Admission{Admitted: true, RunID: r.runID()}, nil
 	case <-time.After(confirmTimeout):
 		a.dropRun(req.Key)
@@ -323,16 +330,38 @@ func (a *Attachment) dropRun(key requests.Key) {
 	}
 }
 
-// confirmRun closes a run's confirmation channel once. The caller holds a.mu.
-func confirmRun(r *run) {
-	if r.confirmed == nil {
+// confirmRun marks a run's native ownership established, binds byTurn, and
+// releases a waiting Submit. The caller holds a.mu. It returns whether a
+// cancel was pending so the caller can deliver it outside the lock.
+func (a *Attachment) confirmRun(r *run, turnID string) (cancelPending bool) {
+	if r.confirmed {
+		return false
+	}
+	r.confirmed = true
+	if turnID != "" {
+		r.turnID = turnID
+		a.byTurn[turnID] = r
+	}
+	if r.confirmedCh != nil {
+		select {
+		case <-r.confirmedCh:
+		default:
+			close(r.confirmedCh)
+		}
+	}
+	return r.cancelPending
+}
+
+// deliverPendingCancel sends the interrupt for a cancel that arrived while the
+// run was tentative, now that ownership is confirmed. No lock held.
+func (a *Attachment) deliverPendingCancel(key requests.Key, turnID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if err := a.client.Call(ctx, "turn/interrupt", map[string]any{"threadId": a.threadID, "turnId": turnID}, nil); err != nil {
 		return
 	}
-	select {
-	case <-r.confirmed:
-	default:
-		close(r.confirmed)
-	}
+	// The resulting turn/completed(interrupted) drives the cancelled state.
+	_ = key
 }
 
 func (r *run) runID() string {
@@ -356,9 +385,20 @@ func refusal(err error) core.Admission {
 func (a *Attachment) Lookup(key requests.Key, epoch string) (core.Evidence, error) {
 	a.mu.Lock()
 	if r, ok := a.runs[key]; ok && r.epoch == epoch {
-		ev := core.Evidence{Known: true, Admitted: true, RunID: r.runID(), State: r.state, LocalIntervention: r.local, Interaction: r.interaction}
-		if r.state.Terminal() {
-			ev.Result = r.result()
+		ev := core.Evidence{Known: true, RunID: r.runID(), State: r.state, LocalIntervention: r.local, Interaction: r.interaction}
+		switch {
+		case r.confirmed || r.queued:
+			// A confirmed running turn, or a Codex-native-accepted queue item:
+			// real admission.
+			ev.Class = core.EvidenceConfirmed
+			ev.Admitted = true
+			if r.state.Terminal() {
+				ev.Result = r.result()
+			}
+		default:
+			// Bound but native ownership not yet proven: tentative, never
+			// admitted, so reconcile leaves it running and never rejects it.
+			ev.Class = core.EvidenceTentative
 		}
 		a.mu.Unlock()
 		return ev, nil
@@ -439,6 +479,13 @@ func (a *Attachment) CancelExact(key requests.Key, epoch string) (core.CancelEvi
 	if r.epoch != epoch || r.state.Terminal() {
 		a.mu.Unlock()
 		return core.CancelEvidence{Disposition: protocol.CancelNoopTerminal}, nil
+	}
+	if !r.confirmed && !r.queued {
+		// We do not yet own a turn; interrupting r.turnID could hit a foreign
+		// turn. Record intent; confirmRun delivers it once ownership is proven.
+		r.cancelPending = true
+		a.mu.Unlock()
+		return core.CancelEvidence{Disposition: protocol.CancelRequested, Message: "intent recorded before native ownership"}, nil
 	}
 	turnID, queued := r.turnID, r.queued
 	a.mu.Unlock()
@@ -623,13 +670,13 @@ func (a *Attachment) onItem(n Notification) {
 	switch p.Item.Type {
 	case "userMessage":
 		if r, ok := a.byClientID[p.Item.ClientID]; ok && p.Item.ClientID != "" {
-			if r.turnID == "" {
-				r.turnID = p.TurnID
-				r.queued = false
-				a.byTurn[p.TurnID] = r
+			r.queued = false
+			// Our text is confirmed in this turn: bind byTurn and mark owned.
+			if a.confirmRun(r, p.TurnID) {
+				key := r.key
+				turnID := r.turnID
+				go a.deliverPendingCancel(key, turnID)
 			}
-			// Our text is confirmed in this turn: admission is real.
-			confirmRun(r)
 			return
 		}
 		// A user message we did not send landed in a turn we own: the human

--- a/internal/remote/codex/attachment.go
+++ b/internal/remote/codex/attachment.go
@@ -1,0 +1,637 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// ClientName is what the attachment reports to the app-server.
+const ClientName = "amq-remote"
+
+// Version is stamped by the binary.
+var Version = "dev"
+
+// Approval methods the app-server sends as server requests. Only the
+// command-execution family is answered; the rest stay local-only.
+const (
+	methodCommandApproval    = "item/commandExecution/requestApproval"
+	methodFileChangeApproval = "item/fileChange/requestApproval"
+	methodLegacyExecApproval = "execCommand/approval"
+)
+
+type run struct {
+	key          requests.Key
+	epoch        string
+	turnID       string
+	queued       bool
+	state        protocol.State
+	text         strings.Builder
+	errText      string
+	local        bool
+	interaction  *protocol.Interaction
+	approvalReqs map[string]json.RawMessage
+}
+
+// Attachment is one running Codex thread reached through the shared
+// app-server daemon. It implements core.Attachment.
+type Attachment struct {
+	client   *Client
+	threadID string
+	targetID string
+	epoch    string
+	cwd      string
+	approve  bool
+
+	mu           sync.Mutex
+	status       string
+	activeTurn   string
+	runs         map[requests.Key]*run
+	byTurn       map[string]*run
+	byClientID   map[string]*run
+	cancelIntent map[requests.Key]bool
+	listeners    map[int]func(core.NativeEvent)
+	nextListener int
+	offline      bool
+}
+
+// Option configures Attach.
+type Option func(*Attachment)
+
+// WithApprovals advertises approve_tool and answers command approvals from
+// remote decisions. Off until fanout of approval requests to a second client
+// is verified live.
+func WithApprovals(on bool) Option { return func(a *Attachment) { a.approve = on } }
+
+// Attach connects to the daemon socket, resumes threadID as a second client,
+// and starts consuming its notifications.
+func Attach(socketPath, threadID string, opts ...Option) (*Attachment, error) {
+	client, err := Dial(socketPath)
+	if err != nil {
+		return nil, err
+	}
+	a := &Attachment{
+		client:       client,
+		threadID:     threadID,
+		targetID:     TargetID(threadID),
+		epoch:        fmt.Sprintf("cx-%d", time.Now().UnixNano()),
+		status:       "unknown",
+		runs:         map[requests.Key]*run{},
+		byTurn:       map[string]*run{},
+		byClientID:   map[string]*run{},
+		cancelIntent: map[requests.Key]bool{},
+		listeners:    map[int]func(core.NativeEvent){},
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	client.OnNotification = a.onNotification
+	client.OnServerRequest = a.onServerRequest
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := client.Call(ctx, "initialize", map[string]any{"clientInfo": map[string]string{"name": ClientName, "version": Version, "title": "AMQ Remote"}}, nil); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("initialize: %w", err)
+	}
+	var resumed struct {
+		Thread struct {
+			ID     string `json:"id"`
+			Cwd    string `json:"cwd"`
+			Status struct {
+				Type string `json:"type"`
+			} `json:"status"`
+		} `json:"thread"`
+	}
+	if err := client.Call(ctx, "thread/resume", map[string]any{"threadId": threadID}, &resumed); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("thread/resume %s: %w", threadID, err)
+	}
+	a.cwd = resumed.Thread.Cwd
+	a.status = threadStatus(resumed.Thread.Status.Type)
+	go func() {
+		<-client.Done()
+		a.mu.Lock()
+		a.offline = true
+		a.mu.Unlock()
+		a.emit(core.NativeEvent{Type: core.EventStatus, Attachment: "offline"})
+	}()
+	return a, nil
+}
+
+// TargetID derives the stable target id for a thread.
+func TargetID(threadID string) string {
+	id := strings.ReplaceAll(threadID, "-", "")
+	if len(id) > 12 {
+		id = id[:12]
+	}
+	return "codex:" + id
+}
+
+func threadStatus(t string) string {
+	switch t {
+	case "idle":
+		return "idle"
+	case "active":
+		return "busy"
+	case "notLoaded", "systemError":
+		return "unknown"
+	}
+	return "unknown"
+}
+
+// Close drops the connection. The thread keeps running in Codex.
+func (a *Attachment) Close() error { return a.client.Close() }
+
+// Inspect implements core.Attachment.
+func (a *Attachment) Inspect() protocol.Session {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	att, status := "live", a.status
+	if a.offline {
+		att, status = "offline", "offline"
+	}
+	var pending *string
+	for _, r := range a.runs {
+		if r.interaction != nil {
+			id := r.interaction.InteractionID
+			pending = &id
+		}
+	}
+	return protocol.Session{
+		Schema:             protocol.SchemaSession,
+		TargetID:           a.targetID,
+		Epoch:              a.epoch,
+		Harness:            "codex",
+		DisplayName:        "codex " + a.threadID,
+		Project:            a.cwd,
+		Attachment:         att,
+		Status:             status,
+		PendingInteraction: pending,
+		Capabilities: protocol.Capabilities{
+			Inspect: true, Submit: true, CancelRequest: true, Steer: true,
+			ApproveTool: a.approve, AnswerQuestion: false, Terminal: "unavailable",
+		},
+		Evidence:   &protocol.Evidence{Submit: "admitted", Completion: "run_terminal"},
+		ObservedAt: protocol.FormatTime(time.Now()),
+	}
+}
+
+// Submit implements core.Attachment. The status check and the turn/start
+// happen under one lock so a local turn starting in between is refused as
+// busy instead of silently joining Codex's running turn (measured behavior).
+func (a *Attachment) Submit(req core.BoundRequest) (core.Admission, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.offline {
+		return core.Admission{}, errors.New("app-server connection is closed")
+	}
+	if req.Epoch != a.epoch {
+		return core.Admission{Code: protocol.CodeStaleEpoch}, nil
+	}
+	if a.cancelIntent[req.Key] {
+		delete(a.cancelIntent, req.Key)
+		return core.Admission{Code: protocol.CodeCancelledBeforeAdmission}, nil
+	}
+	if existing, ok := a.runs[req.Key]; ok {
+		return core.Admission{Admitted: true, RunID: existing.runID()}, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	input := []map[string]string{{"type": "text", "text": req.Input.Text}}
+	r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, approvalReqs: map[string]json.RawMessage{}}
+	busy := a.status == "busy" || a.activeTurn != ""
+	switch {
+	case req.Input.Deliver == protocol.DeliverSteer:
+		if !busy {
+			return core.Admission{Code: protocol.CodeUnsupported, Message: "steer needs an active turn; use deliver=turn"}, nil
+		}
+		if err := a.client.Call(ctx, "turn/steer", map[string]any{"threadId": a.threadID, "expectedTurnId": a.activeTurn, "input": input, "clientUserMessageId": req.Key.RequestID}, nil); err != nil {
+			return refusal(err), nil
+		}
+		r.turnID = a.activeTurn
+	case busy && req.Input.Busy == protocol.BusyQueue:
+		if err := a.client.Call(ctx, "thread/queue/add", map[string]any{"threadId": a.threadID, "clientUserMessageId": req.Key.RequestID, "input": input}, nil); err != nil {
+			return refusal(err), nil
+		}
+		r.queued = true
+	case busy:
+		return core.Admission{Code: protocol.CodeBusy, Message: "a turn is active on this thread"}, nil
+	default:
+		var res struct {
+			Turn struct {
+				ID string `json:"id"`
+			} `json:"turn"`
+		}
+		if err := a.client.Call(ctx, "turn/start", map[string]any{"threadId": a.threadID, "input": input, "clientUserMessageId": req.Key.RequestID}, &res); err != nil {
+			return refusal(err), nil
+		}
+		if res.Turn.ID == "" {
+			return core.Admission{Code: protocol.CodeNativeError, Message: "turn/start returned no turn id"}, nil
+		}
+		if a.activeTurn != "" && a.activeTurn != res.Turn.ID {
+			// Codex answered with a turn that is not the one we saw as active;
+			// treat as a fresh turn and let notifications correct us.
+			a.activeTurn = res.Turn.ID
+		}
+		r.turnID = res.Turn.ID
+		a.activeTurn = res.Turn.ID
+		a.status = "busy"
+	}
+	a.runs[req.Key] = r
+	a.byClientID[req.Key.RequestID] = r
+	if r.turnID != "" {
+		a.byTurn[r.turnID] = r
+	}
+	return core.Admission{Admitted: true, RunID: r.runID()}, nil
+}
+
+func (r *run) runID() string {
+	if r.turnID != "" {
+		return "turn:" + r.turnID
+	}
+	return "queued:" + r.key.RequestID
+}
+
+func refusal(err error) core.Admission {
+	var rpc *rpcError
+	if errors.As(err, &rpc) {
+		return core.Admission{Code: protocol.CodeNativeError, Message: rpc.Message}
+	}
+	return core.Admission{Code: protocol.CodeNativeError, Message: err.Error()}
+}
+
+// Lookup implements core.Attachment. It answers from retained runs first and
+// then from the thread's own history, where the user message carries our
+// request id as clientId.
+func (a *Attachment) Lookup(key requests.Key, epoch string) (core.Evidence, error) {
+	a.mu.Lock()
+	if r, ok := a.runs[key]; ok && r.epoch == epoch {
+		ev := core.Evidence{Known: true, Admitted: true, RunID: r.runID(), State: r.state, LocalIntervention: r.local, Interaction: r.interaction}
+		if r.state.Terminal() {
+			ev.Result = r.result()
+		}
+		a.mu.Unlock()
+		return ev, nil
+	}
+	a.mu.Unlock()
+	return a.lookupHistory(key)
+}
+
+func (a *Attachment) lookupHistory(key requests.Key) (core.Evidence, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	var res struct {
+		Thread struct {
+			Turns []struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+				Error  *struct {
+					Message string `json:"message"`
+				} `json:"error"`
+				Items []struct {
+					Type     string `json:"type"`
+					ClientID string `json:"clientId"`
+					Text     string `json:"text"`
+				} `json:"items"`
+			} `json:"turns"`
+		} `json:"thread"`
+	}
+	if err := a.client.Call(ctx, "thread/read", map[string]any{"threadId": a.threadID, "includeTurns": true}, &res); err != nil {
+		return core.Evidence{}, err
+	}
+	for _, t := range res.Thread.Turns {
+		mine := false
+		var text strings.Builder
+		for _, it := range t.Items {
+			if it.Type == "userMessage" && it.ClientID == key.RequestID {
+				mine = true
+			}
+			if it.Type == "agentMessage" {
+				text.Reset()
+				text.WriteString(it.Text)
+			}
+		}
+		if !mine {
+			continue
+		}
+		ev := core.Evidence{Known: true, Admitted: true, RunID: "turn:" + t.ID}
+		switch t.Status {
+		case "completed":
+			ev.State = protocol.StateCompleted
+			ev.Result = &protocol.Result{Text: text.String(), NativeRef: "codex thread " + a.threadID + " turn " + t.ID}
+		case "failed":
+			ev.State = protocol.StateFailed
+			msg := ""
+			if t.Error != nil {
+				msg = t.Error.Message
+			}
+			ev.Result = &protocol.Result{Text: text.String(), Error: msg}
+		case "interrupted":
+			ev.State = protocol.StateCancelled
+			ev.Result = &protocol.Result{Text: text.String()}
+		default:
+			ev.State = protocol.StateRunning
+		}
+		return ev, nil
+	}
+	return core.Evidence{}, nil
+}
+
+// CancelExact implements core.Attachment.
+func (a *Attachment) CancelExact(key requests.Key, epoch string) (core.CancelEvidence, error) {
+	a.mu.Lock()
+	r, ok := a.runs[key]
+	if !ok {
+		a.cancelIntent[key] = true
+		a.mu.Unlock()
+		return core.CancelEvidence{Disposition: protocol.CancelRequested, Message: "intent recorded before admission"}, nil
+	}
+	if r.epoch != epoch || r.state.Terminal() {
+		a.mu.Unlock()
+		return core.CancelEvidence{Disposition: protocol.CancelNoopTerminal}, nil
+	}
+	turnID, queued := r.turnID, r.queued
+	a.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if queued && turnID == "" {
+		if err := a.client.Call(ctx, "thread/queue/delete", map[string]any{"threadId": a.threadID, "clientUserMessageId": key.RequestID}, nil); err != nil {
+			return core.CancelEvidence{Disposition: protocol.CancelUnsupported, Message: err.Error()}, nil
+		}
+		a.mu.Lock()
+		r.state = protocol.StateCancelled
+		a.mu.Unlock()
+		a.emit(core.NativeEvent{Type: core.EventRunCancelled, Key: key, RunID: r.runID()})
+		return core.CancelEvidence{Disposition: protocol.CancelConfirmed}, nil
+	}
+	if err := a.client.Call(ctx, "turn/interrupt", map[string]any{"threadId": a.threadID, "turnId": turnID}, nil); err != nil {
+		return core.CancelEvidence{Disposition: protocol.CancelRequested, Message: err.Error()}, nil
+	}
+	// Confirmation arrives as turn/completed with status interrupted.
+	return core.CancelEvidence{Disposition: protocol.CancelRequested, Message: "interrupt sent for " + turnID}, nil
+}
+
+// Respond implements core.Attachment for command approvals.
+func (a *Attachment) Respond(key requests.Key, epoch, interactionID, option string) (protocol.Code, error) {
+	a.mu.Lock()
+	r, ok := a.runs[key]
+	if !ok || r.epoch != epoch || r.interaction == nil || r.interaction.InteractionID != interactionID {
+		a.mu.Unlock()
+		return protocol.CodeAlreadyResolved, nil
+	}
+	reqID, ok := r.approvalReqs[interactionID]
+	if !ok {
+		a.mu.Unlock()
+		return protocol.CodeAlreadyResolved, nil
+	}
+	allowed := false
+	for _, o := range r.interaction.Options {
+		if o == option {
+			allowed = true
+		}
+	}
+	if !allowed {
+		a.mu.Unlock()
+		return protocol.CodeInvalid, nil
+	}
+	delete(r.approvalReqs, interactionID)
+	r.interaction = nil
+	a.mu.Unlock()
+	if err := a.client.Respond(reqID, map[string]string{"decision": option}); err != nil {
+		return "", err
+	}
+	a.emit(core.NativeEvent{Type: core.EventQuestionResolved, Key: key, RunID: r.runID()})
+	return "", nil
+}
+
+// AcknowledgeResult implements core.Attachment. Codex keeps the transcript;
+// nothing is retained here beyond the process.
+func (a *Attachment) AcknowledgeResult(requests.Key, string, string) {}
+
+// Subscribe implements core.Attachment.
+func (a *Attachment) Subscribe(fn func(core.NativeEvent)) func() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.nextListener++
+	id := a.nextListener
+	a.listeners[id] = fn
+	return func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		delete(a.listeners, id)
+	}
+}
+
+func (a *Attachment) emit(ev core.NativeEvent) {
+	a.mu.Lock()
+	fns := make([]func(core.NativeEvent), 0, len(a.listeners))
+	for _, fn := range a.listeners {
+		fns = append(fns, fn)
+	}
+	a.mu.Unlock()
+	for _, fn := range fns {
+		fn(ev)
+	}
+}
+
+func (a *Attachment) onNotification(n Notification) {
+	switch n.Method {
+	case "turn/started":
+		var p struct {
+			ThreadID string `json:"threadId"`
+			Turn     struct {
+				ID string `json:"id"`
+			} `json:"turn"`
+		}
+		if json.Unmarshal(n.Params, &p) != nil || p.ThreadID != a.threadID {
+			return
+		}
+		a.mu.Lock()
+		a.activeTurn = p.Turn.ID
+		a.status = "busy"
+		a.mu.Unlock()
+	case "item/started", "item/completed":
+		a.onItem(n)
+	case "turn/completed":
+		var p struct {
+			ThreadID string `json:"threadId"`
+			Turn     struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+				Error  *struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			} `json:"turn"`
+		}
+		if json.Unmarshal(n.Params, &p) != nil || p.ThreadID != a.threadID {
+			return
+		}
+		a.mu.Lock()
+		if a.activeTurn == p.Turn.ID {
+			a.activeTurn = ""
+			a.status = "idle"
+		}
+		r, ok := a.byTurn[p.Turn.ID]
+		if !ok || r.state.Terminal() {
+			a.mu.Unlock()
+			return
+		}
+		var ev core.NativeEvent
+		switch p.Turn.Status {
+		case "completed":
+			r.state = protocol.StateCompleted
+			ev = core.NativeEvent{Type: core.EventRunCompleted}
+		case "interrupted":
+			r.state = protocol.StateCancelled
+			ev = core.NativeEvent{Type: core.EventRunCancelled}
+		default:
+			r.state = protocol.StateFailed
+			if p.Turn.Error != nil {
+				r.errText = p.Turn.Error.Message
+			}
+			ev = core.NativeEvent{Type: core.EventRunFailed}
+		}
+		ev.Key, ev.RunID, ev.Result = r.key, r.runID(), r.result()
+		r.interaction = nil
+		a.mu.Unlock()
+		a.emit(ev)
+	case "thread/status/changed":
+		var p struct {
+			ThreadID string `json:"threadId"`
+			Status   struct {
+				Type string `json:"type"`
+			} `json:"status"`
+		}
+		if json.Unmarshal(n.Params, &p) != nil || p.ThreadID != a.threadID {
+			return
+		}
+		a.mu.Lock()
+		a.status = threadStatus(p.Status.Type)
+		if a.status == "idle" {
+			a.activeTurn = ""
+		}
+		a.mu.Unlock()
+	}
+}
+
+func (a *Attachment) onItem(n Notification) {
+	var p struct {
+		ThreadID string `json:"threadId"`
+		TurnID   string `json:"turnId"`
+		Item     struct {
+			Type     string `json:"type"`
+			ID       string `json:"id"`
+			ClientID string `json:"clientId"`
+			Text     string `json:"text"`
+		} `json:"item"`
+	}
+	if json.Unmarshal(n.Params, &p) != nil || p.ThreadID != a.threadID {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	switch p.Item.Type {
+	case "userMessage":
+		if r, ok := a.byClientID[p.Item.ClientID]; ok && p.Item.ClientID != "" {
+			if r.turnID == "" {
+				r.turnID = p.TurnID
+				r.queued = false
+				a.byTurn[p.TurnID] = r
+			}
+			return
+		}
+		// A user message we did not send landed in a turn we own: the human
+		// steered locally.
+		if r, ok := a.byTurn[p.TurnID]; ok && !r.local && n.Method == "item/started" {
+			r.local = true
+			key, runID := r.key, r.runID()
+			go a.emit(core.NativeEvent{Type: core.EventLocalIntervention, Key: key, RunID: runID})
+		}
+	case "agentMessage":
+		if r, ok := a.byTurn[p.TurnID]; ok && n.Method == "item/completed" {
+			r.text.Reset()
+			r.text.WriteString(p.Item.Text)
+		}
+	}
+}
+
+func (a *Attachment) onServerRequest(req ServerRequest) {
+	switch req.Method {
+	case methodCommandApproval, methodFileChangeApproval, methodLegacyExecApproval:
+	default:
+		return
+	}
+	var p struct {
+		ThreadID           string   `json:"threadId"`
+		TurnID             string   `json:"turnId"`
+		ItemID             string   `json:"itemId"`
+		ApprovalID         string   `json:"approvalId"`
+		Command            any      `json:"command"`
+		AvailableDecisions []string `json:"availableDecisions"`
+	}
+	if json.Unmarshal(req.Params, &p) != nil || p.ThreadID != a.threadID {
+		return
+	}
+	a.mu.Lock()
+	r, ok := a.byTurn[p.TurnID]
+	if !ok || !a.approve {
+		// Not our run, or approvals not advertised: the local TUI answers.
+		a.mu.Unlock()
+		return
+	}
+	id := p.ApprovalID
+	if id == "" {
+		id = p.ItemID
+	}
+	options := p.AvailableDecisions
+	if len(options) == 0 {
+		options = []string{"accept", "decline"}
+	}
+	prompt := ""
+	if b, err := json.Marshal(p.Command); err == nil {
+		prompt = string(b)
+	}
+	r.interaction = &protocol.Interaction{InteractionID: id, Kind: "approval", Prompt: prompt, Options: options, RemoteAnswer: true}
+	r.approvalReqs[id] = req.ID
+	key, runID, inter := r.key, r.runID(), r.interaction
+	a.mu.Unlock()
+	a.emit(core.NativeEvent{Type: core.EventQuestion, Key: key, RunID: runID, Interaction: inter})
+}
+
+func (r *run) result() *protocol.Result {
+	return &protocol.Result{Text: r.text.String(), Error: r.errText}
+}
+
+// LoadedThreads lists the threads the daemon currently has running, so the
+// endpoint can attach to each of them. It opens a short-lived connection.
+func LoadedThreads(socketPath string) ([]string, error) {
+	client, err := Dial(socketPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = client.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := client.Call(ctx, "initialize", map[string]any{"clientInfo": map[string]string{"name": ClientName, "version": Version}}, nil); err != nil {
+		return nil, err
+	}
+	var res struct {
+		Data      []string `json:"data"`
+		ThreadIDs []string `json:"threadIds"`
+	}
+	if err := client.Call(ctx, "thread/loaded/list", map[string]any{}, &res); err != nil {
+		return nil, err
+	}
+	if len(res.Data) > 0 {
+		return res.Data, nil
+	}
+	return res.ThreadIDs, nil
+}

--- a/internal/remote/codex/attachment.go
+++ b/internal/remote/codex/attachment.go
@@ -20,6 +20,12 @@ const ClientName = "amq-remote"
 // Version is stamped by the binary.
 var Version = "dev"
 
+// confirmTimeout bounds how long Submit waits for our own userMessage item to
+// confirm an idle turn/start actually accepted our text. The clientId echo is
+// schema-backed but unverified live (quota-blocked probe), so an unconfirmed
+// turn is refused, never admitted.
+const confirmTimeout = 12 * time.Second
+
 // Approval methods the app-server sends as server requests. Only the
 // command-execution family is answered; the rest stay local-only.
 const (
@@ -39,6 +45,10 @@ type run struct {
 	local        bool
 	interaction  *protocol.Interaction
 	approvalReqs map[string]json.RawMessage
+	// confirmed closes when the userMessage item carrying this run's
+	// clientUserMessageId is observed, proving turn/start accepted our text
+	// rather than joining a turn started in the race window and dropping it.
+	confirmed chan struct{}
 }
 
 // Attachment is one running Codex thread reached through the shared
@@ -184,73 +194,145 @@ func (a *Attachment) Inspect() protocol.Session {
 	}
 }
 
-// Submit implements core.Attachment. The status check and the turn/start
-// happen under one lock so a local turn starting in between is refused as
-// busy instead of silently joining Codex's running turn (measured behavior).
+// Submit implements core.Attachment. It never holds the attachment lock across
+// a network call (that would stall the read loop that delivers the response),
+// and for an idle turn/start it admits only after our own userMessage item
+// confirms the text landed — the measured busy-join drops the caller's text
+// and returns the running turn, which must not become an admitted phantom run.
 func (a *Attachment) Submit(req core.BoundRequest) (core.Admission, error) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if a.offline {
+		a.mu.Unlock()
 		return core.Admission{}, errors.New("app-server connection is closed")
 	}
 	if req.Epoch != a.epoch {
+		a.mu.Unlock()
 		return core.Admission{Code: protocol.CodeStaleEpoch}, nil
 	}
 	if a.cancelIntent[req.Key] {
 		delete(a.cancelIntent, req.Key)
+		a.mu.Unlock()
 		return core.Admission{Code: protocol.CodeCancelledBeforeAdmission}, nil
 	}
 	if existing, ok := a.runs[req.Key]; ok {
-		return core.Admission{Admitted: true, RunID: existing.runID()}, nil
+		id := existing.runID()
+		a.mu.Unlock()
+		return core.Admission{Admitted: true, RunID: id}, nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-	input := []map[string]string{{"type": "text", "text": req.Input.Text}}
-	r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, approvalReqs: map[string]json.RawMessage{}}
 	busy := a.status == "busy" || a.activeTurn != ""
+	activeTurn := a.activeTurn
+	a.mu.Unlock()
+
+	input := []map[string]any{{"type": "text", "text": req.Input.Text}}
+
 	switch {
 	case req.Input.Deliver == protocol.DeliverSteer:
+		// Steer interleaves into the running turn; expectedTurnId makes the
+		// app-server reject if the active turn changed under us, so no
+		// separate confirmation is needed.
 		if !busy {
 			return core.Admission{Code: protocol.CodeUnsupported, Message: "steer needs an active turn; use deliver=turn"}, nil
 		}
-		if err := a.client.Call(ctx, "turn/steer", map[string]any{"threadId": a.threadID, "expectedTurnId": a.activeTurn, "input": input, "clientUserMessageId": req.Key.RequestID}, nil); err != nil {
+		if err := a.call("turn/steer", map[string]any{"threadId": a.threadID, "expectedTurnId": activeTurn, "input": input, "clientUserMessageId": req.Key.RequestID}, nil); err != nil {
 			return refusal(err), nil
 		}
-		r.turnID = a.activeTurn
+		r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, turnID: activeTurn, approvalReqs: map[string]json.RawMessage{}}
+		a.mu.Lock()
+		a.runs[req.Key] = r
+		a.byClientID[req.Key.RequestID] = r
+		a.byTurn[activeTurn] = r
+		a.mu.Unlock()
+		return core.Admission{Admitted: true, RunID: r.runID()}, nil
+
 	case busy && req.Input.Busy == protocol.BusyQueue:
-		if err := a.client.Call(ctx, "thread/queue/add", map[string]any{"threadId": a.threadID, "clientUserMessageId": req.Key.RequestID, "input": input}, nil); err != nil {
+		// Codex's own FIFO queue primitive; acceptance is Codex-native.
+		if err := a.call("thread/queue/add", map[string]any{"threadId": a.threadID, "clientUserMessageId": req.Key.RequestID, "input": input}, nil); err != nil {
 			return refusal(err), nil
 		}
-		r.queued = true
+		r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, queued: true, approvalReqs: map[string]json.RawMessage{}}
+		a.mu.Lock()
+		a.runs[req.Key] = r
+		a.byClientID[req.Key.RequestID] = r
+		a.mu.Unlock()
+		return core.Admission{Admitted: true, RunID: r.runID()}, nil
+
 	case busy:
 		return core.Admission{Code: protocol.CodeBusy, Message: "a turn is active on this thread"}, nil
-	default:
-		var res struct {
-			Turn struct {
-				ID string `json:"id"`
-			} `json:"turn"`
-		}
-		if err := a.client.Call(ctx, "turn/start", map[string]any{"threadId": a.threadID, "input": input, "clientUserMessageId": req.Key.RequestID}, &res); err != nil {
-			return refusal(err), nil
-		}
-		if res.Turn.ID == "" {
-			return core.Admission{Code: protocol.CodeNativeError, Message: "turn/start returned no turn id"}, nil
-		}
-		if a.activeTurn != "" && a.activeTurn != res.Turn.ID {
-			// Codex answered with a turn that is not the one we saw as active;
-			// treat as a fresh turn and let notifications correct us.
-			a.activeTurn = res.Turn.ID
-		}
-		r.turnID = res.Turn.ID
-		a.activeTurn = res.Turn.ID
-		a.status = "busy"
 	}
+
+	// Idle turn/start. Register the run first so onItem can confirm our
+	// userMessage, then call unlocked, then require confirmation.
+	r := &run{key: req.Key, epoch: req.Epoch, state: protocol.StateRunning, approvalReqs: map[string]json.RawMessage{}, confirmed: make(chan struct{})}
+	a.mu.Lock()
 	a.runs[req.Key] = r
 	a.byClientID[req.Key.RequestID] = r
-	if r.turnID != "" {
-		a.byTurn[r.turnID] = r
+	a.mu.Unlock()
+
+	var res struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
 	}
-	return core.Admission{Admitted: true, RunID: r.runID()}, nil
+	if err := a.call("turn/start", map[string]any{"threadId": a.threadID, "input": input, "clientUserMessageId": req.Key.RequestID}, &res); err != nil {
+		a.dropRun(req.Key)
+		return refusal(err), nil
+	}
+	if res.Turn.ID == "" {
+		a.dropRun(req.Key)
+		return core.Admission{Code: protocol.CodeNativeError, Message: "turn/start returned no turn id"}, nil
+	}
+	a.mu.Lock()
+	if r.turnID == "" {
+		r.turnID = res.Turn.ID
+		a.byTurn[res.Turn.ID] = r
+	}
+	a.activeTurn = res.Turn.ID
+	a.status = "busy"
+	confirmed := r.confirmed
+	a.mu.Unlock()
+
+	select {
+	case <-confirmed:
+		return core.Admission{Admitted: true, RunID: r.runID()}, nil
+	case <-time.After(confirmTimeout):
+		a.dropRun(req.Key)
+		return core.Admission{Code: protocol.CodeBusy, Message: "turn/start was not confirmed by our own userMessage item; it may have joined an active turn"}, nil
+	case <-a.client.Done():
+		a.dropRun(req.Key)
+		return core.Admission{Code: protocol.CodeAttachmentLost, Message: "app-server closed during turn/start"}, nil
+	}
+}
+
+// call runs one app-server request with a bounded timeout and no lock held.
+func (a *Attachment) call(method string, params, result any) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	return a.client.Call(ctx, method, params, result)
+}
+
+// dropRun removes a run binding when admission failed, so a retry is clean.
+func (a *Attachment) dropRun(key requests.Key) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if r, ok := a.runs[key]; ok {
+		delete(a.byClientID, key.RequestID)
+		if r.turnID != "" {
+			delete(a.byTurn, r.turnID)
+		}
+		delete(a.runs, key)
+	}
+}
+
+// confirmRun closes a run's confirmation channel once. The caller holds a.mu.
+func confirmRun(r *run) {
+	if r.confirmed == nil {
+		return
+	}
+	select {
+	case <-r.confirmed:
+	default:
+		close(r.confirmed)
+	}
 }
 
 func (r *run) runID() string {
@@ -546,6 +628,8 @@ func (a *Attachment) onItem(n Notification) {
 				r.queued = false
 				a.byTurn[p.TurnID] = r
 			}
+			// Our text is confirmed in this turn: admission is real.
+			confirmRun(r)
 			return
 		}
 		// A user message we did not send landed in a turn we own: the human

--- a/internal/remote/codex/attachment.go
+++ b/internal/remote/codex/attachment.go
@@ -143,11 +143,10 @@ func Attach(socketPath, threadID string, opts ...Option) (*Attachment, error) {
 
 // TargetID derives the stable target id for a thread.
 func TargetID(threadID string) string {
-	id := strings.ReplaceAll(threadID, "-", "")
-	if len(id) > 12 {
-		id = id[:12]
-	}
-	return "codex:" + id
+	// The full de-hyphenated thread id, never truncated: two distinct thread
+	// ids must not collapse to one target (Pro B03). Codex thread ids are
+	// UUIDv7 (32 hex), well within the 128-char target_id bound.
+	return "codex:" + strings.ReplaceAll(threadID, "-", "")
 }
 
 func threadStatus(t string) string {

--- a/internal/remote/codex/attachment.go
+++ b/internal/remote/codex/attachment.go
@@ -357,6 +357,9 @@ func (a *Attachment) deliverPendingCancel(key requests.Key, turnID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	if err := a.client.Call(ctx, "turn/interrupt", map[string]any{"threadId": a.threadID, "turnId": turnID}, nil); err != nil {
+		// TODO(B04): a pending cancel that confirmed then raced completion is
+		// lost here with no state mutation; re-record the intent or emit an
+		// uncertain-cancel event so it is not silently dropped.
 		return
 	}
 	// The resulting turn/completed(interrupted) drives the cancelled state.

--- a/internal/remote/codex/attachment_test.go
+++ b/internal/remote/codex/attachment_test.go
@@ -1,0 +1,152 @@
+package codex
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// fakeAppServer answers the app-server methods the attachment uses with the
+// shapes recorded from the live probe and the generated schema, and lets the
+// test push notifications.
+type fakeAppServer struct {
+	ws    *wsConn
+	calls chan rpcMessage
+}
+
+func startFakeAppServer(t *testing.T) (string, *fakeAppServer) {
+	dir, err := os.MkdirTemp("", "amqcx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "d.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	srv := &fakeAppServer{calls: make(chan rpcMessage, 16)}
+	ready := make(chan struct{})
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		ws, err := acceptServerWS(conn)
+		if err != nil {
+			return
+		}
+		srv.ws = ws
+		close(ready)
+		for {
+			payload, err := ws.readText()
+			if err != nil {
+				return
+			}
+			var msg rpcMessage
+			if json.Unmarshal(payload, &msg) != nil {
+				continue
+			}
+			srv.calls <- msg
+			if msg.ID == nil || msg.Method == "" {
+				continue
+			}
+			switch msg.Method {
+			case "initialize":
+				_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":` + string(*msg.ID) + `,"result":{"userAgent":"fake"}}`))
+			case "thread/resume":
+				_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":` + string(*msg.ID) + `,"result":{"thread":{"id":"t1","cwd":"/work","status":{"type":"idle"}}}}`))
+			case "turn/start":
+				_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":` + string(*msg.ID) + `,"result":{"turn":{"id":"u1","status":"inProgress"}}}`))
+			case "turn/interrupt":
+				_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":` + string(*msg.ID) + `,"result":{}}`))
+			default:
+				_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":` + string(*msg.ID) + `,"error":{"code":-32601,"message":"unexpected ` + msg.Method + `"}}`))
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-ready:
+		default:
+		}
+	})
+	return sock, srv
+}
+
+func (s *fakeAppServer) notify(t *testing.T, method, params string) {
+	if err := s.ws.writeText([]byte(`{"jsonrpc":"2.0","method":"` + method + `","params":` + params + `}`)); err != nil {
+		t.Fatalf("notify %s: %v", method, err)
+	}
+}
+
+// TestSubmitBindsTurnAndCompletes is the adapter happy path: submit starts a
+// turn with our request id as clientUserMessageId, the user-message item
+// echoes it back, the agent message carries the text, and turn/completed
+// yields a completed run with that text.
+func TestSubmitBindsTurnAndCompletes(t *testing.T) {
+	sock, srv := startFakeAppServer(t)
+	att, err := Attach(sock, "t1")
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	t.Cleanup(func() { _ = att.Close() })
+	// drain initialize + thread/resume
+	<-srv.calls
+	<-srv.calls
+
+	events := make(chan core.NativeEvent, 8)
+	att.Subscribe(func(ev core.NativeEvent) { events <- ev })
+
+	s := att.Inspect()
+	if s.Harness != "codex" || s.Status != "idle" || s.Project != "/work" || !s.Capabilities.Submit || s.Capabilities.ApproveTool {
+		t.Fatalf("unexpected session: %+v", s)
+	}
+
+	key := requests.Key{CreatorHost: "local", TargetID: s.TargetID, RequestID: "11111111-1111-4111-8111-111111111501"}
+	adm, err := att.Submit(core.BoundRequest{Key: key, Epoch: s.Epoch, Input: protocol.SubmitInput{Text: "say PONG"}})
+	if err != nil || !adm.Admitted || adm.RunID != "turn:u1" {
+		t.Fatalf("submit: %+v %v", adm, err)
+	}
+	call := <-srv.calls
+	var params map[string]any
+	_ = json.Unmarshal(call.Params, &params)
+	if call.Method != "turn/start" || params["clientUserMessageId"] != key.RequestID {
+		t.Fatalf("unexpected native call: %s %v", call.Method, params)
+	}
+
+	srv.notify(t, "turn/started", `{"threadId":"t1","turn":{"id":"u1"}}`)
+	srv.notify(t, "item/started", `{"threadId":"t1","turnId":"u1","item":{"type":"userMessage","id":"i1","clientId":"`+key.RequestID+`","content":[]}}`)
+	srv.notify(t, "item/completed", `{"threadId":"t1","turnId":"u1","completedAtMs":1,"item":{"type":"agentMessage","id":"i2","text":"PONG"}}`)
+	// A second submit while the turn is active is refused as busy, never
+	// joined to the running turn.
+	adm2, _ := att.Submit(core.BoundRequest{Key: requests.Key{CreatorHost: "local", TargetID: s.TargetID, RequestID: "11111111-1111-4111-8111-111111111502"}, Epoch: s.Epoch, Input: protocol.SubmitInput{Text: "again"}})
+	if adm2.Admitted || adm2.Code != protocol.CodeBusy {
+		t.Fatalf("busy submit not refused: %+v", adm2)
+	}
+	srv.notify(t, "turn/completed", `{"threadId":"t1","turn":{"id":"u1","status":"completed"}}`)
+
+	select {
+	case ev := <-events:
+		if ev.Type != core.EventRunCompleted || ev.Key != key || ev.Result == nil || ev.Result.Text != "PONG" {
+			t.Fatalf("unexpected event: %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no completion event")
+	}
+	ev, err := att.Lookup(key, s.Epoch)
+	if err != nil || !ev.Known || ev.State != protocol.StateCompleted || ev.Result.Text != "PONG" {
+		t.Fatalf("lookup: %+v %v", ev, err)
+	}
+	if att.Inspect().Status != "idle" {
+		t.Fatal("thread not idle after completion")
+	}
+}

--- a/internal/remote/codex/attachment_test.go
+++ b/internal/remote/codex/attachment_test.go
@@ -247,3 +247,13 @@ func TestTentativeRunIsNotOwned(t *testing.T) {
 		}
 	}
 }
+
+// TestTargetIDNoCollision reproduces Pro B03: two distinct thread ids that
+// share a 12-hex prefix must not collapse to one target id.
+func TestTargetIDNoCollision(t *testing.T) {
+	a := TargetID("0123456789ab-cdef-0000-0000-000000000001")
+	b := TargetID("0123456789ab-cdef-0000-0000-000000000002")
+	if a == b {
+		t.Fatalf("distinct threads collapsed to one target: %s", a)
+	}
+}

--- a/internal/remote/codex/attachment_test.go
+++ b/internal/remote/codex/attachment_test.go
@@ -165,3 +165,85 @@ func TestSubmitBindsTurnAndCompletes(t *testing.T) {
 		t.Fatal("thread not idle after completion")
 	}
 }
+
+// TestTentativeRunIsNotOwned reproduces Pro finding B01: while a run is bound
+// but not yet confirmed by its own userMessage item, no consumer may treat it
+// as owned. Lookup must report Tentative (not Admitted), CancelExact must
+// record intent without interrupting a turn we do not own, a foreign turn's
+// completion must not complete our run, and once our userMessage confirms the
+// run the pending cancel is delivered against OUR turn.
+func TestTentativeRunIsNotOwned(t *testing.T) {
+	sock, srv := startFakeAppServer(t)
+	att, err := Attach(sock, "t1")
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	t.Cleanup(func() { _ = att.Close() })
+	<-srv.calls // initialize
+	<-srv.calls // thread/resume
+
+	key := requests.Key{CreatorHost: "local", TargetID: att.Inspect().TargetID, RequestID: "11111111-1111-4111-8111-111111111701"}
+	epoch := att.Inspect().Epoch
+	done := make(chan core.Admission, 1)
+	go func() {
+		adm, _ := att.Submit(core.BoundRequest{Key: key, Epoch: epoch, Input: protocol.SubmitInput{Text: "do it"}})
+		done <- adm
+	}()
+	call := <-srv.calls // turn/start; server replies turn id "u1"
+	if call.Method != "turn/start" {
+		t.Fatalf("expected turn/start, got %s", call.Method)
+	}
+
+	// Tentative window: the run is bound (byClientID) but not confirmed.
+	ev, err := att.Lookup(key, epoch)
+	if err != nil || ev.Class != core.EvidenceTentative || ev.Admitted {
+		t.Fatalf("tentative Lookup wrong: class=%s admitted=%v err=%v", ev.Class, ev.Admitted, err)
+	}
+	ce, _ := att.CancelExact(key, epoch)
+	if ce.Disposition != protocol.CancelRequested {
+		t.Fatalf("tentative cancel disposition=%s, want cancel_requested", ce.Disposition)
+	}
+	// A foreign turn completing must not complete our run.
+	srv.notify(t, "turn/completed", `{"threadId":"t1","turn":{"id":"uForeign","status":"completed"}}`)
+	time.Sleep(30 * time.Millisecond)
+	if lk, _ := att.Lookup(key, epoch); lk.State == protocol.StateCompleted {
+		t.Fatal("foreign turn/completed wrongly completed our run")
+	}
+	// No turn/interrupt may have been sent yet (we never owned a turn).
+	select {
+	case c := <-srv.calls:
+		if c.Method == "turn/interrupt" {
+			t.Fatal("interrupt sent for an unconfirmed run")
+		}
+	default:
+	}
+
+	// Confirm: our userMessage lands for turn u1. This binds byTurn and must
+	// deliver the pending cancel as an interrupt for OUR turn u1.
+	srv.notify(t, "item/started", `{"threadId":"t1","turnId":"u1","item":{"type":"userMessage","id":"i1","clientId":"`+key.RequestID+`","content":[]}}`)
+	select {
+	case adm := <-done:
+		if !adm.Admitted {
+			t.Fatalf("submit did not admit after confirmation: %+v", adm)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("submit never returned after confirmation")
+	}
+	// The pending cancel now fires turn/interrupt for u1.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case c := <-srv.calls:
+			if c.Method == "turn/interrupt" {
+				var p map[string]any
+				_ = json.Unmarshal(c.Params, &p)
+				if p["turnId"] != "u1" {
+					t.Fatalf("interrupt hit turn %v, want our turn u1", p["turnId"])
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("pending cancel never delivered an interrupt for our turn")
+		}
+	}
+}

--- a/internal/remote/codex/attachment_test.go
+++ b/internal/remote/codex/attachment_test.go
@@ -111,20 +111,35 @@ func TestSubmitBindsTurnAndCompletes(t *testing.T) {
 		t.Fatalf("unexpected session: %+v", s)
 	}
 
+	// Submit blocks until our userMessage item confirms the turn accepted our
+	// text, so run it concurrently and deliver the confirming notification.
 	key := requests.Key{CreatorHost: "local", TargetID: s.TargetID, RequestID: "11111111-1111-4111-8111-111111111501"}
-	adm, err := att.Submit(core.BoundRequest{Key: key, Epoch: s.Epoch, Input: protocol.SubmitInput{Text: "say PONG"}})
-	if err != nil || !adm.Admitted || adm.RunID != "turn:u1" {
-		t.Fatalf("submit: %+v %v", adm, err)
+	type admResult struct {
+		adm core.Admission
+		err error
 	}
+	done := make(chan admResult, 1)
+	go func() {
+		adm, err := att.Submit(core.BoundRequest{Key: key, Epoch: s.Epoch, Input: protocol.SubmitInput{Text: "say PONG"}})
+		done <- admResult{adm, err}
+	}()
 	call := <-srv.calls
 	var params map[string]any
 	_ = json.Unmarshal(call.Params, &params)
 	if call.Method != "turn/start" || params["clientUserMessageId"] != key.RequestID {
 		t.Fatalf("unexpected native call: %s %v", call.Method, params)
 	}
-
 	srv.notify(t, "turn/started", `{"threadId":"t1","turn":{"id":"u1"}}`)
 	srv.notify(t, "item/started", `{"threadId":"t1","turnId":"u1","item":{"type":"userMessage","id":"i1","clientId":"`+key.RequestID+`","content":[]}}`)
+	select {
+	case r := <-done:
+		if r.err != nil || !r.adm.Admitted || r.adm.RunID != "turn:u1" {
+			t.Fatalf("submit: %+v %v", r.adm, r.err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("submit did not admit after userMessage confirmation")
+	}
+
 	srv.notify(t, "item/completed", `{"threadId":"t1","turnId":"u1","completedAtMs":1,"item":{"type":"agentMessage","id":"i2","text":"PONG"}}`)
 	// A second submit while the turn is active is refused as busy, never
 	// joined to the running turn.

--- a/internal/remote/codex/rpc.go
+++ b/internal/remote/codex/rpc.go
@@ -141,12 +141,19 @@ func (c *Client) Call(ctx context.Context, method string, params any, result any
 	}
 	c.pending[id] = ch
 	c.mu.Unlock()
+	// Bound the write itself by the context: a blocked socket write must abort
+	// at the deadline, not hang until the connection is closed (Pro B14).
+	if dl, ok := ctx.Deadline(); ok {
+		c.ws.setWriteDeadline(dl)
+	}
 	if err := c.ws.writeText(data); err != nil {
+		c.ws.setWriteDeadline(time.Time{})
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
 		return err
 	}
+	c.ws.setWriteDeadline(time.Time{})
 	select {
 	case resp, ok := <-ch:
 		if !ok {

--- a/internal/remote/codex/rpc.go
+++ b/internal/remote/codex/rpc.go
@@ -1,0 +1,185 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// rpcMessage is one JSON-RPC 2.0 message in either direction. The app-server
+// omits "jsonrpc" on some notifications, so it is optional on decode.
+type rpcMessage struct {
+	JSONRPC string           `json:"jsonrpc,omitempty"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method,omitempty"`
+	Params  json.RawMessage  `json:"params,omitempty"`
+	Result  json.RawMessage  `json:"result,omitempty"`
+	Error   *rpcError        `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *rpcError) Error() string { return fmt.Sprintf("app-server error %d: %s", e.Code, e.Message) }
+
+// ServerRequest is a request the app-server sends to us (approvals, user
+// input). The handler answers through Respond.
+type ServerRequest struct {
+	ID     json.RawMessage
+	Method string
+	Params json.RawMessage
+}
+
+// Notification is a server-initiated notification.
+type Notification struct {
+	Method string
+	Params json.RawMessage
+}
+
+// Client multiplexes one WebSocket connection: requests get correlated
+// responses, notifications and server requests fan out to the handlers set
+// before Run starts reading.
+type Client struct {
+	ws      *wsConn
+	nextID  atomic.Int64
+	mu      sync.Mutex
+	pending map[int64]chan rpcMessage
+	closed  chan struct{}
+	once    sync.Once
+	readErr error
+
+	OnNotification  func(Notification)
+	OnServerRequest func(ServerRequest)
+}
+
+// Dial connects to the app-server unix socket and starts the read loop.
+func Dial(socketPath string) (*Client, error) {
+	ws, err := dialUnixWS(socketPath, 3*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial app-server %s: %w", socketPath, err)
+	}
+	return newClient(ws), nil
+}
+
+func newClient(ws *wsConn) *Client {
+	c := &Client{ws: ws, pending: map[int64]chan rpcMessage{}, closed: make(chan struct{})}
+	go c.readLoop()
+	return c
+}
+
+func (c *Client) readLoop() {
+	for {
+		payload, err := c.ws.readText()
+		if err != nil {
+			c.mu.Lock()
+			c.readErr = err
+			for id, ch := range c.pending {
+				close(ch)
+				delete(c.pending, id)
+			}
+			c.mu.Unlock()
+			c.once.Do(func() { close(c.closed) })
+			return
+		}
+		var msg rpcMessage
+		if err := json.Unmarshal(payload, &msg); err != nil {
+			continue
+		}
+		switch {
+		case msg.ID != nil && msg.Method == "":
+			var id int64
+			if err := json.Unmarshal(*msg.ID, &id); err != nil {
+				continue
+			}
+			c.mu.Lock()
+			ch, ok := c.pending[id]
+			delete(c.pending, id)
+			c.mu.Unlock()
+			if ok {
+				ch <- msg
+			}
+		case msg.ID != nil:
+			if c.OnServerRequest != nil {
+				c.OnServerRequest(ServerRequest{ID: *msg.ID, Method: msg.Method, Params: msg.Params})
+			}
+		case msg.Method != "":
+			if c.OnNotification != nil {
+				c.OnNotification(Notification{Method: msg.Method, Params: msg.Params})
+			}
+		}
+	}
+}
+
+// Done closes when the connection is gone.
+func (c *Client) Done() <-chan struct{} { return c.closed }
+
+// Call sends a request and waits for its response or ctx.
+func (c *Client) Call(ctx context.Context, method string, params any, result any) error {
+	id := c.nextID.Add(1)
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	idRaw := json.RawMessage(fmt.Sprintf("%d", id))
+	msg := rpcMessage{JSONRPC: "2.0", ID: &idRaw, Method: method, Params: raw}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	ch := make(chan rpcMessage, 1)
+	c.mu.Lock()
+	if c.readErr != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("app-server connection closed: %w", c.readErr)
+	}
+	c.pending[id] = ch
+	c.mu.Unlock()
+	if err := c.ws.writeText(data); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return err
+	}
+	select {
+	case resp, ok := <-ch:
+		if !ok {
+			return errors.New("app-server connection closed before reply")
+		}
+		if resp.Error != nil {
+			return resp.Error
+		}
+		if result != nil && len(resp.Result) > 0 {
+			return json.Unmarshal(resp.Result, result)
+		}
+		return nil
+	case <-ctx.Done():
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+// Respond answers a server request.
+func (c *Client) Respond(id json.RawMessage, result any) error {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	msg := rpcMessage{JSONRPC: "2.0", ID: &id, Result: raw}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return c.ws.writeText(data)
+}
+
+// Close closes the connection.
+func (c *Client) Close() error { return c.ws.close() }

--- a/internal/remote/codex/rpc_test.go
+++ b/internal/remote/codex/rpc_test.go
@@ -1,0 +1,100 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestClientRoundTripOverUnixWebSocket is the transport happy path: a stand-in
+// app-server accepts the WebSocket upgrade over a unix socket, answers one
+// request, pushes one notification and one server request, and receives our
+// response to it.
+func TestClientRoundTripOverUnixWebSocket(t *testing.T) {
+	dir, err := os.MkdirTemp("", "amqcx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "s.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	gotResponse := make(chan json.RawMessage, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		ws, err := acceptServerWS(conn)
+		if err != nil {
+			return
+		}
+		payload, err := ws.readText()
+		if err != nil {
+			return
+		}
+		var req rpcMessage
+		if err := json.Unmarshal(payload, &req); err != nil {
+			return
+		}
+		_ = ws.writeText([]byte(`{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"t1","turn":{"id":"u1"}}}`))
+		_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":` + string(*req.ID) + `,"result":{"turn":{"id":"u1"}}}`))
+		_ = ws.writeText([]byte(`{"jsonrpc":"2.0","id":"srv-1","method":"item/commandExecution/requestApproval","params":{"threadId":"t1","turnId":"u1","itemId":"i1"}}`))
+		resp, err := ws.readText()
+		if err != nil {
+			return
+		}
+		gotResponse <- resp
+	}()
+
+	ws, err := dialUnixWS(sock, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	c := newClient(ws)
+	t.Cleanup(func() { _ = c.Close() })
+	notes := make(chan Notification, 4)
+	c.OnNotification = func(n Notification) { notes <- n }
+	c.OnServerRequest = func(r ServerRequest) {
+		_ = c.Respond(r.ID, map[string]string{"decision": "decline"})
+	}
+
+	var result struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := c.Call(ctx, "turn/start", map[string]any{"threadId": "t1", "input": []map[string]string{{"type": "text", "text": "hi"}}}, &result); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if result.Turn.ID != "u1" {
+		t.Fatalf("unexpected result %+v", result)
+	}
+	select {
+	case n := <-notes:
+		if n.Method != "turn/started" {
+			t.Fatalf("unexpected notification %s", n.Method)
+		}
+	case <-ctx.Done():
+		t.Fatal("no notification")
+	}
+	select {
+	case resp := <-gotResponse:
+		var msg rpcMessage
+		if err := json.Unmarshal(resp, &msg); err != nil || msg.ID == nil || string(*msg.ID) != `"srv-1"` {
+			t.Fatalf("server request answer not correlated: %s", resp)
+		}
+	case <-ctx.Done():
+		t.Fatal("server request never answered")
+	}
+}

--- a/internal/remote/codex/ws.go
+++ b/internal/remote/codex/ws.go
@@ -1,0 +1,217 @@
+// Package codex attaches to a running Codex CLI session through the shared
+// local app-server daemon. The daemon's unix socket is a WebSocket control
+// socket carrying one JSON-RPC message per text frame; this file is the
+// minimal RFC 6455 client that transport needs, with no external dependency.
+package codex
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/sha1" //nolint:gosec // RFC 6455 mandates SHA-1 for the accept key.
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const wsGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// MaxFrameBytes bounds one inbound frame; app-server replies are JSON
+// documents that stay far below it.
+const MaxFrameBytes = 16 * 1024 * 1024
+
+const (
+	opText  = 0x1
+	opClose = 0x8
+	opPing  = 0x9
+	opPong  = 0xA
+)
+
+// wsConn is one client WebSocket over an already-dialed connection.
+type wsConn struct {
+	conn net.Conn
+	br   *bufio.Reader
+	wmu  sync.Mutex
+}
+
+// dialUnixWS connects to a unix socket and performs the WebSocket upgrade.
+func dialUnixWS(path string, timeout time.Duration) (*wsConn, error) {
+	conn, err := net.DialTimeout("unix", path, timeout)
+	if err != nil {
+		return nil, err
+	}
+	ws := &wsConn{conn: conn, br: bufio.NewReaderSize(conn, 64*1024)}
+	if err := ws.handshake(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return ws, nil
+}
+
+func (w *wsConn) handshake() error {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return err
+	}
+	key := base64.StdEncoding.EncodeToString(nonce[:])
+	req := "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: " + key + "\r\nSec-WebSocket-Version: 13\r\n\r\n"
+	_ = w.conn.SetDeadline(time.Now().Add(5 * time.Second))
+	defer func() { _ = w.conn.SetDeadline(time.Time{}) }()
+	if _, err := io.WriteString(w.conn, req); err != nil {
+		return err
+	}
+	resp, err := http.ReadResponse(w.br, nil)
+	if err != nil {
+		return fmt.Errorf("websocket handshake: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		return fmt.Errorf("websocket handshake: status %s", resp.Status)
+	}
+	sum := sha1.Sum([]byte(key + wsGUID)) //nolint:gosec // protocol-mandated
+	if resp.Header.Get("Sec-WebSocket-Accept") != base64.StdEncoding.EncodeToString(sum[:]) {
+		return errors.New("websocket handshake: accept key mismatch")
+	}
+	return nil
+}
+
+// writeText sends one masked text frame.
+func (w *wsConn) writeText(payload []byte) error {
+	return w.writeFrame(opText, payload)
+}
+
+func (w *wsConn) writeFrame(opcode byte, payload []byte) error {
+	w.wmu.Lock()
+	defer w.wmu.Unlock()
+	var mask [4]byte
+	if _, err := rand.Read(mask[:]); err != nil {
+		return err
+	}
+	header := []byte{0x80 | opcode}
+	n := len(payload)
+	switch {
+	case n < 126:
+		header = append(header, 0x80|byte(n))
+	case n <= 0xFFFF:
+		header = append(header, 0x80|126, byte(n>>8), byte(n))
+	default:
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(n))
+		header = append(append(header, 0x80|127), ext[:]...)
+	}
+	header = append(header, mask[:]...)
+	masked := make([]byte, n)
+	for i, b := range payload {
+		masked[i] = b ^ mask[i%4]
+	}
+	if _, err := w.conn.Write(append(header, masked...)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readText returns the next text frame payload, answering pings and
+// returning io.EOF on close.
+func (w *wsConn) readText() ([]byte, error) {
+	for {
+		opcode, payload, err := w.readFrame()
+		if err != nil {
+			return nil, err
+		}
+		switch opcode {
+		case opText:
+			return payload, nil
+		case opPing:
+			if err := w.writeFrame(opPong, payload); err != nil {
+				return nil, err
+			}
+		case opClose:
+			_ = w.writeFrame(opClose, nil)
+			return nil, io.EOF
+		case opPong:
+		default:
+			// Binary or continuation frames are not part of this protocol.
+			return nil, fmt.Errorf("unexpected websocket opcode %#x", opcode)
+		}
+	}
+}
+
+func (w *wsConn) readFrame() (byte, []byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(w.br, hdr[:]); err != nil {
+		return 0, nil, err
+	}
+	fin := hdr[0]&0x80 != 0
+	opcode := hdr[0] & 0x0F
+	masked := hdr[1]&0x80 != 0
+	length := uint64(hdr[1] & 0x7F)
+	switch length {
+	case 126:
+		var ext [2]byte
+		if _, err := io.ReadFull(w.br, ext[:]); err != nil {
+			return 0, nil, err
+		}
+		length = uint64(binary.BigEndian.Uint16(ext[:]))
+	case 127:
+		var ext [8]byte
+		if _, err := io.ReadFull(w.br, ext[:]); err != nil {
+			return 0, nil, err
+		}
+		length = binary.BigEndian.Uint64(ext[:])
+	}
+	if length > MaxFrameBytes {
+		return 0, nil, fmt.Errorf("websocket frame of %d bytes exceeds %d", length, MaxFrameBytes)
+	}
+	if !fin {
+		return 0, nil, errors.New("fragmented websocket frames are not supported")
+	}
+	var mask [4]byte
+	if masked {
+		if _, err := io.ReadFull(w.br, mask[:]); err != nil {
+			return 0, nil, err
+		}
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(w.br, payload); err != nil {
+		return 0, nil, err
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i%4]
+		}
+	}
+	return opcode, payload, nil
+}
+
+func (w *wsConn) close() error {
+	_ = w.writeFrame(opClose, nil)
+	return w.conn.Close()
+}
+
+// acceptServerWS performs the server side of the upgrade on an accepted
+// connection. It exists for tests that stand in for the app-server.
+func acceptServerWS(conn net.Conn) (*wsConn, error) {
+	br := bufio.NewReaderSize(conn, 64*1024)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		return nil, err
+	}
+	key := req.Header.Get("Sec-WebSocket-Key")
+	if !strings.EqualFold(req.Header.Get("Upgrade"), "websocket") || key == "" {
+		return nil, errors.New("not a websocket upgrade")
+	}
+	sum := sha1.Sum([]byte(key + wsGUID)) //nolint:gosec // protocol-mandated
+	resp := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n\r\n"
+	if _, err := io.WriteString(conn, resp); err != nil {
+		return nil, err
+	}
+	return &wsConn{conn: conn, br: br}, nil
+}

--- a/internal/remote/codex/ws.go
+++ b/internal/remote/codex/ws.go
@@ -82,6 +82,11 @@ func (w *wsConn) handshake() error {
 	return nil
 }
 
+// setWriteDeadline bounds subsequent frame writes; zero clears it.
+func (w *wsConn) setWriteDeadline(t time.Time) {
+	_ = w.conn.SetWriteDeadline(t)
+}
+
 // writeText sends one masked text frame.
 func (w *wsConn) writeText(payload []byte) error {
 	return w.writeFrame(opText, payload)

--- a/internal/remote/core/attachment.go
+++ b/internal/remote/core/attachment.go
@@ -25,8 +25,13 @@ type Admission struct {
 }
 
 // Evidence is what Lookup returns about a request the attachment may have
-// seen. Known=false means the attachment retains nothing for the key, which
-// is positive evidence that no admission happened while it was live.
+// seen. Known=false means the attachment retains nothing for the key. For an
+// adapter with a real admission primitive (codex, the fake) that is positive
+// evidence admission never happened. An adapter over an API that cannot report
+// its own rejections (the planned Amit extension, whose sendUserMessage
+// swallows errors) must NOT treat Known=false as proof of non-admission; there
+// a lost submit and a never-submitted key look identical, so such an adapter
+// leaves the record uncertain rather than rejecting it.
 type Evidence struct {
 	Known             bool
 	Admitted          bool

--- a/internal/remote/core/attachment.go
+++ b/internal/remote/core/attachment.go
@@ -32,7 +32,32 @@ type Admission struct {
 // swallows errors) must NOT treat Known=false as proof of non-admission; there
 // a lost submit and a never-submitted key look identical, so such an adapter
 // leaves the record uncertain rather than rejecting it.
+// EvidenceClass discriminates what the attachment can prove about a key, so
+// the endpoint never turns "in flight" or "delivered but unknown" into a
+// terminal rejection. See the remote-control ADR (evidence contract).
+type EvidenceClass string
+
+const (
+	// EvidenceNone: the adapter has a real admission primitive and retains
+	// nothing for the key, so admission did not and cannot happen -> reject.
+	EvidenceNone EvidenceClass = "none"
+	// EvidenceUnknown: the operation was delivered but admission cannot be
+	// determined (transport ambiguity, an API that swallows rejections)
+	// -> uncertain, keep correlation.
+	EvidenceUnknown EvidenceClass = "unknown"
+	// EvidenceTentative: submitted and bound, but native ownership is not yet
+	// confirmed -> keep as running/dispatching, do not reject, cancel, or
+	// attribute output until it confirms or times out.
+	EvidenceTentative EvidenceClass = "tentative"
+	// EvidenceConfirmed: native ownership is established -> real admission.
+	EvidenceConfirmed EvidenceClass = "confirmed"
+)
+
 type Evidence struct {
+	// Class is the authoritative discriminator; Known/Admitted are derived
+	// convenience mirrors (Known = Class != None-with-nothing-retained;
+	// Admitted = Class == Confirmed).
+	Class             EvidenceClass
 	Known             bool
 	Admitted          bool
 	RunID             string

--- a/internal/remote/core/attachment.go
+++ b/internal/remote/core/attachment.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// BoundRequest is what the endpoint hands a native attachment. The key is the
+// authenticated creator host plus the request id, so two hosts cannot share
+// a run map entry by reusing a UUID.
+type BoundRequest struct {
+	Key      requests.Key
+	Epoch    string
+	Input    protocol.SubmitInput
+	NotAfter string
+}
+
+// Admission is the attachment's answer to Submit. Admitted means the request
+// is bound to a native run; otherwise Code names the positive refusal.
+type Admission struct {
+	Admitted bool
+	RunID    string
+	Code     protocol.Code
+	Message  string
+}
+
+// Evidence is what Lookup returns about a request the attachment may have
+// seen. Known=false means the attachment retains nothing for the key, which
+// is positive evidence that no admission happened while it was live.
+type Evidence struct {
+	Known             bool
+	Admitted          bool
+	RunID             string
+	State             protocol.State
+	Result            *protocol.Result
+	LocalIntervention bool
+	Interaction       *protocol.Interaction
+}
+
+// CancelEvidence is the attachment's answer to CancelExact.
+type CancelEvidence struct {
+	Disposition protocol.CancelDisposition
+	Message     string
+}
+
+// NativeEventType names what a native attachment observed.
+type NativeEventType string
+
+// Native event types the endpoint consumes.
+const (
+	EventRunCompleted      NativeEventType = "run_completed"
+	EventRunFailed         NativeEventType = "run_failed"
+	EventRunCancelled      NativeEventType = "run_cancelled"
+	EventQuestion          NativeEventType = "question"
+	EventQuestionResolved  NativeEventType = "question_resolved"
+	EventLocalIntervention NativeEventType = "local_intervention"
+	EventEpochChanged      NativeEventType = "epoch_changed"
+	EventStatus            NativeEventType = "status"
+)
+
+// NativeEvent is one observation from an attachment. Key is set for events
+// about a bound request; Epoch and Status for runtime-level events.
+type NativeEvent struct {
+	Type        NativeEventType
+	Key         requests.Key
+	RunID       string
+	Result      *protocol.Result
+	Interaction *protocol.Interaction
+	Epoch       string
+	Status      string
+	Attachment  string
+}
+
+// Attachment is the native seam contract from the design. Implementations
+// serialize Submit and CancelExact against the harness's own input path and
+// never touch the local editor. Every method is exact about the request and
+// epoch it acts on.
+type Attachment interface {
+	// Inspect returns the current session projection.
+	Inspect() protocol.Session
+	// Submit performs the final epoch, busy and cancellation checks at the
+	// owning native boundary and, if admitted, binds the key to a run.
+	Submit(req BoundRequest) (Admission, error)
+	// Lookup returns retained evidence for a key without dispatching.
+	Lookup(key requests.Key, epoch string) (Evidence, error)
+	// CancelExact cancels the bound run or records cancellation intent when
+	// admission has not happened yet. It never aborts a different run.
+	CancelExact(key requests.Key, epoch string) (CancelEvidence, error)
+	// Respond answers one exact pending interaction with one offered option.
+	Respond(key requests.Key, epoch, interactionID, option string) (protocol.Code, error)
+	// AcknowledgeResult releases the retained terminal evidence for the key
+	// once the endpoint has persisted it.
+	AcknowledgeResult(key requests.Key, epoch, digest string)
+	// Subscribe delivers native events until the returned function is called.
+	Subscribe(func(NativeEvent)) func()
+}

--- a/internal/remote/core/corpus_test.go
+++ b/internal/remote/core/corpus_test.go
@@ -1,0 +1,561 @@
+package core_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+const corpusPath = "../../../testdata/remote/corpus.json"
+
+type corpusFile struct {
+	Defaults struct {
+		TargetID    string `json:"target_id"`
+		Epoch       string `json:"epoch"`
+		CreatorHost string `json:"creator_host"`
+		NotAfter    string `json:"not_after"`
+		Now         string `json:"now"`
+	} `json:"defaults"`
+	Fixtures []fixture `json:"fixtures"`
+}
+
+type fixture struct {
+	ID         string           `json:"id"`
+	Title      string           `json:"title"`
+	Boundaries []string         `json:"boundaries"`
+	Steps      []map[string]any `json:"steps"`
+}
+
+// TestContractCorpus runs every fixture in testdata/remote/corpus.json against
+// the endpoint and the fake runtime. Q19 runs once per crash boundary.
+func TestContractCorpus(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Clean(corpusPath))
+	if err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	var c corpusFile
+	if err := json.Unmarshal(raw, &c); err != nil {
+		t.Fatalf("parse corpus: %v", err)
+	}
+	for _, f := range c.Fixtures {
+		f := f
+		if len(f.Boundaries) == 0 {
+			t.Run(f.ID, func(t *testing.T) { newHarness(t, &c, "").run(f) })
+			continue
+		}
+		for _, b := range f.Boundaries {
+			b := b
+			t.Run(f.ID+"/"+b, func(t *testing.T) { newHarness(t, &c, b).run(f) })
+		}
+	}
+}
+
+type harness struct {
+	t          *testing.T
+	c          *corpusFile
+	dir        string
+	fake       *fake.Runtime
+	store      *requests.Store
+	ep         *core.Endpoint
+	clock      time.Time
+	crashPoint string
+	crashArmed bool
+	initialSID string
+
+	mu          sync.Mutex
+	history     map[string][]protocol.State
+	published   []protocol.Snapshot
+	dropPublish bool
+	pending     map[string]chan result
+}
+
+type result struct {
+	reply any
+	err   error
+}
+
+func newHarness(t *testing.T, c *corpusFile, boundary string) *harness {
+	now, err := protocol.ParseTime(c.Defaults.Now)
+	if err != nil {
+		t.Fatalf("defaults.now: %v", err)
+	}
+	h := &harness{
+		t:          t,
+		c:          c,
+		dir:        t.TempDir(),
+		fake:       fake.New(c.Defaults.TargetID, c.Defaults.Epoch),
+		clock:      now,
+		crashPoint: boundary,
+		crashArmed: boundary != "",
+		history:    map[string][]protocol.State{},
+		pending:    map[string]chan result{},
+	}
+	h.initialSID = h.fake.SessionID()
+	h.open()
+	return h
+}
+
+func (h *harness) open() {
+	store, err := requests.Open(h.dir, requests.WithClock(func() time.Time { return h.clock }))
+	if err != nil {
+		h.t.Fatalf("open store: %v", err)
+	}
+	h.store = store
+	h.ep = core.New(core.Config{
+		Store: store,
+		Now:   func() time.Time { return h.clock },
+		Publish: func(s protocol.Snapshot, _ map[string]string) error {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			if h.dropPublish {
+				h.dropPublish = false
+				return errors.New("publication dropped")
+			}
+			h.published = append(h.published, s)
+			return nil
+		},
+		Crash: func(point string) error {
+			if h.crashArmed && point == h.crashPoint {
+				h.crashArmed = false
+				return errors.New("simulated crash")
+			}
+			return nil
+		},
+	})
+	h.ep.Observe(func(rec *requests.Record) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		h.history[rec.RequestID] = append(h.history[rec.RequestID], rec.State)
+	})
+	h.ep.Register(h.fake)
+	if err := h.ep.Reconcile(); err != nil {
+		h.t.Fatalf("reconcile: %v", err)
+	}
+}
+
+func (h *harness) run(f fixture) {
+	for i, step := range f.Steps {
+		h.step(fmt.Sprintf("%s step %d", f.ID, i), step)
+	}
+	if err := h.ep.Close(); err != nil {
+		h.t.Fatalf("close: %v", err)
+	}
+}
+
+func (h *harness) step(where string, step map[string]any) {
+	switch {
+	case step["client"] != nil:
+		n := 1
+		if r, ok := step["repeat"].(float64); ok {
+			n = int(r)
+		}
+		for i := 0; i < n; i++ {
+			h.client(where, step)
+		}
+	case step["native"] != nil:
+		h.native(where, step)
+	case step["expect"] != nil:
+		h.expect(where, step["expect"].(map[string]any))
+	case step["expect_native"] != nil:
+		h.expectNative(where, step["expect_native"].(map[string]any))
+	case step["expect_published"] != nil:
+		h.expectPublished(where, step["expect_published"].(map[string]any))
+	case step["cli"] != nil:
+		h.cli(where, step)
+	case step["endpoint"] != nil:
+		h.endpointControl(where, step)
+	case step["clock"] != nil:
+		now, err := protocol.ParseTime(step["clock"].(string))
+		if err != nil {
+			h.t.Fatalf("%s: clock: %v", where, err)
+		}
+		h.clock = now
+	case step["restart"] != nil:
+		if err := h.ep.Close(); err != nil {
+			h.t.Fatalf("%s: close: %v", where, err)
+		}
+		h.open()
+	default:
+		h.t.Fatalf("%s: unknown step %v", where, step)
+	}
+}
+
+func (h *harness) command(raw map[string]any) (*protocol.Command, core.Source) {
+	cmd := map[string]any{"schema": protocol.SchemaCommand}
+	for k, v := range raw {
+		cmd[k] = v
+	}
+	host := h.c.Defaults.CreatorHost
+	if s, ok := cmd["creator_host"].(string); ok {
+		host = s
+		delete(cmd, "creator_host")
+	}
+	if id, ok := cmd["request_ref_for"].(string); ok {
+		cmd["request_ref"] = protocol.EncodeRef(h.c.Defaults.CreatorHost, h.c.Defaults.TargetID, id)
+		delete(cmd, "request_ref_for")
+	}
+	op := protocol.Op(cmd["op"].(string))
+	switch op {
+	case protocol.OpRequestSubmit, protocol.OpRequestCancel, protocol.OpInteractionRespond:
+		setDefault(cmd, "target_id", h.c.Defaults.TargetID)
+		setDefault(cmd, "epoch", h.c.Defaults.Epoch)
+		if op != protocol.OpInteractionRespond {
+			setDefault(cmd, "not_after", h.c.Defaults.NotAfter)
+		}
+	case protocol.OpSessionInspect, protocol.OpSessionEvents:
+		setDefault(cmd, "target_id", h.c.Defaults.TargetID)
+	}
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		h.t.Fatalf("marshal command: %v", err)
+	}
+	decoded, err := protocol.DecodeCommand(data)
+	if err != nil {
+		h.t.Fatalf("decode command %s: %v", data, err)
+	}
+	return decoded, core.Source{Host: host}
+}
+
+func setDefault(m map[string]any, key, value string) {
+	if _, ok := m[key]; !ok {
+		m[key] = value
+	}
+}
+
+func (h *harness) client(where string, step map[string]any) {
+	cmd, src := h.command(step["client"].(map[string]any))
+	if step["async"] == true {
+		ch := make(chan result, 1)
+		h.mu.Lock()
+		h.pending[cmd.RequestID] = ch
+		h.mu.Unlock()
+		go func() {
+			reply, err := h.ep.Handle(cmd, src)
+			ch <- result{reply, err}
+		}()
+		time.Sleep(20 * time.Millisecond) // let the submit reach the held admission gate
+		return
+	}
+	reply, err := h.ep.Handle(cmd, src)
+	if step["may_crash"] == true && errors.Is(err, core.ErrCrashed) {
+		return
+	}
+	if step["deferred"] == true {
+		if err != nil {
+			h.t.Fatalf("%s: deferred submit errored: %v", where, err)
+		}
+		return
+	}
+	expected, _ := step["reply"].(map[string]any)
+	if expected == nil {
+		if err != nil {
+			h.t.Fatalf("%s: unexpected error: %v", where, err)
+		}
+		return
+	}
+	got := toMap(h.t, reply)
+	if err != nil {
+		var r *protocol.Refusal
+		if !errors.As(err, &r) {
+			h.t.Fatalf("%s: unexpected error: %v", where, err)
+		}
+		got = map[string]any{"code": string(r.Code)}
+	}
+	assertSubset(h.t, where, expected, got)
+}
+
+func toMap(t *testing.T, v any) map[string]any {
+	if v == nil {
+		return map[string]any{}
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal reply: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		// list replies
+		return map[string]any{"list": string(data)}
+	}
+	return m
+}
+
+func assertSubset(t *testing.T, where string, expected, got map[string]any) {
+	for k, ev := range expected {
+		gv, ok := got[k]
+		if !ok {
+			t.Fatalf("%s: reply lacks %q; got %v", where, k, got)
+		}
+		if em, isMap := ev.(map[string]any); isMap {
+			gm, _ := gv.(map[string]any)
+			if gm == nil {
+				t.Fatalf("%s: reply %q is not an object: %v", where, k, gv)
+			}
+			assertSubset(t, where+"."+k, em, gm)
+			continue
+		}
+		if fmt.Sprint(ev) != fmt.Sprint(gv) {
+			t.Fatalf("%s: reply %q = %v, want %v (reply %v)", where, k, gv, ev, got)
+		}
+	}
+}
+
+func (h *harness) native(where string, step map[string]any) {
+	action := step["native"].(string)
+	id, _ := step["request_id"].(string)
+	text, _ := step["text"].(string)
+	switch action {
+	case "hold_admission":
+		h.fake.HoldAdmission()
+	case "release_admission":
+		h.fake.ReleaseAdmission()
+		h.mu.Lock()
+		ch := h.pending[id]
+		if ch == nil {
+			for _, c := range h.pending {
+				ch = c
+			}
+		}
+		h.mu.Unlock()
+		if ch != nil {
+			select {
+			case r := <-ch:
+				if r.err != nil {
+					h.t.Fatalf("%s: async submit errored: %v", where, r.err)
+				}
+			case <-time.After(2 * time.Second):
+				h.t.Fatalf("%s: async submit did not return", where)
+			}
+		}
+	case "complete":
+		if !h.fake.Complete(id, text) {
+			h.t.Fatalf("%s: no running run for %s", where, id)
+		}
+	case "complete_if_admitted":
+		h.fake.Complete(id, text)
+	case "idle", "idle_blip":
+	case "local_draft":
+		h.fake.LocalDraft(text)
+	case "local_input":
+		h.fake.LocalInput(text)
+	case "admission_fails_after_return":
+		h.fake.FailNextAdmissionAfterReturn()
+	case "switch_session":
+		h.fake.SwitchSession(step["new_epoch"].(string))
+	case "question":
+		var opts []string
+		for _, o := range step["options"].([]any) {
+			opts = append(opts, o.(string))
+		}
+		h.fake.Question(id, step["interaction_id"].(string), opts)
+	case "local_answer":
+		h.fake.LocalAnswer(step["interaction_id"].(string), step["option"].(string))
+	case "offline":
+		h.fake.SetOffline(true)
+	case "online":
+		h.fake.SetOffline(false)
+		if err := h.ep.Tick(); err != nil {
+			h.t.Fatalf("%s: tick: %v", where, err)
+		}
+	default:
+		h.t.Fatalf("%s: unknown native action %q", where, action)
+	}
+}
+
+func (h *harness) record(id string) (*requests.Record, bool) {
+	rec, ok, err := h.store.Get(requests.Key{CreatorHost: h.c.Defaults.CreatorHost, TargetID: h.c.Defaults.TargetID, RequestID: id})
+	if err != nil {
+		h.t.Fatalf("get record: %v", err)
+	}
+	return rec, ok
+}
+
+func (h *harness) expect(where string, exp map[string]any) {
+	id, _ := exp["request_id"].(string)
+	var rec *requests.Record
+	if id != "" {
+		var ok bool
+		rec, ok = h.record(id)
+		if !ok {
+			rec = &requests.Record{}
+			rec.State = "absent"
+		}
+	}
+	for k, v := range exp {
+		switch k {
+		case "request_id":
+		case "native_dispatches":
+			if got := h.fake.Snapshot().Dispatches; got != int(v.(float64)) {
+				h.t.Fatalf("%s: native dispatches %d, want %v", where, got, v)
+			}
+		case "native_dispatches_max":
+			if got := h.fake.Snapshot().Dispatches; got > int(v.(float64)) {
+				h.t.Fatalf("%s: native dispatches %d, want at most %v", where, got, v)
+			}
+		case "native_aborts":
+			if got := h.fake.Snapshot().Aborts; got != int(v.(float64)) {
+				h.t.Fatalf("%s: native aborts %d, want %v", where, got, v)
+			}
+		case "input_text":
+			if rec.Input == nil || rec.Input.Text != v.(string) {
+				h.t.Fatalf("%s: input text %v, want %v", where, rec.Input, v)
+			}
+		case "state":
+			if string(rec.State) != v.(string) {
+				h.t.Fatalf("%s: state %s, want %v", where, rec.State, v)
+			}
+		case "state_in":
+			if !contains(v.([]any), string(rec.State)) {
+				h.t.Fatalf("%s: state %s not in %v", where, rec.State, v)
+			}
+		case "never_state":
+			h.mu.Lock()
+			hist := h.history[id]
+			h.mu.Unlock()
+			for _, s := range hist {
+				if contains(v.([]any), string(s)) {
+					h.t.Fatalf("%s: state %s appeared in history %v", where, s, hist)
+				}
+			}
+		case "no_orphan_run":
+			for _, k := range h.fake.Snapshot().RunningKeys {
+				if k.RequestID == id && rec.State != protocol.StateRunning {
+					h.t.Fatalf("%s: fake has a running run for %s while record is %s", where, id, rec.State)
+				}
+			}
+		case "creator_host":
+			if rec.CreatorHost != v.(string) {
+				h.t.Fatalf("%s: creator host %s, want %v", where, rec.CreatorHost, v)
+			}
+		case "records":
+			all, err := h.store.List()
+			if err != nil {
+				h.t.Fatalf("%s: list: %v", where, err)
+			}
+			n := 0
+			for _, r := range all {
+				if r.RequestID == id {
+					n++
+				}
+			}
+			if n != int(v.(float64)) {
+				h.t.Fatalf("%s: %d records for %s, want %v", where, n, id, v)
+			}
+		default:
+			h.t.Fatalf("%s: unknown expectation %q", where, k)
+		}
+	}
+}
+
+func contains(list []any, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *harness) expectNative(where string, exp map[string]any) {
+	snap := h.fake.Snapshot()
+	for k, v := range exp {
+		switch k {
+		case "draft":
+			if h.fake.Draft() != v.(string) {
+				h.t.Fatalf("%s: draft %q, want %q", where, h.fake.Draft(), v)
+			}
+		case "session_id_unchanged":
+			if (h.fake.SessionID() == h.initialSID) != v.(bool) {
+				h.t.Fatalf("%s: session id changed", where)
+			}
+		case "consumer_sets":
+			if snap.ConsumerSets != int(v.(float64)) {
+				h.t.Fatalf("%s: consumer sets %d, want %v", where, snap.ConsumerSets, v)
+			}
+		case "answers":
+			want := v.([]any)
+			if len(snap.Answers) != len(want) {
+				h.t.Fatalf("%s: answers %v, want %v", where, snap.Answers, want)
+			}
+			for i, w := range want {
+				wm := w.(map[string]any)
+				if snap.Answers[i].InteractionID != wm["interaction_id"] || snap.Answers[i].Option != wm["option"] {
+					h.t.Fatalf("%s: answer %d = %v, want %v", where, i, snap.Answers[i], wm)
+				}
+			}
+		default:
+			h.t.Fatalf("%s: unknown native expectation %q", where, k)
+		}
+	}
+}
+
+func (h *harness) expectPublished(where string, exp map[string]any) {
+	id := exp["request_id"].(string)
+	state := exp["terminal_state"].(string)
+	want := int(exp["terminal_count"].(float64))
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, s := range h.published {
+		if s.RequestID == id && string(s.State) == state {
+			n++
+		}
+	}
+	if n != want {
+		h.t.Fatalf("%s: %d published %s snapshots for %s, want %d", where, n, state, id, want)
+	}
+}
+
+func (h *harness) cli(where string, step map[string]any) {
+	if step["cli"] != "wait" {
+		h.t.Fatalf("%s: unknown cli step %v", where, step["cli"])
+	}
+	ref := protocol.EncodeRef(h.c.Defaults.CreatorHost, h.c.Defaults.TargetID, step["request_id"].(string))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	snap, err := h.ep.Wait(ctx, ref)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		h.t.Fatalf("%s: wait returned %v / %v, want deadline", where, snap.State, err)
+	}
+}
+
+func (h *harness) endpointControl(where string, step map[string]any) {
+	switch step["endpoint"] {
+	case "compact_results":
+		if _, err := h.store.Compact(h.clock.Add(time.Second)); err != nil {
+			h.t.Fatalf("%s: compact: %v", where, err)
+		}
+	case "storage_fail_next_write":
+		dir := filepath.Join(h.store.Dir(), "requests", h.c.Defaults.CreatorHost)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			h.t.Fatalf("%s: mkdir: %v", where, err)
+		}
+		if err := os.Chmod(dir, 0o500); err != nil {
+			h.t.Fatalf("%s: chmod: %v", where, err)
+		}
+		h.t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	case "drop_next_publication":
+		h.mu.Lock()
+		h.dropPublish = true
+		h.mu.Unlock()
+	case "start_second":
+		_, err := requests.Open(h.dir)
+		var r *protocol.Refusal
+		if !errors.As(err, &r) || r.Code != protocol.Code(step["expect_code"].(string)) || protocol.ExitCode(err) != int(step["expect_exit"].(float64)) {
+			h.t.Fatalf("%s: second endpoint: %v", where, err)
+		}
+	default:
+		h.t.Fatalf("%s: unknown endpoint control %v", where, step["endpoint"])
+	}
+}

--- a/internal/remote/core/corpus_test.go
+++ b/internal/remote/core/corpus_test.go
@@ -288,6 +288,27 @@ func toMap(t *testing.T, v any) map[string]any {
 		// list replies
 		return map[string]any{"list": string(data)}
 	}
+	// A request reply is a Reply{snapshot, outcome}; flatten it to the flat
+	// shape the fixtures assert. The outcome carries op-specific signals
+	// (request_conflict, already_resolved, a no-op cancel disposition) that
+	// overlay the immutable snapshot without being part of it.
+	snap, hasSnap := m["snapshot"].(map[string]any)
+	out, hasOut := m["outcome"].(map[string]any)
+	if hasSnap && hasOut {
+		flat := snap
+		if code, _ := out["code"].(string); code != "" {
+			flat["code"] = code
+		}
+		if disp, _ := out["disposition"].(string); disp != "" {
+			cancel, _ := flat["cancel"].(map[string]any)
+			if cancel == nil {
+				cancel = map[string]any{}
+			}
+			cancel["disposition"] = disp
+			flat["cancel"] = cancel
+		}
+		return flat
+	}
 	return m
 }
 

--- a/internal/remote/core/corpus_test.go
+++ b/internal/remote/core/corpus_test.go
@@ -296,8 +296,12 @@ func toMap(t *testing.T, v any) map[string]any {
 	out, hasOut := m["outcome"].(map[string]any)
 	if hasSnap && hasOut {
 		flat := snap
-		if code, _ := out["code"].(string); code != "" {
-			flat["code"] = code
+		// Prefer the snapshot's durable code; fall back to the outcome code
+		// (e.g. request_conflict on a running record has no snapshot code).
+		if _, hasSnapCode := flat["code"]; !hasSnapCode {
+			if code, _ := out["code"].(string); code != "" {
+				flat["code"] = code
+			}
 		}
 		if disp, _ := out["disposition"].(string); disp != "" {
 			cancel, _ := flat["cancel"].(map[string]any)

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -296,6 +296,13 @@ func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
 	case adm.Code == protocol.CodeCancelledBeforeAdmission:
 		rec.State = protocol.StateCancelled
 		rec.Code = adm.Code
+		// A cancel that raced this gated admission left the disposition
+		// pending; admission never happened, so confirm it now instead of
+		// persisting cancelled with cancel_requested.
+		if rec.Cancel == nil {
+			rec.Cancel = &protocol.Cancel{RequestedAt: protocol.FormatTime(e.now())}
+		}
+		rec.Cancel.Disposition = protocol.CancelConfirmed
 	default:
 		rec.State = protocol.StateRejected
 		rec.Code = adm.Code
@@ -488,9 +495,43 @@ func (e *Endpoint) respond(cmd *protocol.Command) (any, error) {
 	if t == nil {
 		return nil, protocol.Refuse(protocol.CodeAttachmentLost, "target is not attached")
 	}
+	if _, done := rec.Answered[cmd.InteractionID]; done {
+		// A replay of an answer we already delivered; do not invoke the
+		// attachment a second time.
+		return rec.Snapshot, nil
+	}
 	if rec.Interaction == nil || rec.Interaction.InteractionID != cmd.InteractionID {
 		return nil, protocol.Refuse(protocol.CodeAlreadyResolved, "no such pending interaction")
 	}
+	// Record the answer durably before the native call so a crash-then-replay
+	// cannot answer the same interaction twice.
+	e.mu.Lock()
+	rec, exists, err = e.store.Get(key)
+	if err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	if !exists {
+		e.mu.Unlock()
+		return nil, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+	}
+	if _, done := rec.Answered[cmd.InteractionID]; done {
+		e.mu.Unlock()
+		return rec.Snapshot, nil
+	}
+	rec.Revision++
+	if rec.Answered == nil {
+		rec.Answered = map[string]string{}
+	}
+	rec.Answered[cmd.InteractionID] = cmd.Option
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.store.Update(rec); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	e.notifyLocked(rec)
+	e.mu.Unlock()
+
 	code, err := t.att.Respond(key, cmd.Epoch, cmd.InteractionID, cmd.Option)
 	if err != nil {
 		return nil, err
@@ -622,32 +663,37 @@ func boundResult(r *protocol.Result) *protocol.Result {
 	return &out
 }
 
-// Reconcile runs after Open. It re-examines every non-terminal record against
-// exact native evidence, never re-submits, expires deferred requests whose
-// admission window closed, and republishes unpublished revisions.
+// Reconcile runs after Open and on every Tick. It re-examines every
+// non-terminal record against exact native evidence, never re-submits, expires
+// deferred requests whose window closed, and republishes unpublished
+// revisions. Native attachment calls happen without the endpoint lock held; a
+// single poisoned record is reported, never allowed to abort the whole pass.
 func (e *Endpoint) Reconcile() error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	recs, err := e.store.List()
+	e.mu.Unlock()
 	if err != nil {
 		return err
 	}
+	var firstErr error
 	for _, rec := range recs {
+		var rerr error
 		switch rec.State {
 		case protocol.StateDispatching, protocol.StateRunning, protocol.StateUncertain:
-			if err := e.reconcileLiveLocked(rec); err != nil {
-				return err
-			}
+			rerr = e.reconcileLive(rec)
 		case protocol.StateReceived:
-			if err := e.admitDeferredLocked(rec); err != nil {
-				return err
-			}
+			rerr = e.admitDeferred(rec)
 		}
-		if rec.PublishedRevision < rec.Revision {
-			e.publishLocked(rec)
+		if rerr != nil && firstErr == nil {
+			firstErr = rerr
 		}
+		e.mu.Lock()
+		if cur, ok, gerr := e.store.Get(keyOfRecord(rec)); gerr == nil && ok && cur.PublishedRevision < cur.Revision {
+			e.publishLocked(cur)
+		}
+		e.mu.Unlock()
 	}
-	return nil
+	return firstErr
 }
 
 // Tick retries deferred admissions and expiry; carriers call it on a timer
@@ -656,24 +702,43 @@ func (e *Endpoint) Tick() error {
 	return e.Reconcile()
 }
 
-func (e *Endpoint) reconcileLiveLocked(rec *requests.Record) error {
-	key := requests.Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
+func keyOfRecord(rec *requests.Record) requests.Key {
+	return requests.Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
+}
+
+// reconcileLive resolves one non-terminal record. It calls the attachment
+// without the endpoint lock, then applies the result under the lock.
+func (e *Endpoint) reconcileLive(rec *requests.Record) error {
+	key := keyOfRecord(rec)
+	e.mu.Lock()
 	t, ok := e.targets[rec.TargetID]
+	e.mu.Unlock()
+
 	var ev Evidence
-	var err error
+	var lookupErr error
 	if ok {
-		ev, err = t.att.Lookup(key, rec.Epoch)
+		ev, lookupErr = t.att.Lookup(key, rec.Epoch)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, exists, err := e.store.Get(key)
+	if err != nil {
+		return err
+	}
+	if !exists || rec.State.Terminal() {
+		return nil
 	}
 	switch {
-	case !ok || err != nil:
+	case !ok || lookupErr != nil:
 		if rec.State == protocol.StateUncertain {
 			return nil
 		}
 		rec.State = protocol.StateUncertain
 		rec.Code = protocol.CodeAttachmentLost
 	case !ev.Known:
-		// The live attachment retains nothing for this key: nothing was
-		// admitted and nothing will be. Positive evidence, not a guess.
+		// The live attachment retains nothing for this key: admission never
+		// happened and never will. Positive evidence, not a guess.
 		rec.State = protocol.StateRejected
 		rec.Code = protocol.CodeNativeError
 	case ev.Admitted && ev.State.Terminal():
@@ -711,40 +776,60 @@ func (e *Endpoint) reconcileLiveLocked(rec *requests.Record) error {
 	return nil
 }
 
-func (e *Endpoint) admitDeferredLocked(rec *requests.Record) error {
+// admitDeferred admits a received record whose target came back inside its
+// window. The native Submit happens without the endpoint lock.
+func (e *Endpoint) admitDeferred(rec *requests.Record) error {
+	key := keyOfRecord(rec)
+	e.mu.Lock()
 	t, code := e.admissibleLocked(rec.TargetID, rec.Epoch, rec.NotAfter)
 	if code == "" && t == nil {
+		e.mu.Unlock()
 		return nil // still offline, still inside the window
 	}
 	if code != "" {
+		rec, exists, err := e.store.Get(key)
+		if err != nil || !exists || rec.State != protocol.StateReceived {
+			e.mu.Unlock()
+			return err
+		}
 		rec.Revision++
 		rec.State = protocol.StateRejected
 		rec.Code = code
 		rec.ObservedAt = protocol.FormatTime(e.now())
-		if err := e.store.Update(rec); err != nil {
-			return err
+		err = e.store.Update(rec)
+		if err == nil {
+			e.notifyLocked(rec)
 		}
-		e.notifyLocked(rec)
-		return nil
+		e.mu.Unlock()
+		return err
 	}
-	// Target came back inside the window: dispatch now, under the lock,
-	// because reconciliation is not a request path with a waiting client.
+	// Move to dispatching under the lock, then Submit unlocked.
+	rec, exists, err := e.store.Get(key)
+	if err != nil || !exists || rec.State != protocol.StateReceived {
+		e.mu.Unlock()
+		return err
+	}
 	rec.Revision++
 	rec.State = protocol.StateDispatching
 	rec.NativeDispatches = 1
 	rec.ObservedAt = protocol.FormatTime(e.now())
 	if err := e.store.Update(rec); err != nil {
+		e.mu.Unlock()
 		return err
 	}
 	e.notifyLocked(rec)
-	key := requests.Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
 	input := protocol.SubmitInput{}
 	if rec.Input != nil {
 		input = *rec.Input
 	}
+	e.mu.Unlock()
+
 	adm, nerr := t.att.Submit(BoundRequest{Key: key, Epoch: rec.Epoch, Input: input, NotAfter: rec.NotAfter})
-	rec, _, err := e.store.Get(key)
-	if err != nil || rec.State != protocol.StateDispatching {
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, exists, err = e.store.Get(key)
+	if err != nil || !exists || rec.State != protocol.StateDispatching {
 		return err
 	}
 	switch {
@@ -754,6 +839,13 @@ func (e *Endpoint) admitDeferredLocked(rec *requests.Record) error {
 		rec.State = protocol.StateRunning
 		run := adm.RunID
 		rec.NativeRun = &run
+	case adm.Code == protocol.CodeCancelledBeforeAdmission:
+		rec.State = protocol.StateCancelled
+		rec.Code = adm.Code
+		if rec.Cancel == nil {
+			rec.Cancel = &protocol.Cancel{RequestedAt: protocol.FormatTime(e.now())}
+		}
+		rec.Cancel.Disposition = protocol.CancelConfirmed
 	default:
 		rec.State, rec.Code = protocol.StateRejected, adm.Code
 		if rec.Code == "" {

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -415,6 +415,20 @@ func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (protocol.Reply, er
 		e.publishRevision(rec)
 		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel}}, nil
 	}
+	// Validate the cancel command against the original request binding rather
+	// than silently substituting the record's trusted values (Pro B04). A
+	// cancel naming a different epoch is for a generation that no longer
+	// exists; it must not interrupt the current run.
+	if cmd.Epoch != rec.Epoch {
+		e.mu.Unlock()
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel, Code: protocol.CodeStaleEpoch}}, nil
+	}
+	if exp, perr := protocol.ParseTime(cmd.NotAfter); perr == nil && e.now().After(exp) {
+		// The cancel command's own admission window has closed; do not act on
+		// a stale interrupt.
+		e.mu.Unlock()
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel, Code: protocol.CodeExpired}}, nil
+	}
 	if rec.State.Terminal() {
 		e.mu.Unlock()
 		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel, Disposition: protocol.CancelNoopTerminal}}, nil

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -664,18 +664,24 @@ func (e *Endpoint) onNative(targetID string, ev NativeEvent) {
 	e.publishLocked(rec)
 }
 
-// notifyStorageFailureLocked surfaces a visible storage-failure projection when
-// a durable result write fails on an async native-event path, so a request is
-// never silently left "running". No durable write happens (the store write just
-// failed); Reconcile retries the real write. The caller holds e.mu.
+// notifyStorageFailureLocked surfaces a visible failure projection when a
+// durable write fails on an async native-event path, so a request is never
+// silently left "running". No durable write happens (the store write just
+// failed); Reconcile retries the real write. Any write error surfaces, with a
+// storage_full code when that is the cause and native_error otherwise. The
+// caller holds e.mu.
 func (e *Endpoint) notifyStorageFailureLocked(rec *requests.Record, err error) {
-	var r *protocol.Refusal
-	if !errors.As(err, &r) || r.Code != protocol.CodeStorageFull {
+	if err == nil {
 		return
+	}
+	code := protocol.CodeNativeError
+	var r *protocol.Refusal
+	if errors.As(err, &r) && r.Code == protocol.CodeStorageFull {
+		code = protocol.CodeStorageFull
 	}
 	fail := *rec
 	fail.State = protocol.StateUncertain
-	fail.Code = protocol.CodeStorageFull
+	fail.Code = code
 	fail.Result = nil // never advertise a result we could not persist
 	e.notifyLocked(&fail)
 }

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -176,23 +176,23 @@ func InputDigest(in *protocol.SubmitInput) string {
 	return requests.Digest(data)
 }
 
-func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
+func (e *Endpoint) submit(cmd *protocol.Command, src Source) (protocol.Reply, error) {
 	key := requests.Key{CreatorHost: src.Host, TargetID: cmd.TargetID, RequestID: cmd.RequestID}
-	digest := InputDigest(cmd.Input)
+	digest := protocol.CommandDigest(cmd)
 
 	e.mu.Lock()
 	rec, exists, err := e.store.Get(key)
 	if err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if exists {
 		e.mu.Unlock()
-		reply := rec.Snapshot
+		out := protocol.Outcome{Op: protocol.OpRequestSubmit}
 		if rec.InputDigest != "" && rec.InputDigest != digest {
-			reply.Code = protocol.CodeRequestConflict
+			out.Code = protocol.CodeRequestConflict
 		}
-		return reply, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: out}, nil
 	}
 	rec = &requests.Record{
 		Snapshot: protocol.Snapshot{
@@ -212,20 +212,20 @@ func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
 	}
 	if err := e.crashAt(PointBeforeReceived); err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if err := e.store.Create(rec); err != nil {
 		e.mu.Unlock()
 		var r *protocol.Refusal
 		if errors.As(err, &r) && r.Code == protocol.CodeStorageFull {
-			return e.unpersisted(rec, protocol.StateRejected, protocol.CodeStorageFull), nil
+			return protocol.Reply{Snapshot: e.unpersisted(rec, protocol.StateRejected, protocol.CodeStorageFull), Outcome: protocol.Outcome{Op: protocol.OpRequestSubmit, Code: protocol.CodeStorageFull}}, nil
 		}
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.notifyLocked(rec)
 	if err := e.crashAt(PointAfterReceived); err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	t, code := e.admissibleLocked(cmd.TargetID, cmd.Epoch, cmd.NotAfter)
 	if code != "" {
@@ -237,16 +237,16 @@ func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
 		e.notifyLocked(rec)
 		e.mu.Unlock()
 		if err != nil {
-			return nil, err
+			return protocol.Reply{}, err
 		}
 		e.publishRevision(rec)
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestSubmit}}, nil
 	}
 	if t == nil {
 		// Target registered but offline: keep received and let Tick admit
 		// or expire it later.
 		e.mu.Unlock()
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestSubmit}}, nil
 	}
 	rec.Revision++
 	rec.State = protocol.StateDispatching
@@ -254,36 +254,36 @@ func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
 	rec.ObservedAt = protocol.FormatTime(e.now())
 	if err := e.crashAt(PointBeforeDispatching); err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if err := e.store.Update(rec); err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.notifyLocked(rec)
 	if err := e.crashAt(PointAfterDispatching); err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.mu.Unlock()
 
 	if err := e.crashAt(PointBeforeNative); err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	adm, nerr := t.att.Submit(BoundRequest{Key: key, Epoch: cmd.Epoch, Input: *cmd.Input, NotAfter: cmd.NotAfter})
 	if err := e.crashAt(PointAfterNative); err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	rec, _, err = e.store.Get(key)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if rec.State != protocol.StateDispatching {
 		// A fast native event already moved the record; the evidence wins.
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestSubmit}}, nil
 	}
 	switch {
 	case nerr != nil:
@@ -313,11 +313,11 @@ func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
 	rec.Revision++
 	rec.ObservedAt = protocol.FormatTime(e.now())
 	if err := e.store.Update(rec); err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.notifyLocked(rec)
 	e.publishLocked(rec)
-	return rec.Snapshot, nil
+	return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestSubmit}}, nil
 }
 
 // admissibleLocked checks share, epoch, expiry and capability. It returns the
@@ -353,30 +353,30 @@ func (e *Endpoint) unpersisted(rec *requests.Record, state protocol.State, code 
 	return s
 }
 
-func (e *Endpoint) get(cmd *protocol.Command) (any, error) {
+func (e *Endpoint) get(cmd *protocol.Command) (protocol.Reply, error) {
 	host, targetID, requestID, err := protocol.DecodeRef(cmd.RequestRef)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	rec, ok, err := e.store.Get(requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID})
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if !ok {
-		return nil, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
 	}
-	return rec.Snapshot, nil
+	return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestGet}}, nil
 }
 
-func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
+func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (protocol.Reply, error) {
 	host, targetID, requestID, err := protocol.DecodeRef(cmd.RequestRef)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if targetID != cmd.TargetID {
-		return nil, protocol.Refuse(protocol.CodeInvalid, "request_ref names a different target")
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeInvalid, "request_ref names a different target")
 	}
 	key := requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID}
 	now := protocol.FormatTime(e.now())
@@ -385,7 +385,7 @@ func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
 	rec, exists, err := e.store.Get(key)
 	if err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if !exists {
 		// Cancel arrived before its submit: leave a tombstone that a later
@@ -410,16 +410,14 @@ func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
 		e.notifyLocked(rec)
 		e.mu.Unlock()
 		if err != nil {
-			return nil, err
+			return protocol.Reply{}, err
 		}
 		e.publishRevision(rec)
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel}}, nil
 	}
 	if rec.State.Terminal() {
 		e.mu.Unlock()
-		reply := rec.Snapshot
-		reply.Cancel = &protocol.Cancel{RequestedAt: now, Disposition: protocol.CancelNoopTerminal}
-		return reply, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel, Disposition: protocol.CancelNoopTerminal}}, nil
 	}
 	if rec.State == protocol.StateReceived {
 		rec.Revision++
@@ -431,10 +429,10 @@ func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
 		e.notifyLocked(rec)
 		e.mu.Unlock()
 		if err != nil {
-			return nil, err
+			return protocol.Reply{}, err
 		}
 		e.publishRevision(rec)
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel}}, nil
 	}
 	t := e.targets[targetID]
 	e.mu.Unlock()
@@ -451,12 +449,10 @@ func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
 	defer e.mu.Unlock()
 	rec, _, err = e.store.Get(key)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if rec.State.Terminal() {
-		reply := rec.Snapshot
-		reply.Cancel = &protocol.Cancel{RequestedAt: now, Disposition: protocol.CancelNoopTerminal}
-		return reply, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel, Disposition: protocol.CancelNoopTerminal}}, nil
 	}
 	if nerr != nil {
 		ev = CancelEvidence{Disposition: protocol.CancelRequested, Message: nerr.Error()}
@@ -469,17 +465,17 @@ func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
 	}
 	rec.ObservedAt = now
 	if err := e.store.Update(rec); err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.notifyLocked(rec)
 	e.publishLocked(rec)
-	return rec.Snapshot, nil
+	return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpRequestCancel}}, nil
 }
 
-func (e *Endpoint) respond(cmd *protocol.Command) (any, error) {
+func (e *Endpoint) respond(cmd *protocol.Command) (protocol.Reply, error) {
 	host, targetID, requestID, err := protocol.DecodeRef(cmd.RequestRef)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	key := requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID}
 	e.mu.Lock()
@@ -487,21 +483,21 @@ func (e *Endpoint) respond(cmd *protocol.Command) (any, error) {
 	t := e.targets[targetID]
 	e.mu.Unlock()
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if !exists {
-		return nil, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
 	}
 	if t == nil {
-		return nil, protocol.Refuse(protocol.CodeAttachmentLost, "target is not attached")
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeAttachmentLost, "target is not attached")
 	}
 	if _, done := rec.Answered[cmd.InteractionID]; done {
 		// A replay of an answer we already delivered; do not invoke the
 		// attachment a second time.
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpInteractionRespond, Code: protocol.CodeAlreadyResolved}}, nil
 	}
 	if rec.Interaction == nil || rec.Interaction.InteractionID != cmd.InteractionID {
-		return nil, protocol.Refuse(protocol.CodeAlreadyResolved, "no such pending interaction")
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeAlreadyResolved, "no such pending interaction")
 	}
 	// Record the answer durably before the native call so a crash-then-replay
 	// cannot answer the same interaction twice.
@@ -509,15 +505,15 @@ func (e *Endpoint) respond(cmd *protocol.Command) (any, error) {
 	rec, exists, err = e.store.Get(key)
 	if err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if !exists {
 		e.mu.Unlock()
-		return nil, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
 	}
 	if _, done := rec.Answered[cmd.InteractionID]; done {
 		e.mu.Unlock()
-		return rec.Snapshot, nil
+		return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpInteractionRespond, Code: protocol.CodeAlreadyResolved}}, nil
 	}
 	rec.Revision++
 	if rec.Answered == nil {
@@ -527,25 +523,25 @@ func (e *Endpoint) respond(cmd *protocol.Command) (any, error) {
 	rec.ObservedAt = protocol.FormatTime(e.now())
 	if err := e.store.Update(rec); err != nil {
 		e.mu.Unlock()
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	e.notifyLocked(rec)
 	e.mu.Unlock()
 
 	code, err := t.att.Respond(key, cmd.Epoch, cmd.InteractionID, cmd.Option)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
 	if code != "" {
-		return nil, protocol.Refuse(code, "interaction %s", cmd.InteractionID)
+		return protocol.Reply{}, protocol.Refuse(code, "interaction %s", cmd.InteractionID)
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	rec, _, err = e.store.Get(key)
 	if err != nil {
-		return nil, err
+		return protocol.Reply{}, err
 	}
-	return rec.Snapshot, nil
+	return protocol.Reply{Snapshot: rec.Snapshot, Outcome: protocol.Outcome{Op: protocol.OpInteractionRespond}}, nil
 }
 
 // Targets returns the registered target ids.

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -635,6 +635,9 @@ func (e *Endpoint) onNative(targetID string, ev NativeEvent) {
 	rec.Revision++
 	rec.ObservedAt = protocol.FormatTime(e.now())
 	if err := e.store.Update(rec); err != nil {
+		// The durable write failed on an async path with no client waiting.
+		// Surface a visible storage-failure projection; Reconcile retries.
+		e.notifyStorageFailureLocked(rec, err)
 		return
 	}
 	e.notifyLocked(rec)
@@ -649,6 +652,22 @@ func (e *Endpoint) onNative(targetID string, ev NativeEvent) {
 		}
 	}
 	e.publishLocked(rec)
+}
+
+// notifyStorageFailureLocked surfaces a visible storage-failure projection when
+// a durable result write fails on an async native-event path, so a request is
+// never silently left "running". No durable write happens (the store write just
+// failed); Reconcile retries the real write. The caller holds e.mu.
+func (e *Endpoint) notifyStorageFailureLocked(rec *requests.Record, err error) {
+	var r *protocol.Refusal
+	if !errors.As(err, &r) || r.Code != protocol.CodeStorageFull {
+		return
+	}
+	fail := *rec
+	fail.State = protocol.StateUncertain
+	fail.Code = protocol.CodeStorageFull
+	fail.Result = nil // never advertise a result we could not persist
+	e.notifyLocked(&fail)
 }
 
 func boundResult(r *protocol.Result) *protocol.Result {
@@ -779,6 +798,7 @@ func (e *Endpoint) reconcileLive(rec *requests.Record) error {
 	rec.Revision++
 	rec.ObservedAt = protocol.FormatTime(e.now())
 	if err := e.store.Update(rec); err != nil {
+		e.notifyStorageFailureLocked(rec, err)
 		return err
 	}
 	e.notifyLocked(rec)

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -736,9 +736,21 @@ func (e *Endpoint) reconcileLive(rec *requests.Record) error {
 		}
 		rec.State = protocol.StateUncertain
 		rec.Code = protocol.CodeAttachmentLost
-	case !ev.Known:
-		// The live attachment retains nothing for this key: admission never
-		// happened and never will. Positive evidence, not a guess.
+	case ev.Class == EvidenceTentative:
+		// Bound but native ownership not yet proven. Never reject a submission
+		// that is still about to execute; re-check next tick.
+		return nil
+	case ev.Class == EvidenceUnknown:
+		// Delivered but admission-unknown (transport ambiguity, or an API that
+		// cannot report its own rejection). Keep the correlation, stay uncertain.
+		if rec.State == protocol.StateUncertain {
+			return nil
+		}
+		rec.State = protocol.StateUncertain
+		rec.Code = protocol.CodeAttachmentLost
+	case !ev.Known || ev.Class == EvidenceNone:
+		// The adapter has a real admission primitive and retains nothing:
+		// admission did not and cannot happen. Positive evidence, not a guess.
 		rec.State = protocol.StateRejected
 		rec.Code = protocol.CodeNativeError
 	case ev.Admitted && ev.State.Terminal():

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -1,0 +1,860 @@
+// Package core is the amq-remote endpoint: it owns request identity and
+// records, runs the admission algorithm against native attachments, applies
+// native evidence, reconciles after a restart, and publishes revisions. It
+// does not know how commands arrive; carriers decode with protocol and call
+// Handle.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// Source is the authenticated origin of a command. Host is the peer host from
+// the AMQ carrier or "local" for the CLI; it is never a claimed handle.
+type Source struct {
+	Host string
+	// Origin is carrier routing kept on the record so publication can find
+	// its way back after a restart. It carries no authority.
+	Origin map[string]string
+}
+
+// Publisher receives every new revision with the record's carrier origin. A
+// returned error leaves the revision unpublished; Reconcile republishes it
+// later. Republishing the same revision is safe: receivers upsert by request
+// and revision.
+type Publisher func(protocol.Snapshot, map[string]string) error
+
+// CrashPoint is a test hook that may return an error at a named boundary to
+// simulate a process death there. Production endpoints leave it nil.
+type CrashPoint func(point string) error
+
+// ErrCrashed is returned by Handle when the crash hook fired.
+var ErrCrashed = errors.New("endpoint crashed at boundary")
+
+// Crash boundary names, in the order the design lists them.
+const (
+	PointBeforeReceived    = "before:received_commit"
+	PointAfterReceived     = "after:received_commit"
+	PointBeforeDispatching = "before:dispatching_commit"
+	PointAfterDispatching  = "after:dispatching_commit"
+	PointBeforeNative      = "before:native_submit"
+	PointAfterNative       = "after:native_submit"
+	PointBeforeResult      = "before:result_commit"
+	PointAfterResult       = "after:result_commit"
+	PointBeforeAck         = "before:native_ack"
+	PointAfterAck          = "after:native_ack"
+	PointBeforePublish     = "before:publish"
+	PointAfterPublish      = "after:publish"
+	PointBeforePublished   = "before:published_revision_commit"
+)
+
+type target struct {
+	att         Attachment
+	unsubscribe func()
+}
+
+// Endpoint is the request handler. One Endpoint owns one Store.
+type Endpoint struct {
+	mu        sync.Mutex
+	store     *requests.Store
+	targets   map[string]*target
+	publish   Publisher
+	crash     CrashPoint
+	now       func() time.Time
+	observers []func(*requests.Record)
+	changed   chan struct{}
+}
+
+// Config configures New.
+type Config struct {
+	Store   *requests.Store
+	Publish Publisher
+	Crash   CrashPoint
+	Now     func() time.Time
+}
+
+// New builds an endpoint over an open store. Attachments register through
+// Register; Reconcile should run before the first command.
+func New(cfg Config) *Endpoint {
+	e := &Endpoint{
+		store:   cfg.Store,
+		targets: map[string]*target{},
+		publish: cfg.Publish,
+		crash:   cfg.Crash,
+		now:     cfg.Now,
+		changed: make(chan struct{}),
+	}
+	if e.now == nil {
+		e.now = time.Now
+	}
+	if e.publish == nil {
+		e.publish = func(protocol.Snapshot, map[string]string) error { return nil }
+	}
+	return e
+}
+
+// Observe registers a callback for every record write. Tests use it to
+// collect state history; production uses it for the activity ring.
+func (e *Endpoint) Observe(fn func(*requests.Record)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.observers = append(e.observers, fn)
+}
+
+// Register attaches a runtime under its target id and subscribes to its
+// native events. Registering the same target again replaces the attachment.
+func (e *Endpoint) Register(att Attachment) {
+	s := att.Inspect()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if old, ok := e.targets[s.TargetID]; ok && old.unsubscribe != nil {
+		old.unsubscribe()
+	}
+	t := &target{att: att}
+	t.unsubscribe = att.Subscribe(func(ev NativeEvent) { e.onNative(s.TargetID, ev) })
+	e.targets[s.TargetID] = t
+}
+
+// Close unsubscribes from every attachment and closes the store. Records and
+// the attachments' retained evidence survive for the next endpoint.
+func (e *Endpoint) Close() error {
+	e.mu.Lock()
+	for id, t := range e.targets {
+		if t.unsubscribe != nil {
+			t.unsubscribe()
+		}
+		delete(e.targets, id)
+	}
+	e.mu.Unlock()
+	return e.store.Close()
+}
+
+// Handle runs one validated command from an authenticated source and returns
+// the reply document: a Snapshot for request.* and interaction.respond, a
+// Session or []Session for session.*.
+func (e *Endpoint) Handle(cmd *protocol.Command, src Source) (any, error) {
+	if err := cmd.Validate(); err != nil {
+		return nil, err
+	}
+	if src.Host == "" {
+		return nil, protocol.Refuse(protocol.CodeInvalid, "command source host is required")
+	}
+	switch cmd.Op {
+	case protocol.OpRequestSubmit:
+		return e.submit(cmd, src)
+	case protocol.OpRequestGet:
+		return e.get(cmd)
+	case protocol.OpRequestCancel:
+		return e.cancel(cmd, src)
+	case protocol.OpSessionList:
+		return e.list(), nil
+	case protocol.OpSessionInspect:
+		return e.inspect(cmd.TargetID)
+	case protocol.OpSessionEvents:
+		return e.inspect(cmd.TargetID)
+	case protocol.OpInteractionRespond:
+		return e.respond(cmd)
+	}
+	return nil, protocol.Refuse(protocol.CodeInvalid, "unknown op")
+}
+
+// InputDigest is the protocol digest of a submit input, computed from its
+// canonical JSON so every carrier agrees on the bytes.
+func InputDigest(in *protocol.SubmitInput) string {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return ""
+	}
+	return requests.Digest(data)
+}
+
+func (e *Endpoint) submit(cmd *protocol.Command, src Source) (any, error) {
+	key := requests.Key{CreatorHost: src.Host, TargetID: cmd.TargetID, RequestID: cmd.RequestID}
+	digest := InputDigest(cmd.Input)
+
+	e.mu.Lock()
+	rec, exists, err := e.store.Get(key)
+	if err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	if exists {
+		e.mu.Unlock()
+		reply := rec.Snapshot
+		if rec.InputDigest != "" && rec.InputDigest != digest {
+			reply.Code = protocol.CodeRequestConflict
+		}
+		return reply, nil
+	}
+	rec = &requests.Record{
+		Snapshot: protocol.Snapshot{
+			Schema:      protocol.SchemaRequest,
+			RequestID:   cmd.RequestID,
+			CreatorHost: src.Host,
+			TargetID:    cmd.TargetID,
+			Epoch:       cmd.Epoch,
+			Revision:    1,
+			State:       protocol.StateReceived,
+			InputDigest: digest,
+			NotAfter:    cmd.NotAfter,
+			ObservedAt:  protocol.FormatTime(e.now()),
+		},
+		Input:  cmd.Input,
+		Origin: src.Origin,
+	}
+	if err := e.crashAt(PointBeforeReceived); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	if err := e.store.Create(rec); err != nil {
+		e.mu.Unlock()
+		var r *protocol.Refusal
+		if errors.As(err, &r) && r.Code == protocol.CodeStorageFull {
+			return e.unpersisted(rec, protocol.StateRejected, protocol.CodeStorageFull), nil
+		}
+		return nil, err
+	}
+	e.notifyLocked(rec)
+	if err := e.crashAt(PointAfterReceived); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	t, code := e.admissibleLocked(cmd.TargetID, cmd.Epoch, cmd.NotAfter)
+	if code != "" {
+		rec.Revision++
+		rec.State = protocol.StateRejected
+		rec.Code = code
+		rec.ObservedAt = protocol.FormatTime(e.now())
+		err := e.store.Update(rec)
+		e.notifyLocked(rec)
+		e.mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		e.publishRevision(rec)
+		return rec.Snapshot, nil
+	}
+	if t == nil {
+		// Target registered but offline: keep received and let Tick admit
+		// or expire it later.
+		e.mu.Unlock()
+		return rec.Snapshot, nil
+	}
+	rec.Revision++
+	rec.State = protocol.StateDispatching
+	rec.NativeDispatches = 1
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.crashAt(PointBeforeDispatching); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	if err := e.store.Update(rec); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	e.notifyLocked(rec)
+	if err := e.crashAt(PointAfterDispatching); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	e.mu.Unlock()
+
+	if err := e.crashAt(PointBeforeNative); err != nil {
+		return nil, err
+	}
+	adm, nerr := t.att.Submit(BoundRequest{Key: key, Epoch: cmd.Epoch, Input: *cmd.Input, NotAfter: cmd.NotAfter})
+	if err := e.crashAt(PointAfterNative); err != nil {
+		return nil, err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, _, err = e.store.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	if rec.State != protocol.StateDispatching {
+		// A fast native event already moved the record; the evidence wins.
+		return rec.Snapshot, nil
+	}
+	switch {
+	case nerr != nil:
+		rec.State = protocol.StateUncertain
+		rec.Code = protocol.CodeAttachmentLost
+	case adm.Admitted:
+		rec.State = protocol.StateRunning
+		run := adm.RunID
+		rec.NativeRun = &run
+	case adm.Code == protocol.CodeCancelledBeforeAdmission:
+		rec.State = protocol.StateCancelled
+		rec.Code = adm.Code
+	default:
+		rec.State = protocol.StateRejected
+		rec.Code = adm.Code
+		if rec.Code == "" {
+			rec.Code = protocol.CodeNativeError
+		}
+	}
+	rec.Revision++
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.store.Update(rec); err != nil {
+		return nil, err
+	}
+	e.notifyLocked(rec)
+	e.publishLocked(rec)
+	return rec.Snapshot, nil
+}
+
+// admissibleLocked checks share, epoch, expiry and capability. It returns the
+// live target, or nil with an empty code when the target is registered but
+// offline, or nil with a refusal code.
+func (e *Endpoint) admissibleLocked(targetID, epoch, notAfter string) (*target, protocol.Code) {
+	t, ok := e.targets[targetID]
+	if !ok {
+		return nil, protocol.CodeUnshared
+	}
+	s := t.att.Inspect()
+	if s.Epoch != epoch {
+		return nil, protocol.CodeStaleEpoch
+	}
+	deadline, err := protocol.ParseTime(notAfter)
+	if err != nil || e.now().After(deadline) {
+		return nil, protocol.CodeExpired
+	}
+	if !s.Capabilities.Submit {
+		return nil, protocol.CodeUnsupported
+	}
+	if s.Attachment == "offline" {
+		return nil, ""
+	}
+	return t, ""
+}
+
+func (e *Endpoint) unpersisted(rec *requests.Record, state protocol.State, code protocol.Code) protocol.Snapshot {
+	s := rec.Snapshot
+	s.RequestRef = protocol.EncodeRef(rec.CreatorHost, rec.TargetID, rec.RequestID)
+	s.State = state
+	s.Code = code
+	return s
+}
+
+func (e *Endpoint) get(cmd *protocol.Command) (any, error) {
+	host, targetID, requestID, err := protocol.DecodeRef(cmd.RequestRef)
+	if err != nil {
+		return nil, err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, ok, err := e.store.Get(requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID})
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+	}
+	return rec.Snapshot, nil
+}
+
+func (e *Endpoint) cancel(cmd *protocol.Command, src Source) (any, error) {
+	host, targetID, requestID, err := protocol.DecodeRef(cmd.RequestRef)
+	if err != nil {
+		return nil, err
+	}
+	if targetID != cmd.TargetID {
+		return nil, protocol.Refuse(protocol.CodeInvalid, "request_ref names a different target")
+	}
+	key := requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID}
+	now := protocol.FormatTime(e.now())
+
+	e.mu.Lock()
+	rec, exists, err := e.store.Get(key)
+	if err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	if !exists {
+		// Cancel arrived before its submit: leave a tombstone that a later
+		// submit cannot execute past.
+		rec = &requests.Record{
+			Snapshot: protocol.Snapshot{
+				Schema:      protocol.SchemaRequest,
+				RequestID:   requestID,
+				CreatorHost: host,
+				TargetID:    targetID,
+				Epoch:       cmd.Epoch,
+				Revision:    1,
+				State:       protocol.StateCancelled,
+				Code:        protocol.CodeCancelledBeforeAdmission,
+				Cancel:      &protocol.Cancel{RequestedAt: now, Disposition: protocol.CancelConfirmed},
+				ObservedAt:  now,
+			},
+			Tombstone: true,
+			Origin:    src.Origin,
+		}
+		err := e.store.Create(rec)
+		e.notifyLocked(rec)
+		e.mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		e.publishRevision(rec)
+		return rec.Snapshot, nil
+	}
+	if rec.State.Terminal() {
+		e.mu.Unlock()
+		reply := rec.Snapshot
+		reply.Cancel = &protocol.Cancel{RequestedAt: now, Disposition: protocol.CancelNoopTerminal}
+		return reply, nil
+	}
+	if rec.State == protocol.StateReceived {
+		rec.Revision++
+		rec.State = protocol.StateCancelled
+		rec.Code = protocol.CodeCancelledBeforeAdmission
+		rec.Cancel = &protocol.Cancel{RequestedAt: now, Disposition: protocol.CancelConfirmed}
+		rec.ObservedAt = now
+		err := e.store.Update(rec)
+		e.notifyLocked(rec)
+		e.mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		e.publishRevision(rec)
+		return rec.Snapshot, nil
+	}
+	t := e.targets[targetID]
+	e.mu.Unlock()
+
+	var ev CancelEvidence
+	var nerr error
+	if t == nil {
+		ev = CancelEvidence{Disposition: protocol.CancelRequested, Message: "attachment offline; intent recorded"}
+	} else {
+		ev, nerr = t.att.CancelExact(key, rec.Epoch)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, _, err = e.store.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	if rec.State.Terminal() {
+		reply := rec.Snapshot
+		reply.Cancel = &protocol.Cancel{RequestedAt: now, Disposition: protocol.CancelNoopTerminal}
+		return reply, nil
+	}
+	if nerr != nil {
+		ev = CancelEvidence{Disposition: protocol.CancelRequested, Message: nerr.Error()}
+	}
+	rec.Revision++
+	rec.Cancel = &protocol.Cancel{RequestedAt: now, Disposition: ev.Disposition}
+	if ev.Disposition == protocol.CancelConfirmed {
+		rec.State = protocol.StateCancelled
+		rec.Code = protocol.CodeCancelledByRequest
+	}
+	rec.ObservedAt = now
+	if err := e.store.Update(rec); err != nil {
+		return nil, err
+	}
+	e.notifyLocked(rec)
+	e.publishLocked(rec)
+	return rec.Snapshot, nil
+}
+
+func (e *Endpoint) respond(cmd *protocol.Command) (any, error) {
+	host, targetID, requestID, err := protocol.DecodeRef(cmd.RequestRef)
+	if err != nil {
+		return nil, err
+	}
+	key := requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID}
+	e.mu.Lock()
+	rec, exists, err := e.store.Get(key)
+	t := e.targets[targetID]
+	e.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+	}
+	if t == nil {
+		return nil, protocol.Refuse(protocol.CodeAttachmentLost, "target is not attached")
+	}
+	if rec.Interaction == nil || rec.Interaction.InteractionID != cmd.InteractionID {
+		return nil, protocol.Refuse(protocol.CodeAlreadyResolved, "no such pending interaction")
+	}
+	code, err := t.att.Respond(key, cmd.Epoch, cmd.InteractionID, cmd.Option)
+	if err != nil {
+		return nil, err
+	}
+	if code != "" {
+		return nil, protocol.Refuse(code, "interaction %s", cmd.InteractionID)
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, _, err = e.store.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	return rec.Snapshot, nil
+}
+
+// Targets returns the registered target ids.
+func (e *Endpoint) Targets() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, 0, len(e.targets))
+	for id := range e.targets {
+		out = append(out, id)
+	}
+	return out
+}
+
+func (e *Endpoint) list() []protocol.Session {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]protocol.Session, 0, len(e.targets))
+	for _, t := range e.targets {
+		out = append(out, t.att.Inspect())
+	}
+	return out
+}
+
+func (e *Endpoint) inspect(targetID string) (any, error) {
+	e.mu.Lock()
+	t, ok := e.targets[targetID]
+	e.mu.Unlock()
+	if !ok {
+		return nil, protocol.Refuse(protocol.CodeNotFound, "target %s is not registered", targetID)
+	}
+	return t.att.Inspect(), nil
+}
+
+// onNative applies one native observation to the bound record.
+func (e *Endpoint) onNative(targetID string, ev NativeEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if ev.Type == EventEpochChanged || ev.Type == EventStatus {
+		return
+	}
+	if ev.Key.RequestID == "" {
+		return
+	}
+	rec, ok, err := e.store.Get(ev.Key)
+	if err != nil || !ok {
+		return
+	}
+	if rec.State.Terminal() {
+		return
+	}
+	switch ev.Type {
+	case EventRunCompleted, EventRunFailed, EventRunCancelled:
+		if rec.State != protocol.StateRunning && rec.State != protocol.StateDispatching && rec.State != protocol.StateUncertain {
+			return
+		}
+		if e.crashAt(PointBeforeResult) != nil {
+			return
+		}
+		switch ev.Type {
+		case EventRunCompleted:
+			rec.State = protocol.StateCompleted
+		case EventRunFailed:
+			rec.State = protocol.StateFailed
+			rec.Code = protocol.CodeNativeError
+		default:
+			rec.State = protocol.StateCancelled
+			rec.Code = protocol.CodeCancelledByRequest
+			if rec.Cancel != nil {
+				rec.Cancel.Disposition = protocol.CancelConfirmed
+			}
+		}
+		if ev.RunID != "" {
+			run := ev.RunID
+			rec.NativeRun = &run
+		}
+		rec.Result = boundResult(ev.Result)
+		rec.Interaction = nil
+	case EventQuestion:
+		rec.Interaction = ev.Interaction
+	case EventQuestionResolved:
+		rec.Interaction = nil
+	case EventLocalIntervention:
+		rec.LocalIntervention = true
+	default:
+		return
+	}
+	rec.Revision++
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.store.Update(rec); err != nil {
+		return
+	}
+	e.notifyLocked(rec)
+	if e.crashAt(PointAfterResult) != nil {
+		return
+	}
+	if rec.State.Terminal() {
+		if t, ok := e.targets[targetID]; ok {
+			if e.crashAt(PointBeforeAck) == nil {
+				t.att.AcknowledgeResult(ev.Key, rec.Epoch, rec.InputDigest)
+			}
+		}
+	}
+	e.publishLocked(rec)
+}
+
+func boundResult(r *protocol.Result) *protocol.Result {
+	if r == nil {
+		return nil
+	}
+	out := *r
+	if len(out.Text) > protocol.MaxResultBytes {
+		out.Text = out.Text[:protocol.MaxResultBytes]
+		out.Truncated = true
+	}
+	return &out
+}
+
+// Reconcile runs after Open. It re-examines every non-terminal record against
+// exact native evidence, never re-submits, expires deferred requests whose
+// admission window closed, and republishes unpublished revisions.
+func (e *Endpoint) Reconcile() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	recs, err := e.store.List()
+	if err != nil {
+		return err
+	}
+	for _, rec := range recs {
+		switch rec.State {
+		case protocol.StateDispatching, protocol.StateRunning, protocol.StateUncertain:
+			if err := e.reconcileLiveLocked(rec); err != nil {
+				return err
+			}
+		case protocol.StateReceived:
+			if err := e.admitDeferredLocked(rec); err != nil {
+				return err
+			}
+		}
+		if rec.PublishedRevision < rec.Revision {
+			e.publishLocked(rec)
+		}
+	}
+	return nil
+}
+
+// Tick retries deferred admissions and expiry; carriers call it on a timer
+// and when a target comes back online.
+func (e *Endpoint) Tick() error {
+	return e.Reconcile()
+}
+
+func (e *Endpoint) reconcileLiveLocked(rec *requests.Record) error {
+	key := requests.Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
+	t, ok := e.targets[rec.TargetID]
+	var ev Evidence
+	var err error
+	if ok {
+		ev, err = t.att.Lookup(key, rec.Epoch)
+	}
+	switch {
+	case !ok || err != nil:
+		if rec.State == protocol.StateUncertain {
+			return nil
+		}
+		rec.State = protocol.StateUncertain
+		rec.Code = protocol.CodeAttachmentLost
+	case !ev.Known:
+		// The live attachment retains nothing for this key: nothing was
+		// admitted and nothing will be. Positive evidence, not a guess.
+		rec.State = protocol.StateRejected
+		rec.Code = protocol.CodeNativeError
+	case ev.Admitted && ev.State.Terminal():
+		rec.State = ev.State
+		if ev.State == protocol.StateFailed {
+			rec.Code = protocol.CodeNativeError
+		}
+		run := ev.RunID
+		rec.NativeRun = &run
+		rec.Result = boundResult(ev.Result)
+		rec.LocalIntervention = rec.LocalIntervention || ev.LocalIntervention
+		rec.Interaction = nil
+	case ev.Admitted:
+		if rec.State == protocol.StateRunning && rec.NativeRun != nil && *rec.NativeRun == ev.RunID {
+			return nil
+		}
+		rec.State = protocol.StateRunning
+		rec.Code = ""
+		run := ev.RunID
+		rec.NativeRun = &run
+		rec.Interaction = ev.Interaction
+	default:
+		rec.State = protocol.StateRejected
+		rec.Code = protocol.CodeNativeError
+	}
+	rec.Revision++
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.store.Update(rec); err != nil {
+		return err
+	}
+	e.notifyLocked(rec)
+	if rec.State.Terminal() && ok {
+		t.att.AcknowledgeResult(key, rec.Epoch, rec.InputDigest)
+	}
+	return nil
+}
+
+func (e *Endpoint) admitDeferredLocked(rec *requests.Record) error {
+	t, code := e.admissibleLocked(rec.TargetID, rec.Epoch, rec.NotAfter)
+	if code == "" && t == nil {
+		return nil // still offline, still inside the window
+	}
+	if code != "" {
+		rec.Revision++
+		rec.State = protocol.StateRejected
+		rec.Code = code
+		rec.ObservedAt = protocol.FormatTime(e.now())
+		if err := e.store.Update(rec); err != nil {
+			return err
+		}
+		e.notifyLocked(rec)
+		return nil
+	}
+	// Target came back inside the window: dispatch now, under the lock,
+	// because reconciliation is not a request path with a waiting client.
+	rec.Revision++
+	rec.State = protocol.StateDispatching
+	rec.NativeDispatches = 1
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.store.Update(rec); err != nil {
+		return err
+	}
+	e.notifyLocked(rec)
+	key := requests.Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
+	input := protocol.SubmitInput{}
+	if rec.Input != nil {
+		input = *rec.Input
+	}
+	adm, nerr := t.att.Submit(BoundRequest{Key: key, Epoch: rec.Epoch, Input: input, NotAfter: rec.NotAfter})
+	rec, _, err := e.store.Get(key)
+	if err != nil || rec.State != protocol.StateDispatching {
+		return err
+	}
+	switch {
+	case nerr != nil:
+		rec.State, rec.Code = protocol.StateUncertain, protocol.CodeAttachmentLost
+	case adm.Admitted:
+		rec.State = protocol.StateRunning
+		run := adm.RunID
+		rec.NativeRun = &run
+	default:
+		rec.State, rec.Code = protocol.StateRejected, adm.Code
+		if rec.Code == "" {
+			rec.Code = protocol.CodeNativeError
+		}
+	}
+	rec.Revision++
+	rec.ObservedAt = protocol.FormatTime(e.now())
+	if err := e.store.Update(rec); err != nil {
+		return err
+	}
+	e.notifyLocked(rec)
+	return nil
+}
+
+// Wait blocks until the record for ref reaches a terminal or uncertain state
+// or ctx ends. It never cancels work. Callers map ctx errors to exit 4 or 130.
+func (e *Endpoint) Wait(ctx context.Context, ref string) (protocol.Snapshot, error) {
+	host, targetID, requestID, err := protocol.DecodeRef(ref)
+	if err != nil {
+		return protocol.Snapshot{}, err
+	}
+	key := requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID}
+	for {
+		e.mu.Lock()
+		rec, ok, err := e.store.Get(key)
+		ch := e.changed
+		e.mu.Unlock()
+		if err != nil {
+			return protocol.Snapshot{}, err
+		}
+		if !ok {
+			return protocol.Snapshot{}, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+		}
+		if rec.State.Terminal() || rec.State == protocol.StateUncertain {
+			return rec.Snapshot, nil
+		}
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return rec.Snapshot, ctx.Err()
+		}
+	}
+}
+
+// Snapshot returns the current record for ref without waiting.
+func (e *Endpoint) Snapshot(ref string) (protocol.Snapshot, error) {
+	host, targetID, requestID, err := protocol.DecodeRef(ref)
+	if err != nil {
+		return protocol.Snapshot{}, err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rec, ok, err := e.store.Get(requests.Key{CreatorHost: host, TargetID: targetID, RequestID: requestID})
+	if err != nil {
+		return protocol.Snapshot{}, err
+	}
+	if !ok {
+		return protocol.Snapshot{}, protocol.Refuse(protocol.CodeNotFound, "no record for request_ref")
+	}
+	return rec.Snapshot, nil
+}
+
+func (e *Endpoint) notifyLocked(rec *requests.Record) {
+	for _, fn := range e.observers {
+		fn(rec)
+	}
+	close(e.changed)
+	e.changed = make(chan struct{})
+}
+
+// publishLocked publishes the latest revision and records it on success.
+// Failures leave published_revision behind so Reconcile retries.
+func (e *Endpoint) publishLocked(rec *requests.Record) {
+	if e.crashAt(PointBeforePublish) != nil {
+		return
+	}
+	if err := e.publish(rec.Snapshot, rec.Origin); err != nil {
+		return
+	}
+	if e.crashAt(PointAfterPublish) != nil || e.crashAt(PointBeforePublished) != nil {
+		return
+	}
+	key := requests.Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
+	if err := e.store.MarkPublished(key, rec.Revision); err == nil {
+		rec.PublishedRevision = rec.Revision
+	}
+}
+
+func (e *Endpoint) publishRevision(rec *requests.Record) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.publishLocked(rec)
+}
+
+func (e *Endpoint) crashAt(point string) error {
+	if e.crash == nil {
+		return nil
+	}
+	if err := e.crash(point); err != nil {
+		return fmt.Errorf("%w %s: %w", ErrCrashed, point, err)
+	}
+	return nil
+}

--- a/internal/remote/core/review_regression_test.go
+++ b/internal/remote/core/review_regression_test.go
@@ -1,0 +1,185 @@
+package core_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+func openStore(t *testing.T) (*requests.Store, func() time.Time) {
+	clk := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	now := func() time.Time { return clk }
+	store, err := requests.Open(t.TempDir(), requests.WithClock(now))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store, now
+}
+
+func submitCmd(id string) *protocol.Command {
+	return &protocol.Command{
+		Schema: protocol.SchemaCommand, Op: protocol.OpRequestSubmit,
+		RequestID: id, TargetID: "fake", Epoch: "e_1",
+		NotAfter: protocol.FormatTime(time.Date(2026, 9, 8, 10, 2, 0, 0, time.UTC)),
+		Input:    &protocol.SubmitInput{Text: "x"},
+	}
+}
+
+// TestReconcilePoisonRecordResolvesNotAborts reproduces the P0 where a record
+// left uncertain (target briefly unregistered) then re-examined with the
+// target back but no run bound would attempt uncertain -> rejected, which the
+// store refused, aborting the whole reconcile pass and serve startup.
+func TestReconcilePoisonRecordResolvesNotAborts(t *testing.T) {
+	store, now := openStore(t)
+	// Seed an uncertain record with no run, plus a healthy second record, so
+	// a per-record failure would starve the second one too.
+	for _, id := range []string{"11111111-1111-4111-8111-1111111111a1", "11111111-1111-4111-8111-1111111111a2"} {
+		rec := &requests.Record{Snapshot: protocol.Snapshot{
+			Schema: protocol.SchemaRequest, RequestID: id, CreatorHost: "local",
+			TargetID: "fake", Epoch: "e_1", Revision: 1, State: protocol.StateReceived,
+			InputDigest: requests.Digest([]byte("x")), NotAfter: protocol.FormatTime(now().Add(2 * time.Minute)),
+			ObservedAt: protocol.FormatTime(now()),
+		}}
+		if err := store.Create(rec); err != nil {
+			t.Fatal(err)
+		}
+		rec.Revision, rec.State, rec.NativeDispatches = 2, protocol.StateDispatching, 1
+		if err := store.Update(rec); err != nil {
+			t.Fatal(err)
+		}
+		rec.Revision, rec.State, rec.Code = 3, protocol.StateUncertain, protocol.CodeAttachmentLost
+		if err := store.Update(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(fake.New("fake", "e_1")) // live target, but no run for either key
+	if err := ep.Reconcile(); err != nil {
+		t.Fatalf("reconcile aborted on a poison record: %v", err)
+	}
+	for _, id := range []string{"11111111-1111-4111-8111-1111111111a1", "11111111-1111-4111-8111-1111111111a2"} {
+		rec, _, err := store.Get(requests.Key{CreatorHost: "local", TargetID: "fake", RequestID: id})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.State != protocol.StateRejected {
+			t.Fatalf("record %s stuck at %s, want rejected", id, rec.State)
+		}
+	}
+}
+
+// TestReconcileDoesNotHoldLockAcrossNativeCalls reproduces the P0 where
+// Reconcile held the endpoint mutex across a native Lookup, stalling every
+// other operation. A concurrent Handle must complete while the Lookup blocks.
+func TestReconcileDoesNotHoldLockAcrossNativeCalls(t *testing.T) {
+	store, now := openStore(t)
+	rt := fake.New("fake", "e_1")
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(rt)
+
+	// One running record for Reconcile to Lookup.
+	if _, err := ep.Handle(submitCmd("11111111-1111-4111-8111-1111111111b1"), core.Source{Host: "local"}); err != nil {
+		t.Fatalf("seed submit: %v", err)
+	}
+
+	rt.HoldLookup()
+	reconcileDone := make(chan error, 1)
+	go func() { reconcileDone <- ep.Reconcile() }()
+	time.Sleep(20 * time.Millisecond) // let Reconcile reach the blocked Lookup
+
+	handled := make(chan error, 1)
+	go func() {
+		_, err := ep.Handle(&protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpSessionList}, core.Source{Host: "local"})
+		handled <- err
+	}()
+	select {
+	case err := <-handled:
+		if err != nil {
+			t.Fatalf("concurrent Handle failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Handle blocked while Reconcile held the lock across a native Lookup")
+	}
+	rt.ReleaseLookup()
+	if err := <-reconcileDone; err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+}
+
+// TestCancelBeforeAdmissionConfirmsDisposition reproduces the P1 where a cancel
+// racing a gated admission left a cancelled record whose cancel disposition
+// still read cancel_requested.
+func TestCancelBeforeAdmissionConfirmsDisposition(t *testing.T) {
+	store, now := openStore(t)
+	rt := fake.New("fake", "e_1")
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(rt)
+
+	rt.HoldAdmission()
+	id := "11111111-1111-4111-8111-1111111111c1"
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); _, _ = ep.Handle(submitCmd(id), core.Source{Host: "local"}) }()
+	time.Sleep(20 * time.Millisecond) // submit reaches the held admission gate
+
+	ref := protocol.EncodeRef("local", "fake", id)
+	if _, err := ep.Handle(&protocol.Command{
+		Schema: protocol.SchemaCommand, Op: protocol.OpRequestCancel, RequestRef: ref,
+		TargetID: "fake", Epoch: "e_1", NotAfter: protocol.FormatTime(now().Add(2 * time.Minute)),
+	}, core.Source{Host: "local"}); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	rt.ReleaseAdmission()
+	wg.Wait()
+
+	rec, _, err := store.Get(requests.Key{CreatorHost: "local", TargetID: "fake", RequestID: id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.State != protocol.StateCancelled {
+		t.Fatalf("state %s, want cancelled", rec.State)
+	}
+	if rec.Cancel == nil || rec.Cancel.Disposition != protocol.CancelConfirmed {
+		t.Fatalf("cancelled record has non-confirmed disposition: %+v", rec.Cancel)
+	}
+	if rt.Snapshot().Dispatches != 1 {
+		t.Fatalf("native dispatches = %d, want 1", rt.Snapshot().Dispatches)
+	}
+}
+
+// TestRespondReplayAnswersOnce reproduces the P2: an AMQ-level replay of an
+// interaction answer must not invoke the attachment twice.
+func TestRespondReplayAnswersOnce(t *testing.T) {
+	store, now := openStore(t)
+	rt := fake.New("fake", "e_1")
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(rt)
+
+	id := "11111111-1111-4111-8111-1111111111d1"
+	if _, err := ep.Handle(submitCmd(id), core.Source{Host: "local"}); err != nil {
+		t.Fatal(err)
+	}
+	rt.Question(id, "i_1", []string{"yes", "no"})
+	ref := protocol.EncodeRef("local", "fake", id)
+	respond := &protocol.Command{
+		Schema: protocol.SchemaCommand, Op: protocol.OpInteractionRespond, RequestRef: ref,
+		TargetID: "fake", Epoch: "e_1", InteractionID: "i_1", Option: "yes",
+	}
+	if _, err := ep.Handle(respond, core.Source{Host: "local"}); err != nil {
+		t.Fatalf("respond: %v", err)
+	}
+	// Replay the identical answer, as an AMQ re-import would after a crash.
+	if _, err := ep.Handle(respond, core.Source{Host: "local"}); err != nil {
+		t.Fatalf("respond replay: %v", err)
+	}
+	answers := rt.Snapshot().Answers
+	if len(answers) != 1 || answers[0].InteractionID != "i_1" || answers[0].Option != "yes" {
+		t.Fatalf("interaction answered %d times: %+v", len(answers), answers)
+	}
+}

--- a/internal/remote/core/review_regression_test.go
+++ b/internal/remote/core/review_regression_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -237,5 +238,45 @@ func TestResultWriteFailureIsVisible(t *testing.T) {
 	}
 	if rec.State == protocol.StateCompleted {
 		t.Fatal("record silently completed despite the failed write")
+	}
+}
+
+// TestConflictOutcomeLeavesSnapshotByteIdentical reproduces Pro B11: a
+// conflicting submit must not copy-and-mutate the snapshot's Code; the
+// conflict lives in the reply Outcome while the snapshot stays byte-identical
+// to the stored revision, so equal revisions have equal content.
+func TestConflictOutcomeLeavesSnapshotByteIdentical(t *testing.T) {
+	store, now := openStore(t)
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(fake.New("fake", "e_1"))
+
+	id := "11111111-1111-4111-8111-1111111111a9"
+	first, err := ep.Handle(submitCmd(id), core.Source{Host: "local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstRep := first.(protocol.Reply)
+	// Same id, different bytes -> request_conflict.
+	conflict := submitCmd(id)
+	conflict.Input = &protocol.SubmitInput{Text: "different bytes"}
+	second, err := ep.Handle(conflict, core.Source{Host: "local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := second.(protocol.Reply)
+	if rep.Outcome.Code != protocol.CodeRequestConflict {
+		t.Fatalf("outcome code = %q, want request_conflict", rep.Outcome.Code)
+	}
+	if rep.Snapshot.Code != "" {
+		t.Fatalf("snapshot was mutated with a code %q; conflict belongs in the outcome", rep.Snapshot.Code)
+	}
+	if rep.Snapshot.Revision != firstRep.Snapshot.Revision {
+		t.Fatalf("conflict changed the revision %d -> %d without new content", firstRep.Snapshot.Revision, rep.Snapshot.Revision)
+	}
+	// The two same-revision snapshots must be byte-identical.
+	a, _ := json.Marshal(firstRep.Snapshot)
+	b, _ := json.Marshal(rep.Snapshot)
+	if string(a) != string(b) {
+		t.Fatalf("equal revisions differ:\n %s\n %s", a, b)
 	}
 }

--- a/internal/remote/core/review_regression_test.go
+++ b/internal/remote/core/review_regression_test.go
@@ -280,3 +280,38 @@ func TestConflictOutcomeLeavesSnapshotByteIdentical(t *testing.T) {
 		t.Fatalf("equal revisions differ:\n %s\n %s", a, b)
 	}
 }
+
+// TestCancelWrongEpochDoesNotInterrupt reproduces Pro B04: a cancel command
+// carrying an epoch different from the request's binding must be refused
+// (stale_epoch) without interrupting the current run.
+func TestCancelWrongEpochDoesNotInterrupt(t *testing.T) {
+	store, now := openStore(t)
+	rt := fake.New("fake", "e_1")
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(rt)
+
+	id := "11111111-1111-4111-8111-1111111111b4"
+	if _, err := ep.Handle(submitCmd(id), core.Source{Host: "local"}); err != nil {
+		t.Fatal(err)
+	}
+	ref := protocol.EncodeRef("local", "fake", id)
+	// Cancel with the WRONG epoch.
+	rep, err := ep.Handle(&protocol.Command{
+		Schema: protocol.SchemaCommand, Op: protocol.OpRequestCancel, RequestRef: ref,
+		TargetID: "fake", Epoch: "e_WRONG", NotAfter: protocol.FormatTime(now().Add(2 * time.Minute)),
+	}, core.Source{Host: "local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := rep.(protocol.Reply)
+	if out.Outcome.Code != protocol.CodeStaleEpoch {
+		t.Fatalf("wrong-epoch cancel outcome = %q, want stale_epoch", out.Outcome.Code)
+	}
+	if rt.Snapshot().Aborts != 0 {
+		t.Fatalf("wrong-epoch cancel interrupted the run (%d aborts)", rt.Snapshot().Aborts)
+	}
+	rec, _, _ := store.Get(requests.Key{CreatorHost: "local", TargetID: "fake", RequestID: id})
+	if rec.State != protocol.StateRunning {
+		t.Fatalf("run no longer running after a refused cancel: %s", rec.State)
+	}
+}

--- a/internal/remote/core/review_regression_test.go
+++ b/internal/remote/core/review_regression_test.go
@@ -1,6 +1,8 @@
 package core_test
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -181,5 +183,59 @@ func TestRespondReplayAnswersOnce(t *testing.T) {
 	answers := rt.Snapshot().Answers
 	if len(answers) != 1 || answers[0].InteractionID != "i_1" || answers[0].Option != "yes" {
 		t.Fatalf("interaction answered %d times: %+v", len(answers), answers)
+	}
+}
+
+// TestResultWriteFailureIsVisible reproduces Pro B08's silent-running hole: when
+// the durable write of a terminal result fails, the endpoint must surface a
+// visible storage-failure projection, never leave the request looking running.
+func TestResultWriteFailureIsVisible(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("cannot make a dir unwritable as root")
+	}
+	store, now := openStore(t)
+	rt := fake.New("fake", "e_1")
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(rt)
+
+	var projections []protocol.State
+	var mu sync.Mutex
+	ep.Observe(func(rec *requests.Record) {
+		mu.Lock()
+		if rec.Code == protocol.CodeStorageFull {
+			projections = append(projections, rec.State)
+		}
+		mu.Unlock()
+	})
+
+	id := "11111111-1111-4111-8111-1111111111f1"
+	if _, err := ep.Handle(submitCmd(id), core.Source{Host: "local"}); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	// Make the record's host directory unwritable so the terminal Update fails
+	// with a storage-full class error.
+	hostDir := filepath.Join(store.Dir(), "requests", "local")
+	if err := os.Chmod(hostDir, 0o500); err != nil {
+		t.Skipf("cannot chmod host dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(hostDir, 0o700) })
+
+	rt.Complete(id, "the result")
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	gotProjection := len(projections) > 0
+	mu.Unlock()
+	if !gotProjection {
+		t.Fatal("no storage-failure projection surfaced on a failed terminal write")
+	}
+	// The durable record must not have silently advanced to completed.
+	_ = os.Chmod(hostDir, 0o700)
+	rec, _, err := store.Get(requests.Key{CreatorHost: "local", TargetID: "fake", RequestID: id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.State == protocol.StateCompleted {
+		t.Fatal("record silently completed despite the failed write")
 	}
 }

--- a/internal/remote/fake/fake.go
+++ b/internal/remote/fake/fake.go
@@ -1,0 +1,425 @@
+// Package fake is the controllable runtime the contract corpus drives. It
+// implements core.Attachment with the exact ownership semantics a real
+// harness must show: serialized admission, cancellation intent honored at the
+// boundary, retained evidence across endpoint restarts, and a local editor
+// that remote work never touches.
+package fake
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+type run struct {
+	id                string
+	key               requests.Key
+	epoch             string
+	state             protocol.State
+	result            *protocol.Result
+	localIntervention bool
+	interaction       *protocol.Interaction
+	acknowledged      bool
+}
+
+// Runtime is one fake harness session.
+type Runtime struct {
+	mu sync.Mutex
+
+	targetID   string
+	epoch      string
+	sessionID  string
+	attachment string
+	busy       bool
+	draft      string
+
+	// controls
+	admissionGate        chan struct{}
+	admissionFailsAfter  bool
+	consumerSets         int
+	interactionAnswers   []Answer
+	answeredInteractions map[string]string
+	runsByKey            map[requests.Key]*run
+	runsByInteraction    map[string]*run
+	cancelIntent         map[requests.Key]bool
+	nextRun              int
+	dispatches           int
+	aborts               int
+	listeners            map[int]func(core.NativeEvent)
+	nextListener         int
+	capabilityOverride   *protocol.Capabilities
+}
+
+// Answer records who answered which interaction.
+type Answer struct {
+	InteractionID string
+	Option        string
+	Source        string
+}
+
+// New returns an idle, live fake runtime.
+func New(targetID, epoch string) *Runtime {
+	return &Runtime{
+		targetID:             targetID,
+		epoch:                epoch,
+		sessionID:            "session-1",
+		attachment:           "live",
+		runsByKey:            map[requests.Key]*run{},
+		runsByInteraction:    map[string]*run{},
+		cancelIntent:         map[requests.Key]bool{},
+		answeredInteractions: map[string]string{},
+		listeners:            map[int]func(core.NativeEvent){},
+	}
+}
+
+// Inspect implements core.Attachment.
+func (r *Runtime) Inspect() protocol.Session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	status := "idle"
+	switch {
+	case r.attachment == "offline":
+		status = "offline"
+	case r.busy:
+		status = "busy"
+	}
+	caps := protocol.Capabilities{Inspect: true, Submit: true, CancelRequest: true, AnswerQuestion: true, ApproveTool: true, Steer: true, Terminal: "unavailable"}
+	if r.capabilityOverride != nil {
+		caps = *r.capabilityOverride
+	}
+	return protocol.Session{
+		Schema:       protocol.SchemaSession,
+		TargetID:     r.targetID,
+		Epoch:        r.epoch,
+		Harness:      "fake",
+		DisplayName:  "fake runtime",
+		Attachment:   r.attachment,
+		Status:       status,
+		Capabilities: caps,
+		Evidence:     &protocol.Evidence{Submit: "admitted", Completion: "run_terminal"},
+		ObservedAt:   "2026-09-08T10:00:00Z",
+	}
+}
+
+// Submit implements core.Attachment. It blocks while the admission gate is
+// held, then atomically rechecks epoch and cancellation intent, refuses when
+// busy, and binds the key to a new run.
+func (r *Runtime) Submit(req core.BoundRequest) (core.Admission, error) {
+	r.mu.Lock()
+	gate := r.admissionGate
+	r.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.dispatches++
+	if r.admissionFailsAfter {
+		r.admissionFailsAfter = false
+		return core.Admission{Code: protocol.CodeNativeError, Message: "native admission failed after helper returned"}, nil
+	}
+	if req.Epoch != r.epoch {
+		return core.Admission{Code: protocol.CodeStaleEpoch}, nil
+	}
+	if r.cancelIntent[req.Key] {
+		delete(r.cancelIntent, req.Key)
+		return core.Admission{Code: protocol.CodeCancelledBeforeAdmission}, nil
+	}
+	if existing, ok := r.runsByKey[req.Key]; ok {
+		return core.Admission{Admitted: true, RunID: existing.id}, nil
+	}
+	if r.busy {
+		if req.Input.Busy != protocol.BusyQueue {
+			return core.Admission{Code: protocol.CodeBusy, Message: "a run is active"}, nil
+		}
+	}
+	for _, rn := range r.runsByKey {
+		if rn.state.Terminal() && !rn.acknowledged {
+			return core.Admission{Code: protocol.CodeBusy, Message: "a completed result awaits acknowledgement"}, nil
+		}
+	}
+	r.nextRun++
+	rn := &run{id: fmt.Sprintf("run_%d", r.nextRun), key: req.Key, epoch: req.Epoch, state: protocol.StateRunning}
+	r.runsByKey[req.Key] = rn
+	r.busy = true
+	return core.Admission{Admitted: true, RunID: rn.id}, nil
+}
+
+// Lookup implements core.Attachment.
+func (r *Runtime) Lookup(key requests.Key, epoch string) (core.Evidence, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rn, ok := r.runsByKey[key]
+	if !ok || rn.epoch != epoch {
+		return core.Evidence{}, nil
+	}
+	return core.Evidence{Known: true, Admitted: true, RunID: rn.id, State: rn.state, Result: rn.result, LocalIntervention: rn.localIntervention, Interaction: rn.interaction}, nil
+}
+
+// CancelExact implements core.Attachment.
+func (r *Runtime) CancelExact(key requests.Key, epoch string) (core.CancelEvidence, error) {
+	r.mu.Lock()
+	rn, ok := r.runsByKey[key]
+	if !ok {
+		r.cancelIntent[key] = true
+		r.mu.Unlock()
+		return core.CancelEvidence{Disposition: protocol.CancelRequested, Message: "intent recorded before admission"}, nil
+	}
+	if rn.epoch != epoch || rn.state.Terminal() {
+		r.mu.Unlock()
+		return core.CancelEvidence{Disposition: protocol.CancelNoopTerminal}, nil
+	}
+	r.aborts++
+	rn.state = protocol.StateCancelled
+	r.busy = false
+	ev := core.NativeEvent{Type: core.EventRunCancelled, Key: key, RunID: rn.id}
+	r.mu.Unlock()
+	r.emit(ev)
+	return core.CancelEvidence{Disposition: protocol.CancelConfirmed}, nil
+}
+
+// Respond implements core.Attachment.
+func (r *Runtime) Respond(key requests.Key, _ string, interactionID, option string) (protocol.Code, error) {
+	r.mu.Lock()
+	rn, ok := r.runsByInteraction[interactionID]
+	if !ok || rn.key != key {
+		r.mu.Unlock()
+		return protocol.CodeAlreadyResolved, nil
+	}
+	r.answeredInteractions[interactionID] = option
+	r.interactionAnswers = append(r.interactionAnswers, Answer{InteractionID: interactionID, Option: option, Source: "remote"})
+	delete(r.runsByInteraction, interactionID)
+	rn.interaction = nil
+	ev := core.NativeEvent{Type: core.EventQuestionResolved, Key: key, RunID: rn.id}
+	r.mu.Unlock()
+	r.emit(ev)
+	return "", nil
+}
+
+// AcknowledgeResult implements core.Attachment.
+func (r *Runtime) AcknowledgeResult(key requests.Key, epoch, _ string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if rn, ok := r.runsByKey[key]; ok && rn.epoch == epoch && rn.state.Terminal() {
+		rn.acknowledged = true
+	}
+}
+
+// Subscribe implements core.Attachment.
+func (r *Runtime) Subscribe(fn func(core.NativeEvent)) func() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nextListener++
+	id := r.nextListener
+	r.listeners[id] = fn
+	r.consumerSets = len(r.listeners)
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		delete(r.listeners, id)
+		r.consumerSets = len(r.listeners)
+	}
+}
+
+func (r *Runtime) emit(ev core.NativeEvent) {
+	r.mu.Lock()
+	fns := make([]func(core.NativeEvent), 0, len(r.listeners))
+	for _, fn := range r.listeners {
+		fns = append(fns, fn)
+	}
+	r.mu.Unlock()
+	for _, fn := range fns {
+		fn(ev)
+	}
+}
+
+// Controls used by the corpus runner.
+
+// HoldAdmission makes Submit block until ReleaseAdmission.
+func (r *Runtime) HoldAdmission() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.admissionGate == nil {
+		r.admissionGate = make(chan struct{})
+	}
+}
+
+// ReleaseAdmission unblocks held Submits.
+func (r *Runtime) ReleaseAdmission() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.admissionGate != nil {
+		close(r.admissionGate)
+		r.admissionGate = nil
+	}
+}
+
+// FailNextAdmissionAfterReturn makes the next Submit refuse with a native
+// error after the helper call returned, the Q11 shape.
+func (r *Runtime) FailNextAdmissionAfterReturn() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.admissionFailsAfter = true
+}
+
+// Complete finishes the run bound to requestID with text. It is a no-op when
+// no such run is admitted, so Q19 can call it at every boundary.
+func (r *Runtime) Complete(requestID, text string) bool {
+	r.mu.Lock()
+	var target *run
+	for _, rn := range r.runsByKey {
+		if rn.key.RequestID == requestID && rn.state == protocol.StateRunning {
+			target = rn
+		}
+	}
+	if target == nil {
+		r.mu.Unlock()
+		return false
+	}
+	target.state = protocol.StateCompleted
+	target.result = &protocol.Result{Text: text}
+	r.busy = false
+	ev := core.NativeEvent{Type: core.EventRunCompleted, Key: target.key, RunID: target.id, Result: target.result}
+	r.mu.Unlock()
+	r.emit(ev)
+	return true
+}
+
+// LocalInput records a human steering keystroke during the active run.
+func (r *Runtime) LocalInput(text string) {
+	r.mu.Lock()
+	var target *run
+	for _, rn := range r.runsByKey {
+		if rn.state == protocol.StateRunning {
+			target = rn
+		}
+	}
+	if target == nil {
+		r.mu.Unlock()
+		return
+	}
+	target.localIntervention = true
+	_ = text
+	ev := core.NativeEvent{Type: core.EventLocalIntervention, Key: target.key, RunID: target.id}
+	r.mu.Unlock()
+	r.emit(ev)
+}
+
+// LocalDraft sets the unsent editor text. Remote work must leave it intact.
+func (r *Runtime) LocalDraft(text string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.draft = text
+}
+
+// Draft returns the unsent editor text.
+func (r *Runtime) Draft() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.draft
+}
+
+// SessionID returns the native conversation identity.
+func (r *Runtime) SessionID() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sessionID
+}
+
+// Question raises a pending interaction on the run bound to requestID.
+func (r *Runtime) Question(requestID, interactionID string, options []string) {
+	r.mu.Lock()
+	var target *run
+	for _, rn := range r.runsByKey {
+		if rn.key.RequestID == requestID && rn.state == protocol.StateRunning {
+			target = rn
+		}
+	}
+	if target == nil {
+		r.mu.Unlock()
+		return
+	}
+	target.interaction = &protocol.Interaction{InteractionID: interactionID, Kind: "question", Options: options, RemoteAnswer: true}
+	r.runsByInteraction[interactionID] = target
+	ev := core.NativeEvent{Type: core.EventQuestion, Key: target.key, RunID: target.id, Interaction: target.interaction}
+	r.mu.Unlock()
+	r.emit(ev)
+}
+
+// LocalAnswer answers a pending interaction from the local UI.
+func (r *Runtime) LocalAnswer(interactionID, option string) {
+	r.mu.Lock()
+	rn, ok := r.runsByInteraction[interactionID]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	r.answeredInteractions[interactionID] = option
+	r.interactionAnswers = append(r.interactionAnswers, Answer{InteractionID: interactionID, Option: option, Source: "local"})
+	delete(r.runsByInteraction, interactionID)
+	rn.interaction = nil
+	ev := core.NativeEvent{Type: core.EventQuestionResolved, Key: rn.key, RunID: rn.id}
+	r.mu.Unlock()
+	r.emit(ev)
+}
+
+// SwitchSession simulates /new, /resume, fork or reload: a new epoch and a
+// new native session; old runs stay retained under their old epoch.
+func (r *Runtime) SwitchSession(newEpoch string) {
+	r.mu.Lock()
+	r.epoch = newEpoch
+	r.sessionID = "session-" + newEpoch
+	r.busy = false
+	r.mu.Unlock()
+	r.emit(core.NativeEvent{Type: core.EventEpochChanged, Epoch: newEpoch})
+}
+
+// SetOffline toggles attachment liveness.
+func (r *Runtime) SetOffline(offline bool) {
+	r.mu.Lock()
+	if offline {
+		r.attachment = "offline"
+	} else {
+		r.attachment = "live"
+	}
+	r.mu.Unlock()
+	r.emit(core.NativeEvent{Type: core.EventStatus, Attachment: r.attachment})
+}
+
+// Counters exposes what the corpus asserts about the harness side.
+type Counters struct {
+	Dispatches   int
+	Aborts       int
+	ConsumerSets int
+	Answers      []Answer
+	RunningKeys  []requests.Key
+}
+
+// Snapshot returns the counters.
+func (r *Runtime) Snapshot() Counters {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c := Counters{Dispatches: r.dispatches, Aborts: r.aborts, ConsumerSets: r.consumerSets, Answers: append([]Answer(nil), r.interactionAnswers...)}
+	for k, rn := range r.runsByKey {
+		if rn.state == protocol.StateRunning {
+			c.RunningKeys = append(c.RunningKeys, k)
+		}
+	}
+	return c
+}
+
+// HasRun reports whether any run is bound to requestID.
+func (r *Runtime) HasRun(requestID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k := range r.runsByKey {
+		if k.RequestID == requestID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/remote/fake/fake.go
+++ b/internal/remote/fake/fake.go
@@ -38,6 +38,7 @@ type Runtime struct {
 
 	// controls
 	admissionGate        chan struct{}
+	lookupGate           chan struct{}
 	admissionFailsAfter  bool
 	consumerSets         int
 	interactionAnswers   []Answer
@@ -152,6 +153,12 @@ func (r *Runtime) Submit(req core.BoundRequest) (core.Admission, error) {
 // Lookup implements core.Attachment.
 func (r *Runtime) Lookup(key requests.Key, epoch string) (core.Evidence, error) {
 	r.mu.Lock()
+	gate := r.lookupGate
+	r.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+	r.mu.Lock()
 	defer r.mu.Unlock()
 	rn, ok := r.runsByKey[key]
 	if !ok || rn.epoch != epoch {
@@ -245,6 +252,25 @@ func (r *Runtime) HoldAdmission() {
 	defer r.mu.Unlock()
 	if r.admissionGate == nil {
 		r.admissionGate = make(chan struct{})
+	}
+}
+
+// HoldLookup makes Lookup block until ReleaseLookup.
+func (r *Runtime) HoldLookup() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lookupGate == nil {
+		r.lookupGate = make(chan struct{})
+	}
+}
+
+// ReleaseLookup unblocks held Lookups.
+func (r *Runtime) ReleaseLookup() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lookupGate != nil {
+		close(r.lookupGate)
+		r.lookupGate = nil
 	}
 }
 

--- a/internal/remote/fake/fake.go
+++ b/internal/remote/fake/fake.go
@@ -164,7 +164,7 @@ func (r *Runtime) Lookup(key requests.Key, epoch string) (core.Evidence, error) 
 	if !ok || rn.epoch != epoch {
 		return core.Evidence{}, nil
 	}
-	return core.Evidence{Known: true, Admitted: true, RunID: rn.id, State: rn.state, Result: rn.result, LocalIntervention: rn.localIntervention, Interaction: rn.interaction}, nil
+	return core.Evidence{Class: core.EvidenceConfirmed, Known: true, Admitted: true, RunID: rn.id, State: rn.state, Result: rn.result, LocalIntervention: rn.localIntervention, Interaction: rn.interaction}, nil
 }
 
 // CancelExact implements core.Attachment.

--- a/internal/remote/ipc/ipc.go
+++ b/internal/remote/ipc/ipc.go
@@ -1,0 +1,226 @@
+// Package ipc is the local carrier between the amq-remote CLI and the
+// endpoint process: bounded, LF-framed JSON records over an owner-only Unix
+// domain socket. One connection carries one request and one response, so a
+// wait never blocks another client's cancel.
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+)
+
+// MaxRecordBytes bounds one IPC record; commands are already bounded by the
+// protocol, and replies carry at most one bounded result.
+const MaxRecordBytes = 1024 * 1024
+
+// LocalHost is the authenticated source recorded for commands that arrive
+// over the local socket: the OS user owning the socket.
+const LocalHost = "local"
+
+// Request is one IPC record from a client.
+type Request struct {
+	// Command is an ordinary protocol command, or nil when Wait is set.
+	Command *protocol.Command `json:"command,omitempty"`
+	// Wait blocks for a request to reach a terminal or uncertain state.
+	Wait *WaitRequest `json:"wait,omitempty"`
+}
+
+// WaitRequest is the local-only wait operation.
+type WaitRequest struct {
+	RequestRef string `json:"request_ref"`
+	TimeoutMS  int64  `json:"timeout_ms"`
+}
+
+// Response is one IPC record from the endpoint.
+type Response struct {
+	Reply json.RawMessage `json:"reply,omitempty"`
+	Error *ErrorBody      `json:"error,omitempty"`
+	// TimedOut is set when a wait ended without a terminal state.
+	TimedOut bool `json:"timed_out,omitempty"`
+}
+
+// ErrorBody carries a typed refusal across the socket.
+type ErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// SocketPath returns the endpoint socket for a state directory. Unix socket
+// paths are short-lived and length-limited, so the socket lives beside the
+// state directory's lock rather than deep inside a mailbox tree.
+func SocketPath(stateDir string) string {
+	return filepath.Join(stateDir, "endpoint.sock")
+}
+
+// Server accepts local connections and hands commands to the endpoint.
+type Server struct {
+	ep       *core.Endpoint
+	listener net.Listener
+	path     string
+}
+
+// Listen binds the socket with owner-only permissions. A stale socket file
+// from a dead endpoint is removed only after a connect attempt fails.
+func Listen(stateDir string, ep *core.Endpoint) (*Server, error) {
+	path := SocketPath(stateDir)
+	if _, err := os.Stat(path); err == nil {
+		conn, err := net.DialTimeout("unix", path, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil, protocol.Refuse(protocol.CodeEndpointAlreadyRunning, "an endpoint is listening on %s", path)
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("remove stale socket: %w", err)
+		}
+	}
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = l.Close()
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
+	return &Server{ep: ep, listener: l, path: path}, nil
+}
+
+// Path is the bound socket path.
+func (s *Server) Path() string { return s.path }
+
+// Serve accepts connections until ctx ends. Each connection is one request.
+func (s *Server) Serve(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		_ = s.listener.Close()
+	}()
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				_ = os.Remove(s.path)
+				return nil
+			}
+			return err
+		}
+		go s.handle(ctx, conn)
+	}
+}
+
+func (s *Server) handle(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	req, err := readRecord[Request](conn)
+	if err != nil {
+		writeRecord(conn, Response{Error: &ErrorBody{Code: string(protocol.CodeInvalid), Message: err.Error()}})
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	switch {
+	case req.Wait != nil:
+		timeout := time.Duration(req.Wait.TimeoutMS) * time.Millisecond
+		if timeout <= 0 {
+			timeout = 24 * time.Hour
+		}
+		wctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		snap, err := s.ep.Wait(wctx, req.Wait.RequestRef)
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeRecord(conn, Response{Reply: mustJSON(snap), TimedOut: true})
+			return
+		}
+		if err != nil {
+			writeRecord(conn, errorResponse(err))
+			return
+		}
+		writeRecord(conn, Response{Reply: mustJSON(snap)})
+	case req.Command != nil:
+		reply, err := s.ep.Handle(req.Command, core.Source{Host: LocalHost})
+		if err != nil {
+			writeRecord(conn, errorResponse(err))
+			return
+		}
+		writeRecord(conn, Response{Reply: mustJSON(reply)})
+	default:
+		writeRecord(conn, Response{Error: &ErrorBody{Code: string(protocol.CodeInvalid), Message: "request carries neither command nor wait"}})
+	}
+}
+
+func errorResponse(err error) Response {
+	var r *protocol.Refusal
+	if errors.As(err, &r) {
+		return Response{Error: &ErrorBody{Code: string(r.Code), Message: r.Message}}
+	}
+	return Response{Error: &ErrorBody{Code: "error", Message: err.Error()}}
+}
+
+func mustJSON(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`null`)
+	}
+	return data
+}
+
+// Call sends one request to the endpoint at stateDir and returns its response.
+// A missing endpoint is an action-required refusal that names the fix.
+func Call(stateDir string, req Request) (*Response, error) {
+	path := SocketPath(stateDir)
+	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	if err != nil {
+		return nil, protocol.Refuse(protocol.CodeEndpointUnreachable, "no endpoint at %s; start one with `amq-remote serve`", path)
+	}
+	defer func() { _ = conn.Close() }()
+	writeRecord(conn, req)
+	resp, err := readRecord[Response](conn)
+	if err != nil {
+		return nil, fmt.Errorf("read endpoint response: %w", err)
+	}
+	return resp, nil
+}
+
+// AsError converts a response error body back into a typed refusal.
+func (r *Response) AsError() error {
+	if r == nil || r.Error == nil {
+		return nil
+	}
+	if r.Error.Code == "error" {
+		return errors.New(r.Error.Message)
+	}
+	return &protocol.Refusal{Code: protocol.Code(r.Error.Code), Message: r.Error.Message}
+}
+
+func readRecord[T any](r io.Reader) (*T, error) {
+	br := bufio.NewReaderSize(r, 64*1024)
+	line, err := br.ReadBytes('\n')
+	if err != nil && (!errors.Is(err, io.EOF) || len(line) == 0) {
+		return nil, fmt.Errorf("read record: %w", err)
+	}
+	if len(line) > MaxRecordBytes {
+		return nil, fmt.Errorf("record exceeds %d bytes", MaxRecordBytes)
+	}
+	var v T
+	if err := json.Unmarshal(line, &v); err != nil {
+		return nil, fmt.Errorf("decode record: %w", err)
+	}
+	return &v, nil
+}
+
+func writeRecord(w io.Writer, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+	_, _ = w.Write(data)
+}

--- a/internal/remote/ipc/ipc_test.go
+++ b/internal/remote/ipc/ipc_test.go
@@ -1,0 +1,84 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// TestSubmitStatusWaitOverSocket is the happy path for the local carrier: a
+// client submits to the fake runtime, reads status, and waits for the result
+// that the runtime later produces. Socket paths must stay short, so the state
+// directory lives directly under the system temp root.
+func TestSubmitStatusWaitOverSocket(t *testing.T) {
+	stateDir, err := os.MkdirTemp("", "amqr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateDir) })
+
+	store, err := requests.Open(stateDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	ep := core.New(core.Config{Store: store})
+	rt := fake.New("fake", "e_1")
+	ep.Register(rt)
+	server, err := Listen(stateDir, ep)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = server.Serve(ctx) }()
+
+	cmd := &protocol.Command{
+		Schema:    protocol.SchemaCommand,
+		Op:        protocol.OpRequestSubmit,
+		RequestID: "11111111-1111-4111-8111-111111111201",
+		TargetID:  "fake",
+		Epoch:     "e_1",
+		NotAfter:  protocol.FormatTime(time.Now().Add(time.Minute)),
+		Input:     &protocol.SubmitInput{Text: "say hi"},
+	}
+	resp, err := Call(stateDir, Request{Command: cmd})
+	if err != nil || resp.AsError() != nil {
+		t.Fatalf("submit: %v / %v", err, resp.AsError())
+	}
+	var snap protocol.Snapshot
+	if err := json.Unmarshal(resp.Reply, &snap); err != nil {
+		t.Fatal(err)
+	}
+	if snap.State != protocol.StateRunning || snap.CreatorHost != LocalHost {
+		t.Fatalf("unexpected submit reply: %+v", snap)
+	}
+
+	resp, err = Call(stateDir, Request{Command: &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpRequestGet, RequestRef: snap.RequestRef}})
+	if err != nil || resp.AsError() != nil {
+		t.Fatalf("status: %v / %v", err, resp.AsError())
+	}
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		rt.Complete(cmd.RequestID, "hi")
+	}()
+	resp, err = Call(stateDir, Request{Wait: &WaitRequest{RequestRef: snap.RequestRef, TimeoutMS: 2000}})
+	if err != nil || resp.AsError() != nil || resp.TimedOut {
+		t.Fatalf("wait: %v / %v / timed out=%v", err, resp.AsError(), resp.TimedOut)
+	}
+	if err := json.Unmarshal(resp.Reply, &snap); err != nil {
+		t.Fatal(err)
+	}
+	if snap.State != protocol.StateCompleted || snap.Result == nil || snap.Result.Text != "hi" {
+		t.Fatalf("unexpected wait reply: %+v", snap)
+	}
+	cancel()
+	_ = ep.Close()
+}

--- a/internal/remote/ipc/ipc_test.go
+++ b/internal/remote/ipc/ipc_test.go
@@ -52,18 +52,20 @@ func TestSubmitStatusWaitOverSocket(t *testing.T) {
 	if err != nil || resp.AsError() != nil {
 		t.Fatalf("submit: %v / %v", err, resp.AsError())
 	}
-	var snap protocol.Snapshot
-	if err := json.Unmarshal(resp.Reply, &snap); err != nil {
+	var rep protocol.Reply
+	if err := json.Unmarshal(resp.Reply, &rep); err != nil {
 		t.Fatal(err)
 	}
+	snap := rep.Snapshot
 	if snap.State != protocol.StateRunning || snap.CreatorHost != LocalHost {
-		t.Fatalf("unexpected submit reply: %+v", snap)
+		t.Fatalf("unexpected submit reply: %+v", rep)
 	}
 
 	resp, err = Call(stateDir, Request{Command: &protocol.Command{Schema: protocol.SchemaCommand, Op: protocol.OpRequestGet, RequestRef: snap.RequestRef}})
 	if err != nil || resp.AsError() != nil {
 		t.Fatalf("status: %v / %v", err, resp.AsError())
 	}
+	_ = rep
 
 	go func() {
 		time.Sleep(30 * time.Millisecond)

--- a/internal/remote/protocol/digest_test.go
+++ b/internal/remote/protocol/digest_test.go
@@ -1,0 +1,135 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestCommandDigestIsCanonicalAndStable pins the B13 digest contract: the
+// digest covers the immutable submit command payload (schema, op, request_id,
+// target_id, epoch, not_after, input), is stable across equal commands, and
+// changes when epoch, not_after, or input changes. It must be sha256-prefixed
+// hex and computed over canonical JSON (no insignificant whitespace).
+func TestCommandDigestIsCanonicalAndStable(t *testing.T) {
+	base := &Command{
+		Schema:    SchemaCommand,
+		Op:        OpRequestSubmit,
+		RequestID: "11111111-1111-4111-8111-111111111501",
+		TargetID:  "t_fake1",
+		Epoch:     "e_1",
+		NotAfter:  "2026-09-08T10:02:00Z",
+		Input:     &SubmitInput{Text: "say hi"},
+	}
+	d := CommandDigest(base)
+	if !strings.HasPrefix(d, "sha256:") || len(d) != len("sha256:")+64 {
+		t.Fatalf("digest %q is not sha256 hex", d)
+	}
+	// Stable across equal commands.
+	if got := CommandDigest(base); got != d {
+		t.Fatalf("digest not stable: %q vs %q", got, d)
+	}
+	// Changing the input text changes the digest.
+	changed := *base
+	changed.Input = &SubmitInput{Text: "say bye"}
+	if CommandDigest(&changed) == d {
+		t.Fatal("digest unchanged after input text change")
+	}
+	// Changing the epoch changes the digest (the B13 fix: a retry with a
+	// changed epoch is request_conflict, not a silent dedup).
+	changed = *base
+	changed.Epoch = "e_2"
+	if CommandDigest(&changed) == d {
+		t.Fatal("digest unchanged after epoch change")
+	}
+	// Changing not_after changes the digest.
+	changed = *base
+	changed.NotAfter = "2026-09-08T11:00:00Z"
+	if CommandDigest(&changed) == d {
+		t.Fatal("digest unchanged after not_after change")
+	}
+	// Changing target_id changes the digest.
+	changed = *base
+	changed.TargetID = "t_other"
+	if CommandDigest(&changed) == d {
+		t.Fatal("digest unchanged after target_id change")
+	}
+	// Non-submit ops have no digest.
+	nonSubmit := *base
+	nonSubmit.Op = OpRequestGet
+	nonSubmit.RequestRef = "amqr1_" + strings.Repeat("a", 20)
+	if CommandDigest(&nonSubmit) != "" {
+		t.Fatalf("non-submit op returned a digest: %q", CommandDigest(&nonSubmit))
+	}
+}
+
+// TestCommandDigestCanonicalBytes pins the exact canonical JSON shape so the
+// io lane (endpoint) and any other carrier that builds the bytes themselves
+// agree with CommandDigest. The canonical payload is a JSON object with keys
+// in struct order and no insignificant whitespace.
+func TestCommandDigestCanonicalBytes(t *testing.T) {
+	cmd := &Command{
+		Schema:    SchemaCommand,
+		Op:        OpRequestSubmit,
+		RequestID: "11111111-1111-4111-8111-111111111501",
+		TargetID:  "t_fake1",
+		Epoch:     "e_1",
+		NotAfter:  "2026-09-08T10:02:00Z",
+		Input:     &SubmitInput{Text: "say hi", Busy: BusyQueue, Deliver: DeliverTurn},
+	}
+	// The canonical payload must marshal with keys in the fixed struct order
+	// and no extra whitespace, so re-marshalling is byte-identical.
+	payload := digestPayload{
+		Schema: cmd.Schema, Op: cmd.Op, RequestID: cmd.RequestID,
+		TargetID: cmd.TargetID, Epoch: cmd.Epoch, NotAfter: cmd.NotAfter,
+		Input: cmd.Input,
+	}
+	b1, _ := json.Marshal(payload)
+	b2, _ := json.Marshal(payload)
+	if string(b1) != string(b2) {
+		t.Fatal("canonical payload marshal not deterministic")
+	}
+	// Keys appear in the canonical order.
+	wantOrder := []string{`"schema"`, `"op"`, `"request_id"`, `"target_id"`, `"epoch"`, `"not_after"`, `"input"`}
+	pos := 0
+	for i, k := range wantOrder {
+		idx := strings.Index(string(b1), k)
+		if idx < pos {
+			t.Fatalf("key %s out of canonical order at step %d (idx=%d pos=%d) in %s", k, i, idx, pos, b1)
+		}
+		pos = idx + len(k)
+	}
+}
+
+// TestReplyShape pins the B11 reply-envelope JSON shape: the snapshot is the
+// immutable record revision and the outcome carries the op-specific code, both
+// under their own keys.
+func TestReplyShape(t *testing.T) {
+	rep := Reply{
+		Snapshot: Snapshot{
+			Schema: SchemaRequest, RequestRef: "amqr1_" + strings.Repeat("a", 20),
+			RequestID: "11111111-1111-4111-8111-111111111501",
+			CreatorHost: "hostA", TargetID: "t_fake1", Epoch: "e_1",
+			Revision: 1, State: StateReceived,
+			ObservedAt: "2026-09-08T10:00:00Z",
+		},
+		Outcome: Outcome{Op: OpRequestSubmit, Code: CodeRequestConflict, Message: "input digest mismatch"},
+	}
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, key := range []string{`"snapshot"`, `"outcome"`, `"op"`, `"code"`, `"message"`} {
+		if !strings.Contains(s, key) {
+			t.Fatalf("reply JSON missing %s: %s", key, s)
+		}
+	}
+	// A plain-success outcome omits code/message (omitempty).
+	rep.Outcome = Outcome{Op: OpRequestSubmit}
+	b, _ = json.Marshal(rep)
+	s = string(b)
+	if strings.Contains(s, `"code"`) || strings.Contains(s, `"message"`) {
+		t.Fatalf("success outcome should omit code/message: %s", s)
+	}
+}

--- a/internal/remote/protocol/digest_test.go
+++ b/internal/remote/protocol/digest_test.go
@@ -108,7 +108,7 @@ func TestReplyShape(t *testing.T) {
 	rep := Reply{
 		Snapshot: Snapshot{
 			Schema: SchemaRequest, RequestRef: "amqr1_" + strings.Repeat("a", 20),
-			RequestID: "11111111-1111-4111-8111-111111111501",
+			RequestID:   "11111111-1111-4111-8111-111111111501",
 			CreatorHost: "hostA", TargetID: "t_fake1", Epoch: "e_1",
 			Revision: 1, State: StateReceived,
 			ObservedAt: "2026-09-08T10:00:00Z",

--- a/internal/remote/protocol/protocol.go
+++ b/internal/remote/protocol/protocol.go
@@ -154,6 +154,7 @@ const (
 	CodeAlreadyResolved          Code = "already_resolved"
 	CodeEndpointAlreadyRunning   Code = "endpoint_already_running"
 	CodeEndpointUnreachable      Code = "endpoint_unreachable"
+	CodeStoreClosed              Code = "store_closed"
 )
 
 // CancelDisposition is the recorded outcome of a cancel command.
@@ -307,18 +308,34 @@ func ExitCode(err error) int {
 	if err == nil {
 		return ExitSuccess
 	}
-	var r *Refusal
-	if !errors.As(err, &r) {
-		return ExitError
+	return ExitForCode(RefusalCode(err))
+}
+
+// RefusalCode extracts the Code from a Refusal error, or "" if the error is not
+// a Refusal. It lets callers branch on the refusal code without repeating the
+// errors.As dance.
+func RefusalCode(err error) Code {
+	if err == nil {
+		return ""
 	}
-	switch r.Code {
+	var r *Refusal
+	if errors.As(err, &r) {
+		return r.Code
+	}
+	return ""
+}
+
+// ExitForCode maps a refusal code to the AMQ exit code contract.
+func ExitForCode(code Code) int {
+	switch code {
 	case CodeInvalid:
 		return ExitUsage
 	case CodeNotFound:
 		return ExitNotFound
 	case CodeBusy, CodeUnsupported, CodeUnshared, CodeExpired, CodeStaleEpoch,
 		CodeRequestConflict, CodeStorageFull, CodeAttachmentLost, CodeResultExpired,
-		CodeAlreadyResolved, CodeEndpointAlreadyRunning, CodeEndpointUnreachable:
+		CodeAlreadyResolved, CodeEndpointAlreadyRunning, CodeEndpointUnreachable,
+		CodeStoreClosed:
 		return ExitActionRequired
 	}
 	return ExitError

--- a/internal/remote/protocol/protocol.go
+++ b/internal/remote/protocol/protocol.go
@@ -1,0 +1,576 @@
+// Package protocol defines the AMQ Remote application protocol: the command
+// a client sends to an amq-remote endpoint, the request snapshot the endpoint
+// answers with, and the session projection it advertises. The JSON shapes are
+// frozen in schemas/remote-*-v1.schema.json; this package is the Go reading of
+// those schemas plus the strict decoder every carrier (local IPC, AMQ mailbox,
+// Buzz DM edge) runs before any state changes.
+package protocol
+
+import (
+	"bytes"
+	"encoding/base32"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Schema identifiers. A document with any other value is refused.
+const (
+	SchemaCommand = "amq.remote.command/1"
+	SchemaRequest = "amq.remote.request/1"
+	SchemaSession = "amq.remote.session/1"
+)
+
+// Reference limits from the design. Bounds are enforced before allocation of
+// anything derived from the payload.
+const (
+	MaxCommandBytes = 256 * 1024
+	MaxInputBytes   = 128 * 1024
+	MaxResultBytes  = 512 * 1024
+	MaxOpaqueLen    = 128
+	MaxOptionLen    = 256
+)
+
+// Op is the command discriminator.
+type Op string
+
+// Commands a client may send. The set is closed; view.open and view.close
+// arrive with the terminal backend and are refused until then.
+const (
+	OpRequestSubmit      Op = "request.submit"
+	OpRequestGet         Op = "request.get"
+	OpRequestCancel      Op = "request.cancel"
+	OpSessionList        Op = "session.list"
+	OpSessionInspect     Op = "session.inspect"
+	OpSessionEvents      Op = "session.events"
+	OpInteractionRespond Op = "interaction.respond"
+)
+
+// Busy tells the target what to do when the runtime is already working.
+type Busy string
+
+// Busy policies. The default is reject; queue is an explicit opt-in.
+const (
+	BusyReject Busy = "reject"
+	BusyQueue  Busy = "queue"
+)
+
+// Deliver selects the native delivery mode for a submit.
+type Deliver string
+
+// Delivery modes. turn starts or queues a new top-level turn; steer
+// interleaves into the running turn where the harness supports it.
+const (
+	DeliverTurn  Deliver = "turn"
+	DeliverSteer Deliver = "steer"
+)
+
+// SubmitInput is the work carried by request.submit.
+type SubmitInput struct {
+	Text    string  `json:"text"`
+	Busy    Busy    `json:"busy,omitempty"`
+	Deliver Deliver `json:"deliver,omitempty"`
+}
+
+// Command is the decoded client command. Fields not used by an op are empty.
+type Command struct {
+	Schema        string       `json:"schema"`
+	Op            Op           `json:"op"`
+	RequestID     string       `json:"request_id,omitempty"`
+	RequestRef    string       `json:"request_ref,omitempty"`
+	TargetID      string       `json:"target_id,omitempty"`
+	Epoch         string       `json:"epoch,omitempty"`
+	NotAfter      string       `json:"not_after,omitempty"`
+	Input         *SubmitInput `json:"input,omitempty"`
+	Since         *int64       `json:"since,omitempty"`
+	InteractionID string       `json:"interaction_id,omitempty"`
+	Option        string       `json:"option,omitempty"`
+}
+
+// State is the durable request state.
+type State string
+
+// Request states. See the remote-control ADR for their exact meaning.
+const (
+	StateReceived    State = "received"
+	StateDispatching State = "dispatching"
+	StateRunning     State = "running"
+	StateCompleted   State = "completed"
+	StateFailed      State = "failed"
+	StateCancelled   State = "cancelled"
+	StateRejected    State = "rejected"
+	StateUncertain   State = "uncertain"
+)
+
+// Terminal reports whether no further native evidence can change the state.
+// uncertain is not terminal: later exact evidence may resolve it.
+func (s State) Terminal() bool {
+	switch s {
+	case StateCompleted, StateFailed, StateCancelled, StateRejected:
+		return true
+	}
+	return false
+}
+
+// Code is the typed reason attached to rejected, failed, cancelled and
+// uncertain records, and to command refusals.
+type Code string
+
+// Typed codes. The set is closed so clients can switch on it.
+const (
+	CodeBusy                     Code = "busy"
+	CodeExpired                  Code = "expired"
+	CodeStaleEpoch               Code = "stale_epoch"
+	CodeUnsupported              Code = "unsupported"
+	CodeUnshared                 Code = "unshared"
+	CodeInvalid                  Code = "invalid"
+	CodeRequestConflict          Code = "request_conflict"
+	CodeCancelledBeforeAdmission Code = "cancelled_before_admission"
+	CodeCancelledByRequest       Code = "cancelled_by_request"
+	CodeNativeError              Code = "native_error"
+	CodeStorageFull              Code = "storage_full"
+	CodeAttachmentLost           Code = "attachment_lost"
+	CodeResultExpired            Code = "result_expired"
+	CodeNotFound                 Code = "not_found"
+	CodeAlreadyResolved          Code = "already_resolved"
+	CodeEndpointAlreadyRunning   Code = "endpoint_already_running"
+	CodeEndpointUnreachable      Code = "endpoint_unreachable"
+)
+
+// CancelDisposition is the recorded outcome of a cancel command.
+type CancelDisposition string
+
+// Cancel dispositions. cancel_requested stays until native confirmation.
+const (
+	CancelRequested    CancelDisposition = "cancel_requested"
+	CancelConfirmed    CancelDisposition = "cancelled"
+	CancelNoopTerminal CancelDisposition = "noop_already_terminal"
+	CancelUnsupported  CancelDisposition = "unsupported"
+)
+
+// Cancel records cancellation intent and its disposition.
+type Cancel struct {
+	RequestedAt string            `json:"requested_at,omitempty"`
+	Disposition CancelDisposition `json:"disposition"`
+}
+
+// Interaction is a pending native question or approval.
+type Interaction struct {
+	InteractionID string   `json:"interaction_id"`
+	Kind          string   `json:"kind"`
+	Prompt        string   `json:"prompt,omitempty"`
+	Options       []string `json:"options"`
+	RemoteAnswer  bool     `json:"remote_answer,omitempty"`
+}
+
+// Result is the bounded native outcome kept for remote delivery.
+type Result struct {
+	Text       string `json:"text"`
+	Truncated  bool   `json:"truncated"`
+	StopReason string `json:"stop_reason,omitempty"`
+	Error      string `json:"error,omitempty"`
+	NativeRef  string `json:"native_ref,omitempty"`
+}
+
+// Snapshot is the durable request record and the reply shape for every
+// request.* command. Each published revision is immutable.
+type Snapshot struct {
+	Schema            string       `json:"schema"`
+	RequestRef        string       `json:"request_ref"`
+	RequestID         string       `json:"request_id"`
+	CreatorHost       string       `json:"creator_host"`
+	TargetID          string       `json:"target_id"`
+	Epoch             string       `json:"epoch"`
+	Revision          int64        `json:"revision"`
+	State             State        `json:"state"`
+	Code              Code         `json:"code,omitempty"`
+	InputDigest       string       `json:"input_digest,omitempty"`
+	NotAfter          string       `json:"not_after,omitempty"`
+	NativeRun         *string      `json:"native_run"`
+	LocalIntervention bool         `json:"local_intervention,omitempty"`
+	Cancel            *Cancel      `json:"cancel,omitempty"`
+	Interaction       *Interaction `json:"interaction,omitempty"`
+	Result            *Result      `json:"result,omitempty"`
+	ObservedAt        string       `json:"observed_at"`
+}
+
+// Capabilities is the observed capability projection of one attachment.
+type Capabilities struct {
+	Inspect        bool   `json:"inspect"`
+	Submit         bool   `json:"submit"`
+	CancelRequest  bool   `json:"cancel_request"`
+	AnswerQuestion bool   `json:"answer_question"`
+	ApproveTool    bool   `json:"approve_tool"`
+	Steer          bool   `json:"steer"`
+	Terminal       string `json:"terminal"`
+}
+
+// Evidence names the strongest evidence class an attachment gives.
+type Evidence struct {
+	Submit     string `json:"submit,omitempty"`
+	Completion string `json:"completion,omitempty"`
+}
+
+// Session is the projection of one registered runtime.
+type Session struct {
+	Schema             string       `json:"schema"`
+	TargetID           string       `json:"target_id"`
+	Epoch              string       `json:"epoch"`
+	Harness            string       `json:"harness"`
+	DisplayName        string       `json:"display_name,omitempty"`
+	Host               string       `json:"host,omitempty"`
+	Project            string       `json:"project,omitempty"`
+	Attachment         string       `json:"attachment"`
+	Status             string       `json:"status"`
+	PendingInteraction *string      `json:"pending_interaction,omitempty"`
+	ActiveRequestRef   *string      `json:"active_request_ref,omitempty"`
+	Capabilities       Capabilities `json:"capabilities"`
+	Evidence           *Evidence    `json:"evidence,omitempty"`
+	ObservedAt         string       `json:"observed_at"`
+}
+
+// Refusal is a typed protocol-level refusal. It carries the code a client can
+// switch on and maps to an AMQ exit code through ExitCode.
+type Refusal struct {
+	Code    Code
+	Message string
+}
+
+func (r *Refusal) Error() string {
+	if r.Message == "" {
+		return string(r.Code)
+	}
+	return fmt.Sprintf("%s: %s", r.Code, r.Message)
+}
+
+// Refuse builds a Refusal.
+func Refuse(code Code, format string, args ...any) error {
+	return &Refusal{Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+// Exit codes follow the AMQ contract; see internal/cli/exitcode.go.
+const (
+	ExitSuccess        = 0
+	ExitError          = 1
+	ExitUsage          = 2
+	ExitNotFound       = 3
+	ExitTimeout        = 4
+	ExitActionRequired = 6
+	ExitInterrupted    = 130
+)
+
+// ExitCode maps a command error to the AMQ exit code contract. nil is
+// success. Refusals map by code; any other error is a general error.
+func ExitCode(err error) int {
+	if err == nil {
+		return ExitSuccess
+	}
+	var r *Refusal
+	if !errors.As(err, &r) {
+		return ExitError
+	}
+	switch r.Code {
+	case CodeInvalid:
+		return ExitUsage
+	case CodeNotFound:
+		return ExitNotFound
+	case CodeBusy, CodeUnsupported, CodeUnshared, CodeExpired, CodeStaleEpoch,
+		CodeRequestConflict, CodeStorageFull, CodeAttachmentLost, CodeResultExpired,
+		CodeAlreadyResolved, CodeEndpointAlreadyRunning, CodeEndpointUnreachable:
+		return ExitActionRequired
+	}
+	return ExitError
+}
+
+// ExitForState maps a terminal-or-not snapshot to the exit code `wait` and
+// `status` report. A non-terminal state during a bounded wait is a timeout.
+func ExitForState(s State) int {
+	switch s {
+	case StateCompleted:
+		return ExitSuccess
+	case StateFailed, StateCancelled:
+		return ExitError
+	case StateRejected, StateUncertain:
+		return ExitActionRequired
+	}
+	return ExitTimeout
+}
+
+var (
+	uuidRe   = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	opaqueRe = regexp.MustCompile(`^[A-Za-z0-9_.:-]+$`)
+	refRe    = regexp.MustCompile(`^amqr1_[a-z2-7]{16,200}$`)
+)
+
+// RefPrefix starts every request reference.
+const RefPrefix = "amqr1_"
+
+var refEncoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// EncodeRef builds the opaque request reference for a record. Clients copy
+// it from a receipt; only the endpoint constructs it.
+func EncodeRef(creatorHost, targetID, requestID string) string {
+	raw := strings.Join([]string{creatorHost, targetID, requestID}, "\x00")
+	return RefPrefix + strings.ToLower(refEncoding.EncodeToString([]byte(raw)))
+}
+
+// DecodeRef recovers the record key from a reference. It identifies a record;
+// it never changes the peer's authority or selects a filesystem path.
+func DecodeRef(ref string) (creatorHost, targetID, requestID string, err error) {
+	if !refRe.MatchString(ref) {
+		return "", "", "", Refuse(CodeInvalid, "malformed request_ref")
+	}
+	raw, err := refEncoding.DecodeString(strings.ToUpper(strings.TrimPrefix(ref, RefPrefix)))
+	if err != nil {
+		return "", "", "", Refuse(CodeInvalid, "undecodable request_ref")
+	}
+	parts := strings.Split(string(raw), "\x00")
+	if len(parts) != 3 || !validOpaque(parts[0]) || !validOpaque(parts[1]) || !uuidRe.MatchString(parts[2]) {
+		return "", "", "", Refuse(CodeInvalid, "request_ref does not name a record")
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+func validOpaque(s string) bool {
+	return s != "" && len(s) <= MaxOpaqueLen && opaqueRe.MatchString(s)
+}
+
+// DecodeCommand strictly decodes one command document. It enforces the size
+// bound before decoding, rejects unknown and duplicate keys, and validates
+// every field the op requires. The returned Command is safe to act on.
+func DecodeCommand(data []byte) (*Command, error) {
+	if len(data) > MaxCommandBytes {
+		return nil, Refuse(CodeInvalid, "command exceeds %d bytes", MaxCommandBytes)
+	}
+	if err := rejectDuplicateKeys(data); err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var c Command
+	if err := dec.Decode(&c); err != nil {
+		return nil, Refuse(CodeInvalid, "malformed command: %v", err)
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, Refuse(CodeInvalid, "trailing data after command")
+	}
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// Validate checks the op-specific contract. It is exported so carriers that
+// build a Command in memory (the Buzz DM edge, the CLI) share one rule set.
+func (c *Command) Validate() error {
+	if c.Schema != SchemaCommand {
+		return Refuse(CodeInvalid, "schema must be %s", SchemaCommand)
+	}
+	switch c.Op {
+	case OpRequestSubmit:
+		if err := requireFields(c, "request_id", "target_id", "epoch", "not_after", "input"); err != nil {
+			return err
+		}
+		if err := forbidFields(c, "request_ref", "since", "interaction_id", "option"); err != nil {
+			return err
+		}
+		if c.Input.Text == "" || len(c.Input.Text) > MaxInputBytes {
+			return Refuse(CodeInvalid, "input.text must be 1..%d bytes", MaxInputBytes)
+		}
+		switch c.Input.Busy {
+		case "", BusyReject, BusyQueue:
+		default:
+			return Refuse(CodeInvalid, "input.busy must be reject or queue")
+		}
+		switch c.Input.Deliver {
+		case "", DeliverTurn, DeliverSteer:
+		default:
+			return Refuse(CodeInvalid, "input.deliver must be turn or steer")
+		}
+	case OpRequestGet:
+		if err := requireFields(c, "request_ref"); err != nil {
+			return err
+		}
+		if err := forbidFields(c, "request_id", "target_id", "epoch", "not_after", "input", "since", "interaction_id", "option"); err != nil {
+			return err
+		}
+	case OpRequestCancel:
+		if err := requireFields(c, "request_ref", "target_id", "epoch", "not_after"); err != nil {
+			return err
+		}
+		if err := forbidFields(c, "request_id", "input", "since", "interaction_id", "option"); err != nil {
+			return err
+		}
+	case OpSessionList:
+		if err := forbidFields(c, "request_id", "request_ref", "target_id", "epoch", "not_after", "input", "since", "interaction_id", "option"); err != nil {
+			return err
+		}
+	case OpSessionInspect:
+		if err := requireFields(c, "target_id"); err != nil {
+			return err
+		}
+		if err := forbidFields(c, "request_id", "request_ref", "epoch", "not_after", "input", "since", "interaction_id", "option"); err != nil {
+			return err
+		}
+	case OpSessionEvents:
+		if err := requireFields(c, "target_id"); err != nil {
+			return err
+		}
+		if err := forbidFields(c, "request_id", "request_ref", "epoch", "not_after", "input", "interaction_id", "option"); err != nil {
+			return err
+		}
+		if c.Since != nil && *c.Since < 0 {
+			return Refuse(CodeInvalid, "since must be >= 0")
+		}
+	case OpInteractionRespond:
+		if err := requireFields(c, "request_ref", "target_id", "epoch", "interaction_id", "option"); err != nil {
+			return err
+		}
+		if err := forbidFields(c, "request_id", "not_after", "input", "since"); err != nil {
+			return err
+		}
+		if len(c.Option) > MaxOptionLen {
+			return Refuse(CodeInvalid, "option exceeds %d bytes", MaxOptionLen)
+		}
+	default:
+		return Refuse(CodeInvalid, "unknown op %q", string(c.Op))
+	}
+	return nil
+}
+
+func requireFields(c *Command, names ...string) error {
+	for _, n := range names {
+		switch n {
+		case "request_id":
+			if !uuidRe.MatchString(c.RequestID) {
+				return Refuse(CodeInvalid, "request_id must be a lowercase UUID")
+			}
+		case "request_ref":
+			if _, _, _, err := DecodeRef(c.RequestRef); err != nil {
+				return err
+			}
+		case "target_id":
+			if !validOpaque(c.TargetID) {
+				return Refuse(CodeInvalid, "target_id is required and opaque")
+			}
+		case "epoch":
+			if !validOpaque(c.Epoch) {
+				return Refuse(CodeInvalid, "epoch is required and opaque")
+			}
+		case "interaction_id":
+			if !validOpaque(c.InteractionID) {
+				return Refuse(CodeInvalid, "interaction_id is required and opaque")
+			}
+		case "option":
+			if c.Option == "" {
+				return Refuse(CodeInvalid, "option is required")
+			}
+		case "not_after":
+			if _, err := ParseTime(c.NotAfter); err != nil {
+				return Refuse(CodeInvalid, "not_after must be RFC 3339")
+			}
+		case "input":
+			if c.Input == nil {
+				return Refuse(CodeInvalid, "input is required")
+			}
+		}
+	}
+	return nil
+}
+
+func forbidFields(c *Command, names ...string) error {
+	for _, n := range names {
+		present := false
+		switch n {
+		case "request_id":
+			present = c.RequestID != ""
+		case "request_ref":
+			present = c.RequestRef != ""
+		case "target_id":
+			present = c.TargetID != ""
+		case "epoch":
+			present = c.Epoch != ""
+		case "not_after":
+			present = c.NotAfter != ""
+		case "input":
+			present = c.Input != nil
+		case "since":
+			present = c.Since != nil
+		case "interaction_id":
+			present = c.InteractionID != ""
+		case "option":
+			present = c.Option != ""
+		}
+		if present {
+			return Refuse(CodeInvalid, "%s is not allowed for %s", n, string(c.Op))
+		}
+	}
+	return nil
+}
+
+// ParseTime parses an RFC 3339 timestamp as the protocol requires.
+func ParseTime(s string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, s)
+}
+
+// FormatTime renders a timestamp in the one form the protocol emits.
+func FormatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// rejectDuplicateKeys walks the token stream and refuses any object with a
+// repeated key. encoding/json keeps the last value silently, which would let
+// two carriers disagree about the same bytes.
+func rejectDuplicateKeys(data []byte) error {
+	type frame struct {
+		object    bool
+		keys      map[string]struct{}
+		expectKey bool
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var stack []*frame
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return Refuse(CodeInvalid, "malformed command: %v", err)
+		}
+		if d, ok := tok.(json.Delim); ok {
+			switch d {
+			case '{':
+				stack = append(stack, &frame{object: true, keys: map[string]struct{}{}, expectKey: true})
+			case '[':
+				stack = append(stack, &frame{})
+			case '}', ']':
+				stack = stack[:len(stack)-1]
+				if len(stack) > 0 && stack[len(stack)-1].object {
+					stack[len(stack)-1].expectKey = true
+				}
+			}
+			continue
+		}
+		if len(stack) == 0 {
+			continue
+		}
+		top := stack[len(stack)-1]
+		if !top.object {
+			continue
+		}
+		if top.expectKey {
+			key, _ := tok.(string)
+			if _, dup := top.keys[key]; dup {
+				return Refuse(CodeInvalid, "duplicate key %q", key)
+			}
+			top.keys[key] = struct{}{}
+			top.expectKey = false
+			continue
+		}
+		top.expectKey = true
+	}
+}

--- a/internal/remote/protocol/protocol.go
+++ b/internal/remote/protocol/protocol.go
@@ -222,7 +222,7 @@ type Snapshot struct {
 // command rather than regenerating a different one.
 type Outcome struct {
 	Op          Op                `json:"op"`
-	Code        Code              `json:"code,omitempty"`        // request_conflict, already_resolved, "" on plain success
+	Code        Code              `json:"code,omitempty"` // request_conflict, already_resolved, "" on plain success
 	Message     string            `json:"message,omitempty"`
 	Disposition CancelDisposition `json:"disposition,omitempty"` // cancel replies only
 }
@@ -403,10 +403,11 @@ const digestPrefix = "sha256:"
 // client's command.
 //
 // Canonical byte construction (for carriers that build the bytes themselves):
-//   json.Marshal of digestPayload{Schema,Op,RequestID,TargetID,Epoch,NotAfter,Input}
-//   with struct field order fixed (Go json emits in struct order, which is the
-//   canonical order below) and no extra whitespace, then sha256 hex with the
-//   "sha256:" prefix.
+//
+//	json.Marshal of digestPayload{Schema,Op,RequestID,TargetID,Epoch,NotAfter,Input}
+//	with struct field order fixed (Go json emits in struct order, which is the
+//	canonical order below) and no extra whitespace, then sha256 hex with the
+//	"sha256:" prefix.
 func CommandDigest(cmd *Command) string {
 	if cmd == nil || cmd.Op != OpRequestSubmit {
 		return ""

--- a/internal/remote/protocol/protocol.go
+++ b/internal/remote/protocol/protocol.go
@@ -8,7 +8,9 @@ package protocol
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base32"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -210,6 +212,29 @@ type Snapshot struct {
 	ObservedAt        string       `json:"observed_at"`
 }
 
+// Outcome is the per-COMMAND result, distinct from the immutable per-revision
+// Snapshot. It carries the op-specific disposition that does NOT create a new
+// revision: a request_conflict, an already-resolved interaction, or a cancel
+// that hit a terminal record. Pairing the unchanged snapshot with an Outcome
+// (instead of copy-mutating the snapshot's Code/Cancel) keeps the invariant
+// that equal revisions are byte-identical, so retries recover the original
+// command rather than regenerating a different one.
+type Outcome struct {
+	Op          Op                `json:"op"`
+	Code        Code              `json:"code,omitempty"`        // request_conflict, already_resolved, "" on plain success
+	Message     string            `json:"message,omitempty"`
+	Disposition CancelDisposition `json:"disposition,omitempty"` // cancel replies only
+}
+
+// Reply pairs the current immutable record revision with the operation
+// outcome. The Snapshot is byte-identical to a stored revision and is NEVER
+// mutated for op-specific reasons; every op-specific signal lives in Outcome.
+// Carriers and the CLI map exit codes from Outcome.Code.
+type Reply struct {
+	Snapshot Snapshot `json:"snapshot"`
+	Outcome  Outcome  `json:"outcome"`
+}
+
 // Capabilities is the observed capability projection of one attachment.
 type Capabilities struct {
 	Inspect        bool   `json:"inspect"`
@@ -349,6 +374,58 @@ func DecodeRef(ref string) (creatorHost, targetID, requestID string, err error) 
 
 func validOpaque(s string) bool {
 	return s != "" && len(s) <= MaxOpaqueLen && opaqueRe.MatchString(s)
+}
+
+// digestPrefix is the algorithm tag every request input_digest carries.
+const digestPrefix = "sha256:"
+
+// CommandDigest is the digest of the immutable submit command payload, over
+// exactly {schema, op, request_id, target_id, epoch, not_after, input}. It is
+// canonical JSON: object keys sorted, no insignificant whitespace, so every
+// carrier agrees on the bytes. A retry with a changed epoch or not_after (or
+// input) yields a different digest and is request_conflict; a retry that
+// recovers the original command bytes yields the same digest. The digest
+// excludes revision/state/result — those are server-derived, not part of the
+// client's command.
+//
+// Canonical byte construction (for carriers that build the bytes themselves):
+//   json.Marshal of digestPayload{Schema,Op,RequestID,TargetID,Epoch,NotAfter,Input}
+//   with struct field order fixed (Go json emits in struct order, which is the
+//   canonical order below) and no extra whitespace, then sha256 hex with the
+//   "sha256:" prefix.
+func CommandDigest(cmd *Command) string {
+	if cmd == nil || cmd.Op != OpRequestSubmit {
+		return ""
+	}
+	payload := digestPayload{
+		Schema:    cmd.Schema,
+		Op:        cmd.Op,
+		RequestID: cmd.RequestID,
+		TargetID:  cmd.TargetID,
+		Epoch:     cmd.Epoch,
+		NotAfter:  cmd.NotAfter,
+		Input:     cmd.Input,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return digestPrefix + hex.EncodeToString(sum[:])
+}
+
+// digestPayload is the stable canonical shape for CommandDigest. Field order
+// is the canonical key order; do not reorder without bumping the schema and
+// migrating records. omitempty is intentionally absent on submit-required
+// fields so the canonical shape is identical for every valid submit.
+type digestPayload struct {
+	Schema    string       `json:"schema"`
+	Op        Op           `json:"op"`
+	RequestID string       `json:"request_id"`
+	TargetID  string       `json:"target_id"`
+	Epoch     string       `json:"epoch"`
+	NotAfter  string       `json:"not_after"`
+	Input     *SubmitInput `json:"input"`
 }
 
 // DecodeCommand strictly decodes one command document. It enforces the size

--- a/internal/remote/protocol/protocol.go
+++ b/internal/remote/protocol/protocol.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Schema identifiers. A document with any other value is refused.
@@ -26,13 +27,24 @@ const (
 )
 
 // Reference limits from the design. Bounds are enforced before allocation of
-// anything derived from the payload.
+// anything derived from the payload. The byte budgets are coherent by
+// construction: a record always holds one max-size result plus the retained
+// input and record overhead, so MaxRecordBytes >= MaxResultBytes + MaxInputBytes
+// + headroom. Truncation is UTF-8-rune safe and never drops the native
+// reference, so a truncated answer stays locatable on the target host.
 const (
 	MaxCommandBytes = 256 * 1024
 	MaxInputBytes   = 128 * 1024
 	MaxResultBytes  = 512 * 1024
-	MaxOpaqueLen    = 128
-	MaxOptionLen    = 256
+	// MaxRecordBytes bounds one durable request record on disk and on the wire.
+	// It is the protocol result bound plus the retained input bound plus fixed
+	// headroom for the snapshot, interaction, cancel and bookkeeping fields, so
+	// a record carrying a full-size result never overflows the store. The store
+	// and the IPC layer share this single source of truth.
+	MaxRecordOverhead = 64 * 1024
+	MaxRecordBytes    = MaxResultBytes + MaxInputBytes + MaxRecordOverhead
+	MaxOpaqueLen      = 128
+	MaxOptionLen      = 256
 )
 
 // Op is the command discriminator.
@@ -515,6 +527,27 @@ func forbidFields(c *Command, names ...string) error {
 // ParseTime parses an RFC 3339 timestamp as the protocol requires.
 func ParseTime(s string) (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, s)
+}
+
+// TruncateText bounds text to at most max bytes on a UTF-8 rune boundary, so
+// no multi-byte rune is split. It reports whether truncation happened. A
+// truncated result must keep its native reference so the full text stays
+// locatable on the target host; callers set Result.Truncated and keep
+// Result.NativeRef rather than dropping them.
+func TruncateText(text string, max int) (string, bool) {
+	if len(text) <= max {
+		return text, false
+	}
+	// Step back to the last rune start at or before max bytes.
+	end := max
+	for end > 0 && !utf8.RuneStart(text[end]) {
+		end--
+	}
+	// If the byte at end is not itself a valid rune start, back up until it is.
+	for end > 0 && !utf8.RuneStart(text[end]) {
+		end--
+	}
+	return text[:end], true
 }
 
 // FormatTime renders a timestamp in the one form the protocol emits.

--- a/internal/remote/protocol/protocol.go
+++ b/internal/remote/protocol/protocol.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -337,14 +338,27 @@ func ExitForState(s State) int {
 	return ExitTimeout
 }
 
+// uuidLen is the fixed length of a lowercase UUID request_id.
+const uuidLen = 36
+
 var (
 	uuidRe   = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 	opaqueRe = regexp.MustCompile(`^[A-Za-z0-9_.:-]+$`)
-	refRe    = regexp.MustCompile(`^amqr1_[a-z2-7]{16,200}$`)
 )
 
 // RefPrefix starts every request reference.
 const RefPrefix = "amqr1_"
+
+// MaxRefLen is the maximum length of a request reference. It is derived from
+// the opaque-segment bound (creator_host and target_id, each MaxOpaqueLen) plus
+// the fixed UUID request_id and the two NUL separators, base32-encoded without
+// padding (8 chars per 5 bytes, rounded up), plus the RefPrefix. The regex and
+// the schemas use this as the upper bound so a receipt for a max-size key
+// always round-trips (BK6: the previous 200-char cap rejected valid max-size
+// refs of up to 477 chars).
+const MaxRefLen = len(RefPrefix) + (MaxOpaqueLen*2+uuidLen+2+4)/5*8
+
+var refRe = regexp.MustCompile(`^amqr1_[a-z2-7]{16,` + strconv.Itoa(MaxRefLen) + `}$`)
 
 var refEncoding = base32.StdEncoding.WithPadding(base32.NoPadding)
 

--- a/internal/remote/protocol/protocol_test.go
+++ b/internal/remote/protocol/protocol_test.go
@@ -1,0 +1,125 @@
+package protocol
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// corpusFile is the shared contract corpus every remote component consumes.
+const corpusFile = "../../../testdata/remote/corpus.json"
+
+type corpus struct {
+	Defaults struct {
+		TargetID    string `json:"target_id"`
+		Epoch       string `json:"epoch"`
+		CreatorHost string `json:"creator_host"`
+		NotAfter    string `json:"not_after"`
+	} `json:"defaults"`
+	Fixtures []struct {
+		ID    string           `json:"id"`
+		Steps []map[string]any `json:"steps"`
+	} `json:"fixtures"`
+}
+
+// TestDecodeCorpusCommands is the happy path: every client command in the
+// corpus, once the fixture defaults are filled in, decodes without error.
+func TestDecodeCorpusCommands(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Clean(corpusFile))
+	if err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	var c corpus
+	if err := json.Unmarshal(raw, &c); err != nil {
+		t.Fatalf("parse corpus: %v", err)
+	}
+	seen := 0
+	for _, f := range c.Fixtures {
+		for i, step := range f.Steps {
+			raw, ok := step["client"].(map[string]any)
+			if !ok {
+				continue
+			}
+			cmd := map[string]any{"schema": SchemaCommand}
+			for k, v := range raw {
+				cmd[k] = v
+			}
+			host := c.Defaults.CreatorHost
+			if h, ok := cmd["creator_host"].(string); ok {
+				host = h
+				delete(cmd, "creator_host")
+			}
+			if id, ok := cmd["request_ref_for"].(string); ok {
+				cmd["request_ref"] = EncodeRef(host, c.Defaults.TargetID, id)
+				delete(cmd, "request_ref_for")
+			}
+			op := Op(cmd["op"].(string))
+			switch op {
+			case OpRequestSubmit, OpRequestCancel, OpInteractionRespond:
+				setDefault(cmd, "target_id", c.Defaults.TargetID)
+				setDefault(cmd, "epoch", c.Defaults.Epoch)
+				if op != OpInteractionRespond {
+					setDefault(cmd, "not_after", c.Defaults.NotAfter)
+				}
+			case OpSessionInspect, OpSessionEvents:
+				setDefault(cmd, "target_id", c.Defaults.TargetID)
+			}
+			data, err := json.Marshal(cmd)
+			if err != nil {
+				t.Fatalf("%s step %d: marshal: %v", f.ID, i, err)
+			}
+			decoded, err := DecodeCommand(data)
+			if err != nil {
+				t.Fatalf("%s step %d: decode %s: %v", f.ID, i, data, err)
+			}
+			if decoded.Op != op {
+				t.Fatalf("%s step %d: op %q != %q", f.ID, i, decoded.Op, op)
+			}
+			seen++
+		}
+	}
+	if seen < 20 {
+		t.Fatalf("corpus exercised only %d client commands", seen)
+	}
+}
+
+func setDefault(m map[string]any, key, value string) {
+	if _, ok := m[key]; !ok {
+		m[key] = value
+	}
+}
+
+func TestRequestRefRoundTrip(t *testing.T) {
+	ref := EncodeRef("hostA", "t_fake1", "11111111-1111-4111-8111-111111111101")
+	if !strings.HasPrefix(ref, RefPrefix) {
+		t.Fatalf("ref %q lacks prefix", ref)
+	}
+	host, target, id, err := DecodeRef(ref)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if host != "hostA" || target != "t_fake1" || id != "11111111-1111-4111-8111-111111111101" {
+		t.Fatalf("round trip mismatch: %s %s %s", host, target, id)
+	}
+}
+
+// TestDecodeRefusesDuplicateAndUnknownKeys pins the strictness the design
+// requires: two carriers must never disagree about the same bytes.
+func TestDecodeRefusesDuplicateAndUnknownKeys(t *testing.T) {
+	base := `{"schema":"amq.remote.command/1","op":"session.list"`
+	for name, doc := range map[string]string{
+		"duplicate": base + `,"op":"session.list"}`,
+		"unknown":   base + `,"extra":1}`,
+		"trailing":  base + `}{}`,
+	} {
+		_, err := DecodeCommand([]byte(doc))
+		if ExitCode(err) != ExitUsage {
+			t.Fatalf("%s: want usage refusal, got %v", name, err)
+		}
+	}
+	if _, err := DecodeCommand([]byte(base + "}")); err != nil {
+		t.Fatalf("clean document refused: %v", err)
+	}
+}

--- a/internal/remote/protocol/ref_bound_test.go
+++ b/internal/remote/protocol/ref_bound_test.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRefBoundFitsMaxSizeKey pins BK6: a request reference built from the
+// maximum opaque-segment lengths (creator_host and target_id each MaxOpaqueLen,
+// plus a fixed-length UUID) must match the ref regex and round-trip through
+// DecodeRef. The previous 200-char cap rejected these valid max-size refs
+// (up to 477 chars), so a receipt for a max-size key could not be reused.
+func TestRefBoundFitsMaxSizeKey(t *testing.T) {
+	host := strings.Repeat("a", MaxOpaqueLen)
+	tgt := strings.Repeat("b", MaxOpaqueLen)
+	id := "11111111-1111-4111-8111-111111111501"
+	ref := EncodeRef(host, tgt, id)
+	if uint(len(ref)) > uint(MaxRefLen) {
+		t.Fatalf("max-size ref len %d exceeds MaxRefLen %d", len(ref), MaxRefLen)
+	}
+	if !refRe.MatchString(ref) {
+		t.Fatalf("max-size ref (len %d) does not match refRe (cap %d)", len(ref), MaxRefLen)
+	}
+	gotHost, gotTgt, gotID, err := DecodeRef(ref)
+	if err != nil {
+		t.Fatalf("max-size ref did not decode: %v", err)
+	}
+	if gotHost != host || gotTgt != tgt || gotID != id {
+		t.Fatalf("round-trip mismatch: %s %s %s", gotHost, gotTgt, gotID)
+	}
+}
+
+// TestRefBoundRejectsOverlong rejects a ref whose base32 body exceeds MaxRefLen
+// (a forged or corrupted reference), so the bound is enforced both ways.
+func TestRefBoundRejectsOverlong(t *testing.T) {
+	overlong := RefPrefix + strings.Repeat("a", MaxRefLen+1)
+	if refRe.MatchString(overlong) {
+		t.Fatal("overlong ref matched refRe")
+	}
+}

--- a/internal/remote/protocol/schema_test.go
+++ b/internal/remote/protocol/schema_test.go
@@ -30,8 +30,8 @@ func compileSchema(t *testing.T, name string) *jsonschema.Schema {
 
 // corpusFixture is the slice of the shared corpus the schema test consumes.
 type corpusFixture struct {
-	ID    string             `json:"id"`
-	Steps []corpusStep       `json:"steps"`
+	ID    string       `json:"id"`
+	Steps []corpusStep `json:"steps"`
 }
 type corpusStep struct {
 	Client map[string]any `json:"client,omitempty"`
@@ -47,8 +47,8 @@ func loadCorpus(t *testing.T) (defaults map[string]string, fixtures []corpusFixt
 		t.Fatalf("read corpus: %v", err)
 	}
 	var c struct {
-		Defaults  map[string]string `json:"defaults"`
-		Fixtures  []corpusFixture   `json:"fixtures"`
+		Defaults map[string]string `json:"defaults"`
+		Fixtures []corpusFixture   `json:"fixtures"`
 	}
 	if err := json.Unmarshal(raw, &c); err != nil {
 		t.Fatalf("parse corpus: %v", err)
@@ -137,7 +137,7 @@ func TestRequestSnapshotsValidateAgainstSchema(t *testing.T) {
 			"schema": SchemaRequest, "request_ref": ref, "request_id": "11111111-1111-4111-8111-111111111101",
 			"creator_host": "hostA", "target_id": "t_fake1", "epoch": "e_1", "revision": 4,
 			"state": "completed", "native_run": "run_1",
-			"result": map[string]any{"text": "hi", "truncated": false},
+			"result":      map[string]any{"text": "hi", "truncated": false},
 			"observed_at": "2026-09-01T00:00:00Z",
 		}},
 		{"completed-compacted", map[string]any{

--- a/internal/remote/protocol/schema_test.go
+++ b/internal/remote/protocol/schema_test.go
@@ -1,0 +1,245 @@
+package protocol
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// schemaDir is the repository schemas directory, resolved from the package
+// source directory (internal/remote/protocol -> ../../../schemas), matching the
+// corpusFile relative path used by the other tests in this package.
+var schemaDir = filepath.Clean(filepath.Join("..", "..", "..", "schemas"))
+
+// compileSchema compiles one of the frozen v1 schemas. The default file loader
+// resolves the schema's internal #/$defs refs; AddResource is not needed because
+// the schemas are self-contained.
+func compileSchema(t *testing.T, name string) *jsonschema.Schema {
+	t.Helper()
+	c := jsonschema.NewCompiler()
+	sch, err := c.Compile(filepath.Join(schemaDir, name))
+	if err != nil {
+		t.Fatalf("compile %s: %v", name, err)
+	}
+	return sch
+}
+
+// corpusFixture is the slice of the shared corpus the schema test consumes.
+type corpusFixture struct {
+	ID    string             `json:"id"`
+	Steps []corpusStep       `json:"steps"`
+}
+type corpusStep struct {
+	Client map[string]any `json:"client,omitempty"`
+	Reply  map[string]any `json:"reply,omitempty"`
+	Expect map[string]any `json:"expect,omitempty"`
+}
+
+// loadCorpus reads the shared contract corpus and its defaults.
+func loadCorpus(t *testing.T) (defaults map[string]string, fixtures []corpusFixture) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(corpusFile))
+	if err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	var c struct {
+		Defaults  map[string]string `json:"defaults"`
+		Fixtures  []corpusFixture   `json:"fixtures"`
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		t.Fatalf("parse corpus: %v", err)
+	}
+	return c.Defaults, c.Fixtures
+}
+
+// fillCommand applies the corpus defaults to one client command the same way
+// TestDecodeCorpusCommands does, so the document is a complete wire command
+// ready for schema validation (not just Go decoding).
+func fillCommand(cmd map[string]any, defaults map[string]string) map[string]any {
+	out := map[string]any{"schema": SchemaCommand}
+	for k, v := range cmd {
+		out[k] = v
+	}
+	host := defaults["creator_host"]
+	if h, ok := out["creator_host"].(string); ok {
+		host = h
+		delete(out, "creator_host")
+	}
+	if id, ok := out["request_ref_for"].(string); ok {
+		out["request_ref"] = EncodeRef(host, defaults["target_id"], id)
+		delete(out, "request_ref_for")
+	}
+	op := Op(out["op"].(string))
+	switch op {
+	case OpRequestSubmit, OpRequestCancel, OpInteractionRespond:
+		setDefault(out, "target_id", defaults["target_id"])
+		setDefault(out, "epoch", defaults["epoch"])
+		if op != OpInteractionRespond {
+			setDefault(out, "not_after", defaults["not_after"])
+		}
+	case OpSessionInspect, OpSessionEvents:
+		setDefault(out, "target_id", defaults["target_id"])
+	}
+	return out
+}
+
+// TestCorpusCommandsValidateAgainstSchema is the B12 guard: every client
+// command in the shared corpus, once defaults are filled, validates against
+// schemas/remote-command-v1.schema.json. Before the oneOf-branch schema fix
+// this was 0/34 because each branch required `schema` but did not list it as a
+// property under additionalProperties:false.
+func TestCorpusCommandsValidateAgainstSchema(t *testing.T) {
+	defaults, fixtures := loadCorpus(t)
+	sch := compileSchema(t, "remote-command-v1.schema.json")
+	seen := 0
+	for _, f := range fixtures {
+		for i, step := range f.Steps {
+			if step.Client == nil {
+				continue
+			}
+			cmd := fillCommand(step.Client, defaults)
+			if err := sch.Validate(cmd); err != nil {
+				t.Fatalf("%s step %d: command does not validate against schema: %v\n%s",
+					f.ID, i, err, mustJSON(cmd))
+			}
+			seen++
+		}
+	}
+	if seen < 20 {
+		t.Fatalf("corpus exercised only %d client commands", seen)
+	}
+	t.Logf("validated %d corpus commands against remote-command-v1.schema.json", seen)
+}
+
+// TestRequestSnapshotsValidateAgainstSchema covers the request-snapshot schema:
+// a full completed record, the compacted-completed tombstone (completed with
+// result_expired code and no result), and a plain running record all validate.
+// The compacted variant is the B12 addition: a tombstoned completed record
+// keeps state=completed + code=result_expired instead of carrying a result.
+func TestRequestSnapshotsValidateAgainstSchema(t *testing.T) {
+	sch := compileSchema(t, "remote-request-v1.schema.json")
+	ref := EncodeRef("hostA", "t_fake1", "11111111-1111-4111-8111-111111111101")
+	digest := "sha256:" + strings.Repeat("a", 64)
+	cases := []struct {
+		name string
+		doc  map[string]any
+	}{
+		{"running", map[string]any{
+			"schema": SchemaRequest, "request_ref": ref, "request_id": "11111111-1111-4111-8111-111111111101",
+			"creator_host": "hostA", "target_id": "t_fake1", "epoch": "e_1", "revision": 3,
+			"state": "running", "native_run": "run_1", "observed_at": "2026-09-01T00:00:00Z",
+		}},
+		{"completed-full", map[string]any{
+			"schema": SchemaRequest, "request_ref": ref, "request_id": "11111111-1111-4111-8111-111111111101",
+			"creator_host": "hostA", "target_id": "t_fake1", "epoch": "e_1", "revision": 4,
+			"state": "completed", "native_run": "run_1",
+			"result": map[string]any{"text": "hi", "truncated": false},
+			"observed_at": "2026-09-01T00:00:00Z",
+		}},
+		{"completed-compacted", map[string]any{
+			"schema": SchemaRequest, "request_ref": ref, "request_id": "11111111-1111-4111-8111-111111111101",
+			"creator_host": "hostA", "target_id": "t_fake1", "epoch": "e_1", "revision": 5,
+			"state": "completed", "code": "result_expired", "input_digest": digest,
+			"observed_at": "2026-09-01T00:00:00Z",
+		}},
+		{"failed", map[string]any{
+			"schema": SchemaRequest, "request_ref": ref, "request_id": "11111111-1111-4111-8111-111111111101",
+			"creator_host": "hostA", "target_id": "t_fake1", "epoch": "e_1", "revision": 4,
+			"state": "failed", "code": "native_error", "native_run": "run_1",
+			"observed_at": "2026-09-01T00:00:00Z",
+		}},
+	}
+	for _, c := range cases {
+		if err := sch.Validate(c.doc); err != nil {
+			t.Fatalf("%s: snapshot does not validate: %v\n%s", c.name, err, mustJSON(c.doc))
+		}
+	}
+
+	// A compacted completed record carrying the WRONG code must be rejected:
+	// the only code admitted on a completed tombstone is result_expired.
+	bad := map[string]any{
+		"schema": SchemaRequest, "request_ref": ref, "request_id": "11111111-1111-4111-8111-111111111101",
+		"creator_host": "hostA", "target_id": "t_fake1", "epoch": "e_1", "revision": 5,
+		"state": "completed", "code": "native_error", "input_digest": digest,
+		"observed_at": "2026-09-01T00:00:00Z",
+	}
+	if err := sch.Validate(bad); err == nil {
+		t.Fatalf("completed tombstone with non-result_expired code was accepted")
+	}
+}
+
+// TestTruncateTextIsUTF8Safe pins the B08 truncation contract: the result is at
+// most max bytes, no multi-byte rune is split, and truncation is reported only
+// when the input exceeded the bound.
+func TestTruncateTextIsUTF8Safe(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+	}{
+		{"under-limit", "abc", 10},
+		{"exact-limit", "abc", 3},
+		{"ascii-trim", "abcdef", 3},
+		{"rune-split-mid", "héllo", 2}, // é is 2 bytes; max=2 lands mid-rune
+		{"rune-split-after", "héllo", 3},
+	}
+	for _, c := range cases {
+		got, trunc := TruncateText(c.in, c.max)
+		if len(got) > c.max {
+			t.Fatalf("%s: result %q (%d bytes) exceeds max %d", c.name, got, len(got), c.max)
+		}
+		if !utf8ValidString(got) {
+			t.Fatalf("%s: result %q is not valid UTF-8", c.name, got)
+		}
+		wantTrunc := len(c.in) > c.max
+		if trunc != wantTrunc {
+			t.Fatalf("%s: trunc=%v want=%v", c.name, trunc, wantTrunc)
+		}
+	}
+	// Large input with a trailing multi-byte rune split at the boundary.
+	big := strings.Repeat("x", MaxResultBytes-1) + "é" // é is 2 bytes; total = MaxResultBytes+1
+	got, trunc := TruncateText(big, MaxResultBytes)
+	if len(got) > MaxResultBytes || !utf8ValidString(got) || !trunc {
+		t.Fatalf("large rune-split: len=%d valid=%v trunc=%v", len(got), utf8ValidString(got), trunc)
+	}
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+// utf8ValidString mirrors unicode/utf8.ValidString without importing the
+// package here (the protocol package keeps a minimal test-only helper).
+func utf8ValidString(s string) bool {
+	for i := 0; i < len(s); {
+		c := s[i]
+		var size int
+		switch {
+		case c < 0x80:
+			size = 1
+		case c&0xE0 == 0xC0:
+			size = 2
+		case c&0xF0 == 0xE0:
+			size = 3
+		case c&0xF8 == 0xF0:
+			size = 4
+		default:
+			return false
+		}
+		if i+size > len(s) {
+			return false
+		}
+		for j := 1; j < size; j++ {
+			if s[i+j]&0xC0 != 0x80 {
+				return false
+			}
+		}
+		i += size
+	}
+	return true
+}

--- a/internal/remote/requests/lock_other.go
+++ b/internal/remote/requests/lock_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package requests
+
+import "github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+
+type ownerLock struct{}
+
+func acquireOwnerLock(path string) (*ownerLock, error) {
+	return nil, protocol.Refuse(protocol.CodeUnsupported, "the request store needs a unix file lock; %s is not supported on this platform", path)
+}
+
+func (l *ownerLock) release() error { return nil }
+
+func isNoSpace(error) bool { return false }

--- a/internal/remote/requests/lock_unix.go
+++ b/internal/remote/requests/lock_unix.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package requests
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+)
+
+// ownerLock is the process-wide single-writer lock. It is an advisory flock
+// held for the life of the Store, not a distributed lease.
+type ownerLock struct {
+	f *os.File
+}
+
+func acquireOwnerLock(path string) (*ownerLock, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open owner lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, protocol.Refuse(protocol.CodeEndpointAlreadyRunning, "another endpoint owns %s", path)
+		}
+		return nil, fmt.Errorf("lock owner file: %w", err)
+	}
+	return &ownerLock{f: f}, nil
+}
+
+func (l *ownerLock) release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	unlockErr := syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	closeErr := l.f.Close()
+	l.f = nil
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}
+
+func isNoSpace(err error) bool {
+	return errors.Is(err, syscall.ENOSPC) || errors.Is(err, syscall.EDQUOT)
+}

--- a/internal/remote/requests/store.go
+++ b/internal/remote/requests/store.go
@@ -32,9 +32,12 @@ const (
 	dirMode       = 0o700
 )
 
-// MaxRecordBytes bounds one record on disk; the input and result bounds in
-// the protocol keep real records far below it.
-const MaxRecordBytes = 256 * 1024
+// MaxRecordBytes bounds one record on disk. It delegates to the protocol
+// budget so the store, the wire bound, and the result/input limits are one
+// coherent set: a record always holds a full-size result plus input and
+// overhead (see protocol.MaxRecordBytes). It is a var, not a const, only so
+// tests can shrink it; production never reassigns it.
+var MaxRecordBytes = protocol.MaxRecordBytes
 
 var hostSegmentRe = regexp.MustCompile(`^[A-Za-z0-9_.:-]{1,128}$`)
 

--- a/internal/remote/requests/store.go
+++ b/internal/remote/requests/store.go
@@ -1,0 +1,410 @@
+// Package requests is the single-writer durable store for remote request
+// records. One record is one atomic JSON file; every change is a new revision
+// written with the repository's tmp, fsync, rename primitives. The store
+// enforces the request state graph and revision monotonicity; it does not
+// dispatch, publish, or talk to a harness.
+package requests
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+)
+
+// Layout under the companion state directory.
+const (
+	layoutVersion = "v1"
+	requestsDir   = "requests"
+	ownerLockFile = "owner.lock"
+	recordSuffix  = ".json"
+	fileMode      = 0o600
+	dirMode       = 0o700
+)
+
+// MaxRecordBytes bounds one record on disk; the input and result bounds in
+// the protocol keep real records far below it.
+const MaxRecordBytes = 256 * 1024
+
+var hostSegmentRe = regexp.MustCompile(`^[A-Za-z0-9_.:-]{1,128}$`)
+
+// Record is the durable request record: the public snapshot plus the
+// bookkeeping only the endpoint reads.
+type Record struct {
+	protocol.Snapshot
+
+	// Input is the exact submit input, kept until compaction so recovery can
+	// show what was asked. It is never re-dispatched from here.
+	Input *protocol.SubmitInput `json:"input,omitempty"`
+
+	// PublishedRevision is the last revision known to have left through AMQ.
+	PublishedRevision int64 `json:"published_revision"`
+
+	// NativeDispatches counts native submit attempts. The design allows at
+	// most one; the store refuses a second.
+	NativeDispatches int `json:"native_dispatches"`
+
+	// Tombstone marks a record that exists only to block a later submit or
+	// to remember a compacted result.
+	Tombstone bool `json:"tombstone,omitempty"`
+
+	// Origin is carrier-specific routing for publication (for example the
+	// AMQ handle and thread the command arrived in). It is never authority.
+	Origin map[string]string `json:"origin,omitempty"`
+
+	// UpdatedAt is the store write time, distinct from ObservedAt.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Key identifies one record. The creator host is the authenticated source of
+// the command, never a claimed handle.
+type Key struct {
+	CreatorHost string
+	TargetID    string
+	RequestID   string
+}
+
+// Store is the single-writer record store. Open acquires the owner lock;
+// Close releases it.
+type Store struct {
+	dir      string
+	lock     *ownerLock
+	now      func() time.Time
+	readOnly bool
+}
+
+// Option configures Open.
+type Option func(*Store)
+
+// WithClock injects the clock used for UpdatedAt. Tests pass a fixed clock.
+func WithClock(now func() time.Time) Option {
+	return func(s *Store) { s.now = now }
+}
+
+// Open prepares <stateDir>/v1 and takes the owner lock. A second opener on the
+// same directory is refused with endpoint_already_running before it can read
+// or write any record.
+func Open(stateDir string, opts ...Option) (*Store, error) {
+	if stateDir == "" {
+		return nil, protocol.Refuse(protocol.CodeInvalid, "state directory is required")
+	}
+	dir := filepath.Join(stateDir, layoutVersion)
+	if err := os.MkdirAll(filepath.Join(dir, requestsDir), dirMode); err != nil {
+		return nil, fmt.Errorf("create request store: %w", err)
+	}
+	lock, err := acquireOwnerLock(filepath.Join(dir, ownerLockFile))
+	if err != nil {
+		return nil, err
+	}
+	s := &Store{dir: dir, lock: lock, now: time.Now}
+	for _, o := range opts {
+		o(s)
+	}
+	return s, nil
+}
+
+// OpenReadOnly returns a store that reads records without taking the owner
+// lock. Writes through it are refused; the CLI uses it for `requests`.
+func OpenReadOnly(stateDir string) (*Store, error) {
+	if stateDir == "" {
+		return nil, protocol.Refuse(protocol.CodeInvalid, "state directory is required")
+	}
+	dir := filepath.Join(stateDir, layoutVersion)
+	if _, err := os.Stat(filepath.Join(dir, requestsDir)); err != nil {
+		return nil, protocol.Refuse(protocol.CodeNotFound, "no request store at %s", dir)
+	}
+	return &Store{dir: dir, now: time.Now, readOnly: true}, nil
+}
+
+// Close releases the owner lock. The records stay on disk.
+func (s *Store) Close() error {
+	if s.lock == nil {
+		return nil
+	}
+	err := s.lock.release()
+	s.lock = nil
+	return err
+}
+
+// Dir is the versioned store directory.
+func (s *Store) Dir() string { return s.dir }
+
+// Digest returns the protocol digest of exact submit input bytes.
+func Digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (s *Store) path(k Key) (string, error) {
+	if !hostSegmentRe.MatchString(k.CreatorHost) || !hostSegmentRe.MatchString(k.TargetID) {
+		return "", protocol.Refuse(protocol.CodeInvalid, "record key has an invalid segment")
+	}
+	if _, _, _, err := protocol.DecodeRef(protocol.EncodeRef(k.CreatorHost, k.TargetID, k.RequestID)); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.dir, requestsDir, k.CreatorHost, k.TargetID+"__"+k.RequestID+recordSuffix), nil
+}
+
+// Get reads one record. The boolean is false when no record exists.
+func (s *Store) Get(k Key) (*Record, bool, error) {
+	p, err := s.path(k)
+	if err != nil {
+		return nil, false, err
+	}
+	data, err := os.ReadFile(p)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read record: %w", err)
+	}
+	rec, err := decodeRecord(data)
+	if err != nil {
+		return nil, false, fmt.Errorf("record %s: %w", filepath.Base(p), err)
+	}
+	return rec, true, nil
+}
+
+// Create writes revision 1 of a new record. It refuses if a record exists.
+func (s *Store) Create(rec *Record) error {
+	if rec.Revision != 1 {
+		return protocol.Refuse(protocol.CodeInvalid, "new record must be revision 1")
+	}
+	k := keyOf(rec)
+	if _, exists, err := s.Get(k); err != nil {
+		return err
+	} else if exists {
+		return protocol.Refuse(protocol.CodeRequestConflict, "record already exists")
+	}
+	switch rec.State {
+	case protocol.StateReceived, protocol.StateRejected, protocol.StateCancelled:
+	default:
+		return protocol.Refuse(protocol.CodeInvalid, "a new record starts as received, rejected, or cancelled")
+	}
+	return s.write(rec)
+}
+
+// Update writes the next revision of an existing record after checking the
+// state graph, the immutable fields, and the single-dispatch rule.
+func (s *Store) Update(rec *Record) error {
+	prev, exists, err := s.Get(keyOf(rec))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return protocol.Refuse(protocol.CodeNotFound, "record does not exist")
+	}
+	if rec.Revision != prev.Revision+1 {
+		return protocol.Refuse(protocol.CodeInvalid, "revision must be %d", prev.Revision+1)
+	}
+	if err := checkImmutable(prev, rec); err != nil {
+		return err
+	}
+	if !allowed(prev.State, rec.State) {
+		return protocol.Refuse(protocol.CodeInvalid, "state %s cannot become %s", prev.State, rec.State)
+	}
+	if rec.NativeDispatches > 1 || rec.NativeDispatches < prev.NativeDispatches {
+		return protocol.Refuse(protocol.CodeInvalid, "native dispatch count must be monotonic and at most 1")
+	}
+	if rec.PublishedRevision < prev.PublishedRevision || rec.PublishedRevision > rec.Revision {
+		return protocol.Refuse(protocol.CodeInvalid, "published_revision must be monotonic and not ahead of revision")
+	}
+	return s.write(rec)
+}
+
+// MarkPublished records that revision left through the publisher. It rewrites
+// the record in place without a revision bump: publication bookkeeping is not
+// new evidence about the request.
+func (s *Store) MarkPublished(k Key, revision int64) error {
+	rec, exists, err := s.Get(k)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return protocol.Refuse(protocol.CodeNotFound, "record does not exist")
+	}
+	if revision > rec.Revision || revision < rec.PublishedRevision {
+		return protocol.Refuse(protocol.CodeInvalid, "published revision %d is out of range", revision)
+	}
+	rec.PublishedRevision = revision
+	return s.write(rec)
+}
+
+// List returns every record, oldest key first, for reconciliation.
+func (s *Store) List() ([]*Record, error) {
+	var out []*Record
+	base := filepath.Join(s.dir, requestsDir)
+	hosts, err := os.ReadDir(base)
+	if err != nil {
+		return nil, fmt.Errorf("list hosts: %w", err)
+	}
+	for _, h := range hosts {
+		if !h.IsDir() {
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(base, h.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %w", h.Name(), err)
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), recordSuffix) || strings.HasPrefix(f.Name(), ".") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(base, h.Name(), f.Name()))
+			if err != nil {
+				return nil, fmt.Errorf("read %s: %w", f.Name(), err)
+			}
+			rec, err := decodeRecord(data)
+			if err != nil {
+				return nil, fmt.Errorf("record %s: %w", f.Name(), err)
+			}
+			out = append(out, rec)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].UpdatedAt != out[j].UpdatedAt {
+			return out[i].UpdatedAt < out[j].UpdatedAt
+		}
+		return out[i].RequestRef < out[j].RequestRef
+	})
+	return out, nil
+}
+
+// Compact replaces the result and input of terminal records whose evidence
+// is older than before with a deduplication tombstone. The request identity,
+// digest, epoch and disposition survive, so a replay answers result_expired
+// instead of dispatching again.
+func (s *Store) Compact(before time.Time) (int, error) {
+	recs, err := s.List()
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, rec := range recs {
+		if !rec.State.Terminal() || rec.Tombstone {
+			continue
+		}
+		observed, err := protocol.ParseTime(rec.ObservedAt)
+		if err != nil || !observed.Before(before) {
+			continue
+		}
+		rec.Revision++
+		rec.Result = nil
+		rec.Input = nil
+		rec.Interaction = nil
+		rec.Tombstone = true
+		if rec.State == protocol.StateCompleted {
+			rec.Code = protocol.CodeResultExpired
+		}
+		if err := s.write(rec); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
+}
+
+func (s *Store) write(rec *Record) error {
+	if s.readOnly {
+		return protocol.Refuse(protocol.CodeUnsupported, "store opened read-only")
+	}
+	if rec.Schema == "" {
+		rec.Schema = protocol.SchemaRequest
+	}
+	if rec.Schema != protocol.SchemaRequest {
+		return protocol.Refuse(protocol.CodeInvalid, "record schema must be %s", protocol.SchemaRequest)
+	}
+	if rec.RequestRef == "" {
+		rec.RequestRef = protocol.EncodeRef(rec.CreatorHost, rec.TargetID, rec.RequestID)
+	}
+	if rec.ObservedAt == "" {
+		rec.ObservedAt = protocol.FormatTime(s.now())
+	}
+	rec.UpdatedAt = protocol.FormatTime(s.now())
+	p, err := s.path(keyOf(rec))
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("encode record: %w", err)
+	}
+	if len(data) > MaxRecordBytes {
+		return protocol.Refuse(protocol.CodeStorageFull, "record exceeds %d bytes", MaxRecordBytes)
+	}
+	if _, err := fsq.WriteFileAtomic(filepath.Dir(p), filepath.Base(p), data, fileMode); err != nil {
+		if errors.Is(err, os.ErrPermission) || isNoSpace(err) {
+			return protocol.Refuse(protocol.CodeStorageFull, "cannot persist record: %v", err)
+		}
+		return fmt.Errorf("persist record: %w", err)
+	}
+	return nil
+}
+
+func decodeRecord(data []byte) (*Record, error) {
+	if len(data) > MaxRecordBytes {
+		return nil, fmt.Errorf("record exceeds %d bytes", MaxRecordBytes)
+	}
+	var rec Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, err
+	}
+	if rec.Schema != protocol.SchemaRequest || rec.Revision < 1 || rec.RequestID == "" {
+		return nil, errors.New("record is not a valid request snapshot")
+	}
+	return &rec, nil
+}
+
+func keyOf(rec *Record) Key {
+	return Key{CreatorHost: rec.CreatorHost, TargetID: rec.TargetID, RequestID: rec.RequestID}
+}
+
+func checkImmutable(prev, next *Record) error {
+	switch {
+	case prev.RequestID != next.RequestID, prev.CreatorHost != next.CreatorHost,
+		prev.TargetID != next.TargetID, prev.Epoch != next.Epoch:
+		return protocol.Refuse(protocol.CodeInvalid, "record identity is immutable")
+	case prev.InputDigest != "" && next.InputDigest != prev.InputDigest:
+		return protocol.Refuse(protocol.CodeRequestConflict, "input digest is immutable")
+	}
+	return nil
+}
+
+// allowed is the request state graph from the remote-control ADR. Terminal
+// states never change; uncertain may resolve on exact native evidence.
+func allowed(from, to protocol.State) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case protocol.StateReceived:
+		return to == protocol.StateDispatching || to == protocol.StateRejected || to == protocol.StateCancelled
+	case protocol.StateDispatching:
+		switch to {
+		case protocol.StateRunning, protocol.StateCompleted, protocol.StateFailed,
+			protocol.StateRejected, protocol.StateCancelled, protocol.StateUncertain:
+			return true
+		}
+	case protocol.StateRunning:
+		switch to {
+		case protocol.StateCompleted, protocol.StateFailed, protocol.StateCancelled, protocol.StateUncertain:
+			return true
+		}
+	case protocol.StateUncertain:
+		switch to {
+		case protocol.StateRunning, protocol.StateCompleted, protocol.StateFailed, protocol.StateCancelled:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/remote/requests/store.go
+++ b/internal/remote/requests/store.go
@@ -54,6 +54,11 @@ type Record struct {
 	// most one; the store refuses a second.
 	NativeDispatches int `json:"native_dispatches"`
 
+	// Answered is the interaction ids this endpoint has already delivered an
+	// answer for, with the option sent. It is written before the native call
+	// so a replay after a crash cannot answer the same interaction twice.
+	Answered map[string]string `json:"answered,omitempty"`
+
 	// Tombstone marks a record that exists only to block a later submit or
 	// to remember a compacted result.
 	Tombstone bool `json:"tombstone,omitempty"`
@@ -146,13 +151,23 @@ func Digest(data []byte) string {
 }
 
 func (s *Store) path(k Key) (string, error) {
-	if !hostSegmentRe.MatchString(k.CreatorHost) || !hostSegmentRe.MatchString(k.TargetID) {
+	if !safeSegment(k.CreatorHost) || !safeSegment(k.TargetID) {
 		return "", protocol.Refuse(protocol.CodeInvalid, "record key has an invalid segment")
 	}
 	if _, _, _, err := protocol.DecodeRef(protocol.EncodeRef(k.CreatorHost, k.TargetID, k.RequestID)); err != nil {
 		return "", err
 	}
 	return filepath.Join(s.dir, requestsDir, k.CreatorHost, k.TargetID+"__"+k.RequestID+recordSuffix), nil
+}
+
+// safeSegment reports whether a key segment is a safe single path component.
+// The dot segments are refused here rather than trusting every carrier to
+// prefix its host string.
+func safeSegment(seg string) bool {
+	if seg == "." || seg == ".." {
+		return false
+	}
+	return hostSegmentRe.MatchString(seg)
 }
 
 // Get reads one record. The boolean is false when no record exists.
@@ -397,12 +412,16 @@ func allowed(from, to protocol.State) bool {
 		}
 	case protocol.StateRunning:
 		switch to {
-		case protocol.StateCompleted, protocol.StateFailed, protocol.StateCancelled, protocol.StateUncertain:
+		case protocol.StateCompleted, protocol.StateFailed, protocol.StateCancelled,
+			protocol.StateRejected, protocol.StateUncertain:
 			return true
 		}
 	case protocol.StateUncertain:
+		// Exact native evidence resolves an uncertain record to any outcome,
+		// including a positive refusal that admission never happened.
 		switch to {
-		case protocol.StateRunning, protocol.StateCompleted, protocol.StateFailed, protocol.StateCancelled:
+		case protocol.StateRunning, protocol.StateCompleted, protocol.StateFailed,
+			protocol.StateCancelled, protocol.StateRejected:
 			return true
 		}
 	}

--- a/internal/remote/requests/store.go
+++ b/internal/remote/requests/store.go
@@ -83,12 +83,15 @@ type Key struct {
 }
 
 // Store is the single-writer record store. Open acquires the owner lock;
-// Close releases it.
+// Close releases it and marks the store closed so every subsequent mutation
+// refuses. A closed store is not writable even if a stale reference survives
+// after a replacement endpoint has taken ownership.
 type Store struct {
 	dir      string
 	lock     *ownerLock
 	now      func() time.Time
 	readOnly bool
+	closed   bool
 }
 
 // Option configures Open.
@@ -134,8 +137,11 @@ func OpenReadOnly(stateDir string) (*Store, error) {
 	return &Store{dir: dir, now: time.Now, readOnly: true}, nil
 }
 
-// Close releases the owner lock. The records stay on disk.
+// Close releases the owner lock and marks the store closed. Every mutation
+// after Close refuses with store_closed, so a stale reference cannot write
+// once ownership has moved on. The records stay on disk.
 func (s *Store) Close() error {
+	s.closed = true
 	if s.lock == nil {
 		return nil
 	}
@@ -192,6 +198,9 @@ func (s *Store) Get(k Key) (*Record, bool, error) {
 
 // Create writes revision 1 of a new record. It refuses if a record exists.
 func (s *Store) Create(rec *Record) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
 	if rec.Revision != 1 {
 		return protocol.Refuse(protocol.CodeInvalid, "new record must be revision 1")
 	}
@@ -212,6 +221,9 @@ func (s *Store) Create(rec *Record) error {
 // Update writes the next revision of an existing record after checking the
 // state graph, the immutable fields, and the single-dispatch rule.
 func (s *Store) Update(rec *Record) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
 	prev, exists, err := s.Get(keyOf(rec))
 	if err != nil {
 		return err
@@ -241,6 +253,9 @@ func (s *Store) Update(rec *Record) error {
 // the record in place without a revision bump: publication bookkeeping is not
 // new evidence about the request.
 func (s *Store) MarkPublished(k Key, revision int64) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
 	rec, exists, err := s.Get(k)
 	if err != nil {
 		return err
@@ -401,6 +416,9 @@ func normalizeRecord(rec *Record) {
 // digest, epoch and disposition survive, so a replay answers result_expired
 // instead of dispatching again.
 func (s *Store) Compact(before time.Time) (int, error) {
+	if err := s.checkClosed(); err != nil {
+		return 0, err
+	}
 	recs, err := s.List()
 	if err != nil {
 		return 0, err
@@ -430,7 +448,21 @@ func (s *Store) Compact(before time.Time) (int, error) {
 	return n, nil
 }
 
+// checkClosed refuses every mutation on a closed store. Close sets closed
+// before releasing the owner lock, so a stale reference cannot write after a
+// replacement endpoint has taken ownership. Reads (Get/List) are still
+// permitted on a closed store for diagnosis.
+func (s *Store) checkClosed() error {
+	if s.closed {
+		return protocol.Refuse(protocol.CodeStoreClosed, "store is closed")
+	}
+	return nil
+}
+
 func (s *Store) write(rec *Record) error {
+	if s.closed {
+		return protocol.Refuse(protocol.CodeStoreClosed, "store is closed")
+	}
 	if s.readOnly {
 		return protocol.Refuse(protocol.CodeUnsupported, "store opened read-only")
 	}

--- a/internal/remote/requests/store.go
+++ b/internal/remote/requests/store.go
@@ -173,24 +173,21 @@ func safeSegment(seg string) bool {
 	return hostSegmentRe.MatchString(seg)
 }
 
-// Get reads one record. The boolean is false when no record exists.
+// Get reads one record. The boolean is false when no record exists. It uses
+// the same read+normalize path as List so a live request and a recovery pass
+// never disagree about a record's state. A present-but-undecodable file is
+// returned as an error (poison), not as absent, so a caller does not create a
+// conflicting revision-1 over a corrupt file.
 func (s *Store) Get(k Key) (*Record, bool, error) {
 	p, err := s.path(k)
 	if err != nil {
 		return nil, false, err
 	}
-	data, err := os.ReadFile(p)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, false, nil
-	}
+	rec, exists, err := s.readRecord(p)
 	if err != nil {
-		return nil, false, fmt.Errorf("read record: %w", err)
+		return nil, false, err
 	}
-	rec, err := decodeRecord(data)
-	if err != nil {
-		return nil, false, fmt.Errorf("record %s: %w", filepath.Base(p), err)
-	}
-	return rec, true, nil
+	return rec, exists, nil
 }
 
 // Create writes revision 1 of a new record. It refuses if a record exists.
@@ -258,33 +255,72 @@ func (s *Store) MarkPublished(k Key, revision int64) error {
 	return s.write(rec)
 }
 
-// List returns every record, oldest key first, for reconciliation.
+// Poison is one undecodable record encountered during List. The key is
+// recovered from the file path so the dedup identity survives even when the
+// JSON does not: a later submit for the same request is still blocked by the
+// on-disk file, and an operator can see which record to repair. List never
+// aborts on a poison record; it isolates it here and continues.
+type Poison struct {
+	Key   Key
+	Path  string
+	Error string
+}
+
+// List returns every decodable record, oldest key first, for reconciliation.
+// A poison (undecodable or invalid) record is isolated and skipped, never
+// allowed to abort the whole pass: Reconcile must reach every healthy record
+// even when one is corrupt. Use ListWithPoison to also collect diagnostics.
 func (s *Store) List() ([]*Record, error) {
+	recs, _, err := s.ListWithPoison()
+	return recs, err
+}
+
+// ListWithPoison returns every decodable record plus a diagnosed poison list.
+// Read and decode errors are isolated per file: a bad record is skipped, its
+// identity is recovered from the path, and the pass continues. The first
+// filesystem error that is not per-record (a host directory that cannot be
+// listed) is still returned, because that affects more than one record.
+func (s *Store) ListWithPoison() ([]*Record, []Poison, error) {
 	var out []*Record
+	var poison []Poison
 	base := filepath.Join(s.dir, requestsDir)
 	hosts, err := os.ReadDir(base)
 	if err != nil {
-		return nil, fmt.Errorf("list hosts: %w", err)
+		return nil, nil, fmt.Errorf("list hosts: %w", err)
 	}
 	for _, h := range hosts {
 		if !h.IsDir() {
 			continue
 		}
-		files, err := os.ReadDir(filepath.Join(base, h.Name()))
+		if !safeSegment(h.Name()) {
+			// A host directory that is not a valid segment cannot hold records
+			// we could round-trip; skip it without aborting the pass.
+			continue
+		}
+		hostDir := filepath.Join(base, h.Name())
+		files, err := os.ReadDir(hostDir)
 		if err != nil {
-			return nil, fmt.Errorf("list %s: %w", h.Name(), err)
+			// A directory listing failure is broader than one record; surface it.
+			return nil, nil, fmt.Errorf("list %s: %w", h.Name(), err)
 		}
 		for _, f := range files {
 			if f.IsDir() || !strings.HasSuffix(f.Name(), recordSuffix) || strings.HasPrefix(f.Name(), ".") {
 				continue
 			}
-			data, err := os.ReadFile(filepath.Join(base, h.Name(), f.Name()))
-			if err != nil {
-				return nil, fmt.Errorf("read %s: %w", f.Name(), err)
+			path := filepath.Join(hostDir, f.Name())
+			rec, exists, perr := s.readRecord(path)
+			if perr != nil {
+				poison = append(poison, Poison{
+					Key:   keyFromPath(h.Name(), f.Name()),
+					Path:  path,
+					Error: perr.Error(),
+				})
+				continue
 			}
-			rec, err := decodeRecord(data)
-			if err != nil {
-				return nil, fmt.Errorf("record %s: %w", f.Name(), err)
+			if !exists {
+				// Race: the file vanished between ReadDir and ReadFile. Skip it;
+				// it is not poison and it is not a record.
+				continue
 			}
 			out = append(out, rec)
 		}
@@ -295,7 +331,69 @@ func (s *Store) List() ([]*Record, error) {
 		}
 		return out[i].RequestRef < out[j].RequestRef
 	})
-	return out, nil
+	return out, poison, nil
+}
+
+// readRecord reads and decodes one record file, applying the shared
+// state-normalization that both the event (Get) and recovery (List) paths
+// use, so a record recovered during Reconcile is never silently stricter or
+// looser than one read by a live request. The boolean is false only when the
+// file does not exist; a present-but-undecodable file returns an error so a
+// caller never mistakes poison for absence.
+func (s *Store) readRecord(path string) (*Record, bool, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	rec, err := decodeRecord(data)
+	if err != nil {
+		return nil, true, fmt.Errorf("record %s: %w", filepath.Base(path), err)
+	}
+	normalizeRecord(rec)
+	return rec, true, nil
+}
+
+// keyFromPath recovers a record key from its on-disk path segments so a poison
+// record's dedup identity survives even when the JSON does not. The layout is
+// <creatorHost>/<targetID>__<requestID>.json. A malformed name yields an empty
+// key; the poison entry is still reported with the raw path for repair.
+func keyFromPath(host, filename string) Key {
+	name := strings.TrimSuffix(filename, recordSuffix)
+	idx := strings.Index(name, "__")
+	if idx < 0 {
+		return Key{CreatorHost: host}
+	}
+	targetID, requestID := name[:idx], name[idx+2:]
+	if !safeSegment(targetID) || requestID == "" {
+		return Key{CreatorHost: host}
+	}
+	return Key{CreatorHost: host, TargetID: targetID, RequestID: requestID}
+}
+
+// normalizeRecord is the single state-normalization shared by the event and
+// recovery read paths. It clamps a decoded record's fields to the invariants
+// the store guarantees on write, so Reconcile never acts on a looser reading
+// than a live request would. It does not mutate identity (request_ref,
+// request_id, creator_host, target_id, epoch, input_digest) or revision, which
+// are immutable and already validated by decodeRecord.
+func normalizeRecord(rec *Record) {
+	if rec == nil {
+		return
+	}
+	if rec.Schema == "" {
+		rec.Schema = protocol.SchemaRequest
+	}
+	if rec.RequestRef == "" {
+		rec.RequestRef = protocol.EncodeRef(rec.CreatorHost, rec.TargetID, rec.RequestID)
+	}
+	// A terminal record must not carry a pending interaction; clear a stale
+	// one left by a crash between setting and clearing it.
+	if rec.State.Terminal() {
+		rec.Interaction = nil
+	}
 }
 
 // Compact replaces the result and input of terminal records whose evidence

--- a/internal/remote/requests/store_test.go
+++ b/internal/remote/requests/store_test.go
@@ -1,6 +1,8 @@
 package requests
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -109,5 +111,102 @@ func TestStoreRefusesSecondWriterAndBadTransitions(t *testing.T) {
 	}
 	if err := s.Create(rec); protocol.ExitCode(err) != protocol.ExitActionRequired {
 		t.Fatalf("duplicate create: want request_conflict, got %v", err)
+	}
+}
+
+// TestListIsolatesPoisonRecords pins B15: a corrupt record on disk must not
+// abort List (and therefore Reconcile). The bad record is isolated, its
+// dedup identity is recovered from the path, and every healthy record after
+// it is still returned. A poison record also blocks a conflicting re-create
+// (Get surfaces it as an error, not as absent).
+func TestListIsolatesPoisonRecords(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, WithClock(fixedClock))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Two healthy records, one poison in between, one healthy after.
+	good1 := newRecord("11111111-1111-4111-8111-111111111301")
+	if err := s.Create(good1); err != nil {
+		t.Fatalf("create good1: %v", err)
+	}
+	poisonKey := Key{CreatorHost: "hostA", TargetID: "t_fake1", RequestID: "11111111-1111-4111-8111-111111111302"}
+	poisonPath, err := s.path(poisonKey)
+	if err != nil {
+		t.Fatalf("poison path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(poisonPath), dirMode); err != nil {
+		t.Fatalf("mkdir poison dir: %v", err)
+	}
+	// Write a file that exists but is not a valid record.
+	if err := os.WriteFile(poisonPath, []byte("{not valid json"), fileMode); err != nil {
+		t.Fatalf("write poison: %v", err)
+	}
+	good2 := newRecord("11111111-1111-4111-8111-111111111303")
+	if err := s.Create(good2); err != nil {
+		t.Fatalf("create good2: %v", err)
+	}
+
+	// List must return the two healthy records and NOT abort on the poison one.
+	recs, poison, err := s.ListWithPoison()
+	if err != nil {
+		t.Fatalf("list with poison: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("want 2 healthy records, got %d: %+v", len(recs), recs)
+	}
+	if len(poison) != 1 {
+		t.Fatalf("want 1 poison record, got %d: %+v", len(poison), poison)
+	}
+	// The poison record's dedup identity is recovered from the path.
+	p := poison[0]
+	if p.Key != poisonKey {
+		t.Fatalf("poison key: got %+v want %+v", p.Key, poisonKey)
+	}
+	if p.Path != poisonPath || p.Error == "" {
+		t.Fatalf("poison diagnostic incomplete: path=%q err=%q", p.Path, p.Error)
+	}
+
+	// The plain List() returns only healthy records (no abort).
+	recs2, err := s.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(recs2) != 2 {
+		t.Fatalf("List() want 2 healthy records, got %d", len(recs2))
+	}
+
+	// A poison record blocks a conflicting re-create: Get surfaces the error
+	// rather than treating the corrupt file as absent.
+	_, exists, gerr := s.Get(poisonKey)
+	if gerr == nil {
+		t.Fatalf("Get on poison record: want error, got exists=%v nil", exists)
+	}
+	if exists {
+		t.Fatalf("Get on poison record reported exists=true")
+	}
+}
+
+// TestNormalizeRecordClearsStaleInteraction pins the shared state-normalization:
+// a terminal record recovered from disk must not carry a pending interaction
+// left by a crash between setting and clearing it.
+func TestNormalizeRecordClearsStaleInteraction(t *testing.T) {
+	rec := &Record{
+		Snapshot: protocol.Snapshot{
+			Schema:      protocol.SchemaRequest,
+			RequestID:   "11111111-1111-4111-8111-111111111401",
+			CreatorHost: "hostA",
+			TargetID:    "t_fake1",
+			Epoch:       "e_1",
+			Revision:    4,
+			State:       protocol.StateCompleted,
+			Interaction: &protocol.Interaction{InteractionID: "ix1", Kind: "question", Options: []string{"a"}},
+		},
+	}
+	normalizeRecord(rec)
+	if rec.Interaction != nil {
+		t.Fatalf("terminal record kept a stale interaction: %+v", rec.Interaction)
 	}
 }

--- a/internal/remote/requests/store_test.go
+++ b/internal/remote/requests/store_test.go
@@ -261,4 +261,3 @@ func TestClosedStoreRejectsEveryMutation(t *testing.T) {
 		t.Fatalf("create after reopen: %v", err)
 	}
 }
-

--- a/internal/remote/requests/store_test.go
+++ b/internal/remote/requests/store_test.go
@@ -1,0 +1,113 @@
+package requests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+)
+
+func fixedClock() time.Time { return time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC) }
+
+func newRecord(id string) *Record {
+	return &Record{
+		Snapshot: protocol.Snapshot{
+			Schema:      protocol.SchemaRequest,
+			RequestID:   id,
+			CreatorHost: "hostA",
+			TargetID:    "t_fake1",
+			Epoch:       "e_1",
+			Revision:    1,
+			State:       protocol.StateReceived,
+			InputDigest: Digest([]byte("say hi")),
+		},
+		Input: &protocol.SubmitInput{Text: "say hi"},
+	}
+}
+
+// TestRecordLifecycle is the happy path: create, advance through the state
+// graph, read back, and compact a completed result into a tombstone that
+// still answers result_expired.
+func TestRecordLifecycle(t *testing.T) {
+	s, err := Open(t.TempDir(), WithClock(fixedClock))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	rec := newRecord("11111111-1111-4111-8111-111111111101")
+	if err := s.Create(rec); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if rec.RequestRef == "" {
+		t.Fatal("create did not assign request_ref")
+	}
+	rec.Revision, rec.State = 2, protocol.StateDispatching
+	if err := s.Update(rec); err != nil {
+		t.Fatalf("dispatching: %v", err)
+	}
+	run := "run_1"
+	rec.Revision, rec.State, rec.NativeRun, rec.NativeDispatches = 3, protocol.StateRunning, &run, 1
+	if err := s.Update(rec); err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	rec.Revision, rec.State = 4, protocol.StateCompleted
+	rec.Result = &protocol.Result{Text: "hi"}
+	rec.ObservedAt = "2026-09-01T00:00:00Z"
+	if err := s.Update(rec); err != nil {
+		t.Fatalf("completed: %v", err)
+	}
+
+	got, ok, err := s.Get(Key{"hostA", "t_fake1", rec.RequestID})
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.State != protocol.StateCompleted || got.Result == nil || got.Result.Text != "hi" || got.Revision != 4 {
+		t.Fatalf("unexpected record: %+v", got.Snapshot)
+	}
+
+	n, err := s.Compact(fixedClock())
+	if err != nil || n != 1 {
+		t.Fatalf("compact: n=%d err=%v", n, err)
+	}
+	got, _, err = s.Get(Key{"hostA", "t_fake1", rec.RequestID})
+	if err != nil {
+		t.Fatalf("get after compact: %v", err)
+	}
+	if !got.Tombstone || got.Result != nil || got.Code != protocol.CodeResultExpired || got.State != protocol.StateCompleted || got.InputDigest == "" {
+		t.Fatalf("compaction lost identity or kept the result: %+v", got)
+	}
+}
+
+// TestStoreRefusesSecondWriterAndBadTransitions pins the two invariants the
+// design relies on: one endpoint per root, and no state graph shortcuts.
+func TestStoreRefusesSecondWriterAndBadTransitions(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, WithClock(fixedClock))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if _, err := Open(dir); protocol.ExitCode(err) != protocol.ExitActionRequired {
+		t.Fatalf("second writer: want action-required refusal, got %v", err)
+	}
+
+	rec := newRecord("11111111-1111-4111-8111-111111111102")
+	if err := s.Create(rec); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	bad := *rec
+	bad.Revision, bad.State = 2, protocol.StateCompleted
+	if err := s.Update(&bad); err == nil {
+		t.Fatal("received -> completed was accepted")
+	}
+	bad = *rec
+	bad.Revision, bad.State, bad.NativeDispatches = 2, protocol.StateDispatching, 2
+	if err := s.Update(&bad); err == nil {
+		t.Fatal("two native dispatches were accepted")
+	}
+	if err := s.Create(rec); protocol.ExitCode(err) != protocol.ExitActionRequired {
+		t.Fatalf("duplicate create: want request_conflict, got %v", err)
+	}
+}

--- a/internal/remote/requests/store_test.go
+++ b/internal/remote/requests/store_test.go
@@ -210,3 +210,55 @@ func TestNormalizeRecordClearsStaleInteraction(t *testing.T) {
 		t.Fatalf("terminal record kept a stale interaction: %+v", rec.Interaction)
 	}
 }
+
+// TestClosedStoreRejectsEveryMutation pins B13 store half: after Close, every
+// mutation refuses with store_closed, so a stale reference cannot write after a
+// replacement endpoint has taken ownership. Create, Update, MarkPublished, and
+// Compact all go through write() and must refuse. A fresh Open after Close
+// re-acquires the lock and can write again.
+func TestClosedStoreRejectsEveryMutation(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, WithClock(fixedClock))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	rec := newRecord("11111111-1111-4111-8111-111111111601")
+	if err := s.Create(rec); err != nil {
+		t.Fatalf("create before close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Every mutation must refuse with store_closed, not succeed silently.
+	wantCode := protocol.CodeStoreClosed
+	if got := protocol.ExitCode(s.Create(newRecord("11111111-1111-4111-8111-111111111602"))); got != protocol.ExitActionRequired {
+		t.Fatalf("Create after close: want exit %d, got %d", protocol.ExitActionRequired, got)
+	}
+	if code := protocol.RefusalCode(s.Create(newRecord("11111111-1111-4111-8111-111111111603"))); code != wantCode {
+		t.Fatalf("Create after close: want code %q, got %q", wantCode, code)
+	}
+	upd := *rec
+	upd.Revision = 2
+	upd.State = protocol.StateRunning
+	if code := protocol.RefusalCode(s.Update(&upd)); code != wantCode {
+		t.Fatalf("Update after close: want code %q, got %q", wantCode, code)
+	}
+	if code := protocol.RefusalCode(s.MarkPublished(keyOf(&upd), 1)); code != wantCode {
+		t.Fatalf("MarkPublished after close: want code %q, got %q", wantCode, code)
+	}
+	if n, err := s.Compact(fixedClock()); err == nil {
+		t.Fatalf("Compact after close: want error, got n=%d", n)
+	} else if code := protocol.RefusalCode(err); code != wantCode {
+		t.Fatalf("Compact after close: want code %q, got %q", wantCode, code)
+	}
+	// A fresh Open after Close re-acquires the lock and can write again.
+	s2, err := Open(dir, WithClock(fixedClock))
+	if err != nil {
+		t.Fatalf("reopen after close: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if err := s2.Create(newRecord("11111111-1111-4111-8111-111111111604")); err != nil {
+		t.Fatalf("create after reopen: %v", err)
+	}
+}
+

--- a/schemas/remote-command-v1.schema.json
+++ b/schemas/remote-command-v1.schema.json
@@ -23,6 +23,7 @@
     {
       "title": "request.submit",
       "properties": {
+        "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "request.submit" },
         "request_id": { "$ref": "#/$defs/uuid" },
         "target_id": { "$ref": "#/$defs/opaque" },
@@ -45,6 +46,7 @@
     {
       "title": "request.get",
       "properties": {
+        "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "request.get" },
         "request_ref": { "$ref": "#/$defs/requestRef" }
       },
@@ -54,6 +56,7 @@
     {
       "title": "request.cancel",
       "properties": {
+        "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "request.cancel" },
         "request_ref": { "$ref": "#/$defs/requestRef" },
         "target_id": { "$ref": "#/$defs/opaque" },
@@ -65,13 +68,14 @@
     },
     {
       "title": "session.list",
-      "properties": { "op": { "const": "session.list" } },
+      "properties": { "schema": { "const": "amq.remote.command/1" }, "op": { "const": "session.list" } },
       "required": ["schema", "op"],
       "additionalProperties": false
     },
     {
       "title": "session.inspect",
       "properties": {
+        "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "session.inspect" },
         "target_id": { "$ref": "#/$defs/opaque" }
       },
@@ -81,6 +85,7 @@
     {
       "title": "session.events",
       "properties": {
+        "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "session.events" },
         "target_id": { "$ref": "#/$defs/opaque" },
         "since": { "type": "integer", "minimum": 0, "description": "Event cursor. Omit or 0 for a fresh snapshot." }
@@ -91,6 +96,7 @@
     {
       "title": "interaction.respond",
       "properties": {
+        "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "interaction.respond" },
         "request_ref": { "$ref": "#/$defs/requestRef" },
         "target_id": { "$ref": "#/$defs/opaque" },

--- a/schemas/remote-command-v1.schema.json
+++ b/schemas/remote-command-v1.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/avivsinai/agent-message-queue/schemas/remote-command-v1.schema.json",
+  "title": "AMQ Remote command v1",
+  "description": "One command from a client to an amq-remote endpoint. Carried as the body of an ordinary AMQ message to the endpoint's handle, over local IPC, or produced by the Buzz DM edge. Discriminated by op. Unknown fields are rejected.",
+  "type": "object",
+  "required": ["schema", "op"],
+  "properties": {
+    "schema": { "const": "amq.remote.command/1" },
+    "op": {
+      "enum": [
+        "request.submit",
+        "request.get",
+        "request.cancel",
+        "session.list",
+        "session.inspect",
+        "session.events",
+        "interaction.respond"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "title": "request.submit",
+      "properties": {
+        "op": { "const": "request.submit" },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "target_id": { "$ref": "#/$defs/opaque" },
+        "epoch": { "$ref": "#/$defs/opaque" },
+        "not_after": { "$ref": "#/$defs/rfc3339" },
+        "input": {
+          "type": "object",
+          "required": ["text"],
+          "properties": {
+            "text": { "type": "string", "minLength": 1, "maxLength": 131072 },
+            "busy": { "enum": ["reject", "queue"], "default": "reject" },
+            "deliver": { "enum": ["turn", "steer"], "default": "turn" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["schema", "op", "request_id", "target_id", "epoch", "not_after", "input"],
+      "additionalProperties": false
+    },
+    {
+      "title": "request.get",
+      "properties": {
+        "op": { "const": "request.get" },
+        "request_ref": { "$ref": "#/$defs/requestRef" }
+      },
+      "required": ["schema", "op", "request_ref"],
+      "additionalProperties": false
+    },
+    {
+      "title": "request.cancel",
+      "properties": {
+        "op": { "const": "request.cancel" },
+        "request_ref": { "$ref": "#/$defs/requestRef" },
+        "target_id": { "$ref": "#/$defs/opaque" },
+        "epoch": { "$ref": "#/$defs/opaque" },
+        "not_after": { "$ref": "#/$defs/rfc3339" }
+      },
+      "required": ["schema", "op", "request_ref", "target_id", "epoch", "not_after"],
+      "additionalProperties": false
+    },
+    {
+      "title": "session.list",
+      "properties": { "op": { "const": "session.list" } },
+      "required": ["schema", "op"],
+      "additionalProperties": false
+    },
+    {
+      "title": "session.inspect",
+      "properties": {
+        "op": { "const": "session.inspect" },
+        "target_id": { "$ref": "#/$defs/opaque" }
+      },
+      "required": ["schema", "op", "target_id"],
+      "additionalProperties": false
+    },
+    {
+      "title": "session.events",
+      "properties": {
+        "op": { "const": "session.events" },
+        "target_id": { "$ref": "#/$defs/opaque" },
+        "since": { "type": "integer", "minimum": 0, "description": "Event cursor. Omit or 0 for a fresh snapshot." }
+      },
+      "required": ["schema", "op", "target_id"],
+      "additionalProperties": false
+    },
+    {
+      "title": "interaction.respond",
+      "properties": {
+        "op": { "const": "interaction.respond" },
+        "request_ref": { "$ref": "#/$defs/requestRef" },
+        "target_id": { "$ref": "#/$defs/opaque" },
+        "epoch": { "$ref": "#/$defs/opaque" },
+        "interaction_id": { "$ref": "#/$defs/opaque" },
+        "option": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Exactly one option id offered by the pending interaction." }
+      },
+      "required": ["schema", "op", "request_ref", "target_id", "epoch", "interaction_id", "option"],
+      "additionalProperties": false
+    }
+  ],
+  "$defs": {
+    "uuid": { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
+    "opaque": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9_.:-]+$" },
+    "rfc3339": { "type": "string", "format": "date-time" },
+    "requestRef": {
+      "type": "string",
+      "description": "Opaque versioned reference from a receipt: amqr1_<base32 of creator_host, target_id, request_id>. Clients copy it; they never construct it.",
+      "pattern": "^amqr1_[a-z2-7]{16,200}$"
+    }
+  }
+}

--- a/schemas/remote-command-v1.schema.json
+++ b/schemas/remote-command-v1.schema.json
@@ -88,7 +88,7 @@
         "schema": { "const": "amq.remote.command/1" },
         "op": { "const": "session.events" },
         "target_id": { "$ref": "#/$defs/opaque" },
-        "since": { "type": "integer", "minimum": 0, "description": "Event cursor. Omit or 0 for a fresh snapshot." }
+        "since": { "type": "integer", "minimum": 0, "description": "Event cursor: the last event ordinal the caller already holds. Omit or 0 for a fresh snapshot. If the cursor is older than the retained event window, the response marks a gap (the caller must reset to a fresh snapshot)." }
       },
       "required": ["schema", "op", "target_id"],
       "additionalProperties": false
@@ -114,8 +114,8 @@
     "rfc3339": { "type": "string", "format": "date-time" },
     "requestRef": {
       "type": "string",
-      "description": "Opaque versioned reference from a receipt: amqr1_<base32 of creator_host, target_id, request_id>. Clients copy it; they never construct it.",
-      "pattern": "^amqr1_[a-z2-7]{16,200}$"
+      "description": "Opaque versioned reference from a receipt: amqr1_<base32 of creator_host, target_id, request_id>. Clients copy it; they never construct it. Upper bound is derived from the opaque-segment limits (see protocol.MaxRefLen).",
+      "pattern": "^amqr1_[a-z2-7]{16,512}$"
     }
   }
 }

--- a/schemas/remote-request-v1.schema.json
+++ b/schemas/remote-request-v1.schema.json
@@ -36,7 +36,7 @@
         "result_expired"
       ]
     },
-    "input_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$", "description": "Digest of the exact submit payload bytes; a retry with a different digest is request_conflict." },
+    "input_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$", "description": "Digest of the immutable submit command payload (schema, op, request_id, target_id, epoch, not_after, input) as canonical JSON; a retry with a changed epoch, deadline, or input is request_conflict." },
     "not_after": { "type": "string", "format": "date-time" },
     "native_run": { "type": ["string", "null"], "maxLength": 256, "description": "Harness run identity once admission is established." },
     "local_intervention": { "type": "boolean", "default": false },

--- a/schemas/remote-request-v1.schema.json
+++ b/schemas/remote-request-v1.schema.json
@@ -77,7 +77,8 @@
     "observed_at": { "type": "string", "format": "date-time", "description": "Time of the underlying evidence, not of the read." }
   },
   "allOf": [
-    { "if": { "properties": { "state": { "const": "completed" } } }, "then": { "required": ["result", "native_run"] } },
+    { "if": { "properties": { "state": { "const": "completed" } }, "not": { "required": ["code"] } }, "then": { "required": ["result", "native_run"] } },
+    { "if": { "properties": { "state": { "const": "completed" } }, "required": ["code"] }, "then": { "properties": { "code": { "const": "result_expired" } }, "required": ["code"] } },
     { "if": { "properties": { "state": { "enum": ["rejected", "uncertain", "failed"] } } }, "then": { "required": ["code"] } }
   ]
 }

--- a/schemas/remote-request-v1.schema.json
+++ b/schemas/remote-request-v1.schema.json
@@ -8,7 +8,7 @@
   "additionalProperties": false,
   "properties": {
     "schema": { "const": "amq.remote.request/1" },
-    "request_ref": { "type": "string", "pattern": "^amqr1_[a-z2-7]{16,200}$" },
+    "request_ref": { "type": "string", "pattern": "^amqr1_[a-z2-7]{16,512}$" },
     "request_id": { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
     "creator_host": { "type": "string", "minLength": 1, "maxLength": 128, "description": "Authenticated source host of the command, never a claimed handle." },
     "target_id": { "type": "string", "minLength": 1, "maxLength": 128 },

--- a/schemas/remote-request-v1.schema.json
+++ b/schemas/remote-request-v1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/avivsinai/agent-message-queue/schemas/remote-request-v1.schema.json",
+  "title": "AMQ Remote request snapshot v1",
+  "description": "The durable record of one remote work request, and the shape of every reply about it. Each published revision is immutable. Clients apply increasing revisions; an equal revision with different content is a protocol error.",
+  "type": "object",
+  "required": ["schema", "request_ref", "request_id", "creator_host", "target_id", "epoch", "revision", "state", "observed_at"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": { "const": "amq.remote.request/1" },
+    "request_ref": { "type": "string", "pattern": "^amqr1_[a-z2-7]{16,200}$" },
+    "request_id": { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
+    "creator_host": { "type": "string", "minLength": 1, "maxLength": 128, "description": "Authenticated source host of the command, never a claimed handle." },
+    "target_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "epoch": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "revision": { "type": "integer", "minimum": 1 },
+    "state": {
+      "enum": ["received", "dispatching", "running", "completed", "failed", "cancelled", "rejected", "uncertain"]
+    },
+    "code": {
+      "type": "string",
+      "description": "Typed reason for rejected, failed, cancelled, or uncertain.",
+      "enum": [
+        "busy",
+        "expired",
+        "stale_epoch",
+        "unsupported",
+        "unshared",
+        "invalid",
+        "request_conflict",
+        "cancelled_before_admission",
+        "cancelled_by_request",
+        "native_error",
+        "storage_full",
+        "attachment_lost",
+        "result_expired"
+      ]
+    },
+    "input_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$", "description": "Digest of the exact submit payload bytes; a retry with a different digest is request_conflict." },
+    "not_after": { "type": "string", "format": "date-time" },
+    "native_run": { "type": ["string", "null"], "maxLength": 256, "description": "Harness run identity once admission is established." },
+    "local_intervention": { "type": "boolean", "default": false },
+    "cancel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition"],
+      "properties": {
+        "requested_at": { "type": "string", "format": "date-time" },
+        "disposition": { "enum": ["cancel_requested", "cancelled", "noop_already_terminal", "unsupported"] }
+      }
+    },
+    "interaction": {
+      "type": "object",
+      "description": "Pending native question or approval, visible locally as well.",
+      "additionalProperties": false,
+      "required": ["interaction_id", "kind", "options"],
+      "properties": {
+        "interaction_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "kind": { "enum": ["question", "approval"] },
+        "prompt": { "type": "string", "maxLength": 16384 },
+        "options": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1, "maxLength": 256 } },
+        "remote_answer": { "type": "boolean", "description": "Whether the attachment can address this exact interaction from a remote answer." }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text", "truncated"],
+      "properties": {
+        "text": { "type": "string", "maxLength": 524288 },
+        "truncated": { "type": "boolean" },
+        "stop_reason": { "type": "string", "maxLength": 128 },
+        "error": { "type": "string", "maxLength": 4096 },
+        "native_ref": { "type": "string", "maxLength": 512, "description": "Where the full result lives on the target host; not fetchable remotely." }
+      }
+    },
+    "observed_at": { "type": "string", "format": "date-time", "description": "Time of the underlying evidence, not of the read." }
+  },
+  "allOf": [
+    { "if": { "properties": { "state": { "const": "completed" } } }, "then": { "required": ["result", "native_run"] } },
+    { "if": { "properties": { "state": { "enum": ["rejected", "uncertain", "failed"] } } }, "then": { "required": ["code"] } }
+  ]
+}

--- a/schemas/remote-session-v1.schema.json
+++ b/schemas/remote-session-v1.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/avivsinai/agent-message-queue/schemas/remote-session-v1.schema.json",
+  "title": "AMQ Remote session projection v1",
+  "description": "One shared, registered runtime as the endpoint currently sees it. Capabilities are observed from the installed attachment, never inferred from the harness name. Weaker capability is refused, not substituted.",
+  "type": "object",
+  "required": ["schema", "target_id", "epoch", "harness", "attachment", "status", "capabilities", "observed_at"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": { "const": "amq.remote.session/1" },
+    "target_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "epoch": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "harness": { "enum": ["codex", "amit", "claude_code", "fake"] },
+    "display_name": { "type": "string", "maxLength": 256 },
+    "host": { "type": "string", "maxLength": 128 },
+    "project": { "type": "string", "maxLength": 1024, "description": "Working directory or project label as the harness reports it." },
+    "attachment": { "enum": ["live", "stale", "offline"] },
+    "status": { "enum": ["idle", "busy", "waiting_input", "offline", "unknown"] },
+    "pending_interaction": { "type": ["string", "null"], "maxLength": 128 },
+    "active_request_ref": { "type": ["string", "null"], "pattern": "^amqr1_[a-z2-7]{16,200}$" },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inspect", "submit", "cancel_request", "answer_question", "approve_tool", "steer", "terminal"],
+      "properties": {
+        "inspect": { "type": "boolean" },
+        "submit": { "type": "boolean" },
+        "cancel_request": { "type": "boolean" },
+        "answer_question": { "type": "boolean" },
+        "approve_tool": { "type": "boolean" },
+        "steer": { "type": "boolean" },
+        "terminal": { "enum": ["unavailable"] , "description": "v1 has no terminal backend; the value is present so a later backend is an additive change." }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "description": "Evidence class the attachment can give for each operation, in wake capability-vector vocabulary plus 'admitted'.",
+      "additionalProperties": false,
+      "properties": {
+        "submit": { "enum": ["delivered", "submitted", "admitted"] },
+        "completion": { "enum": ["none", "session_idle", "run_terminal"] }
+      }
+    },
+    "observed_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/schemas/remote-session-v1.schema.json
+++ b/schemas/remote-session-v1.schema.json
@@ -17,7 +17,7 @@
     "attachment": { "enum": ["live", "stale", "offline"] },
     "status": { "enum": ["idle", "busy", "waiting_input", "offline", "unknown"] },
     "pending_interaction": { "type": ["string", "null"], "maxLength": 128 },
-    "active_request_ref": { "type": ["string", "null"], "pattern": "^amqr1_[a-z2-7]{16,200}$" },
+    "active_request_ref": { "type": ["string", "null"], "pattern": "^amqr1_[a-z2-7]{16,512}$" },
     "capabilities": {
       "type": "object",
       "additionalProperties": false,

--- a/testdata/remote/corpus.json
+++ b/testdata/remote/corpus.json
@@ -1,0 +1,786 @@
+{
+  "schema": "amq.remote.corpus/1",
+  "description": "Contract corpus for the amq-remote request core. One fixture per scenario. The fake runtime, the endpoint, the CLI and the Buzz edge all consume this file. Steps run in order on a deterministic clock; 'client' steps send a command and check the reply, 'native' steps drive the fake runtime, 'crash' stops the endpoint at a named boundary, 'restart' brings it back and reconciles, 'expect' asserts the durable record.",
+  "defaults": {
+    "target_id": "t_fake1",
+    "epoch": "e_1",
+    "creator_host": "hostA",
+    "not_after": "2026-09-08T10:02:00Z",
+    "now": "2026-09-08T10:00:00Z"
+  },
+  "fixtures": [
+    {
+      "id": "Q01",
+      "title": "Identical submit delivered 100 times dispatches once",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111101",
+            "input": {
+              "text": "say hi"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "repeat": 99,
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111101",
+            "input": {
+              "text": "say hi"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111101",
+            "native_dispatches": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q02",
+      "title": "Reused id with different bytes is request_conflict",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111102",
+            "input": {
+              "text": "first"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111102",
+            "input": {
+              "text": "second"
+            }
+          },
+          "reply": {
+            "state": "running",
+            "code": "request_conflict"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111102",
+            "native_dispatches": 1,
+            "input_text": "first"
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q03",
+      "title": "Cancel reaches the target before submit",
+      "steps": [
+        {
+          "client": {
+            "op": "request.cancel",
+            "request_ref_for": "11111111-1111-4111-8111-111111111103"
+          },
+          "reply": {
+            "state": "cancelled",
+            "code": "cancelled_before_admission"
+          }
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111103",
+            "input": {
+              "text": "late"
+            }
+          },
+          "reply": {
+            "state": "cancelled",
+            "code": "cancelled_before_admission"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111103",
+            "native_dispatches": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q04",
+      "title": "Cancel races the native admission boundary",
+      "steps": [
+        {
+          "native": "hold_admission"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111104",
+            "input": {
+              "text": "race"
+            }
+          },
+          "async": true
+        },
+        {
+          "client": {
+            "op": "request.cancel",
+            "request_ref_for": "11111111-1111-4111-8111-111111111104"
+          },
+          "reply": {
+            "cancel": {
+              "disposition": "cancel_requested"
+            }
+          }
+        },
+        {
+          "native": "release_admission"
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111104",
+            "state_in": [
+              "cancelled"
+            ],
+            "no_orphan_run": true
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q05",
+      "title": "Delayed cancel of A never aborts B",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111105",
+            "input": {
+              "text": "A"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "native": "complete",
+          "request_id": "11111111-1111-4111-8111-111111111105",
+          "text": "A done"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111106",
+            "input": {
+              "text": "B"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "client": {
+            "op": "request.cancel",
+            "request_ref_for": "11111111-1111-4111-8111-111111111105"
+          },
+          "reply": {
+            "state": "completed",
+            "cancel": {
+              "disposition": "noop_already_terminal"
+            }
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111106",
+            "state": "running",
+            "native_aborts": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q06",
+      "title": "Global idle is not completion",
+      "steps": [
+        {
+          "native": "idle"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111107",
+            "input": {
+              "text": "work"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "native": "idle_blip"
+        },
+        {
+          "client": {
+            "op": "request.get",
+            "request_ref_for": "11111111-1111-4111-8111-111111111107"
+          },
+          "reply": {
+            "state": "running"
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q07",
+      "title": "Wait after completion returns the stored result",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111108",
+            "input": {
+              "text": "quick"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "native": "complete",
+          "request_id": "11111111-1111-4111-8111-111111111108",
+          "text": "done quickly"
+        },
+        {
+          "client": {
+            "op": "request.get",
+            "request_ref_for": "11111111-1111-4111-8111-111111111108"
+          },
+          "reply": {
+            "state": "completed",
+            "result": {
+              "text": "done quickly",
+              "truncated": false
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q08",
+      "title": "Interrupting wait does not cancel",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111109",
+            "input": {
+              "text": "long"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "cli": "wait",
+          "request_id": "11111111-1111-4111-8111-111111111109",
+          "interrupt_after": "1s",
+          "exit": 130
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111109",
+            "state": "running",
+            "native_aborts": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q09",
+      "title": "Remote submit during a local draft leaves the draft intact",
+      "steps": [
+        {
+          "native": "local_draft",
+          "text": "half-typed local thought"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111110",
+            "input": {
+              "text": "remote"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "expect_native": {
+            "draft": "half-typed local thought",
+            "session_id_unchanged": true
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q10",
+      "title": "Human steers a remote run; intervention recorded, no misattribution",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111111",
+            "input": {
+              "text": "remote"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "native": "local_input",
+          "text": "actually do it differently"
+        },
+        {
+          "native": "complete",
+          "request_id": "11111111-1111-4111-8111-111111111111",
+          "text": "joint result"
+        },
+        {
+          "client": {
+            "op": "request.get",
+            "request_ref_for": "11111111-1111-4111-8111-111111111111"
+          },
+          "reply": {
+            "state": "completed",
+            "local_intervention": true
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q11",
+      "title": "Helper returns before native admission fails; no false running",
+      "steps": [
+        {
+          "native": "admission_fails_after_return"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111112",
+            "input": {
+              "text": "x"
+            }
+          },
+          "reply": {
+            "state": "rejected",
+            "code": "native_error"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111112",
+            "never_state": [
+              "running",
+              "completed"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q12",
+      "title": "Reload or session switch advances the epoch; old epoch cannot control",
+      "steps": [
+        {
+          "native": "switch_session",
+          "new_epoch": "e_2"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111113",
+            "epoch": "e_1",
+            "input": {
+              "text": "stale"
+            }
+          },
+          "reply": {
+            "state": "rejected",
+            "code": "stale_epoch"
+          }
+        },
+        {
+          "client": {
+            "op": "session.inspect"
+          },
+          "reply": {
+            "epoch": "e_2"
+          }
+        },
+        {
+          "expect_native": {
+            "consumer_sets": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q13",
+      "title": "Local and remote both answer one question; second gets already_resolved",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111114",
+            "input": {
+              "text": "ask me"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "native": "question",
+          "request_id": "11111111-1111-4111-8111-111111111114",
+          "interaction_id": "i_1",
+          "options": [
+            "yes",
+            "no"
+          ]
+        },
+        {
+          "native": "local_answer",
+          "interaction_id": "i_1",
+          "option": "yes"
+        },
+        {
+          "client": {
+            "op": "interaction.respond",
+            "request_ref_for": "11111111-1111-4111-8111-111111111114",
+            "interaction_id": "i_1",
+            "option": "no"
+          },
+          "reply": {
+            "code": "already_resolved"
+          }
+        },
+        {
+          "expect_native": {
+            "answers": [
+              {
+                "interaction_id": "i_1",
+                "option": "yes"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q14",
+      "title": "Submit expires while the target is offline; never executes later",
+      "steps": [
+        {
+          "native": "offline"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111115",
+            "not_after": "2026-09-08T10:01:00Z",
+            "input": {
+              "text": "late"
+            }
+          },
+          "deferred": true
+        },
+        {
+          "clock": "2026-09-08T10:05:00Z"
+        },
+        {
+          "native": "online"
+        },
+        {
+          "client": {
+            "op": "request.get",
+            "request_ref_for": "11111111-1111-4111-8111-111111111115"
+          },
+          "reply": {
+            "state": "rejected",
+            "code": "expired"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111115",
+            "native_dispatches": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q15",
+      "title": "Replay after result compaction returns result_expired, not a new dispatch",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111116",
+            "input": {
+              "text": "old"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "native": "complete",
+          "request_id": "11111111-1111-4111-8111-111111111116",
+          "text": "old result"
+        },
+        {
+          "endpoint": "compact_results"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111116",
+            "input": {
+              "text": "old"
+            }
+          },
+          "reply": {
+            "state": "completed",
+            "code": "result_expired"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111116",
+            "native_dispatches": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q16",
+      "title": "Durable write failure means no dispatch",
+      "steps": [
+        {
+          "endpoint": "storage_fail_next_write"
+        },
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111117",
+            "input": {
+              "text": "x"
+            }
+          },
+          "reply": {
+            "state": "rejected",
+            "code": "storage_full"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111117",
+            "native_dispatches": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q17",
+      "title": "Two endpoints on one root: second refuses before importing",
+      "steps": [
+        {
+          "endpoint": "start_second",
+          "expect_exit": 6,
+          "expect_code": "endpoint_already_running"
+        },
+        {
+          "expect": {
+            "native_dispatches": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q18",
+      "title": "Lost publication is republished as the same revision, never rerun",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111118",
+            "input": {
+              "text": "x"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "endpoint": "drop_next_publication"
+        },
+        {
+          "native": "complete",
+          "request_id": "11111111-1111-4111-8111-111111111118",
+          "text": "r"
+        },
+        {
+          "restart": true
+        },
+        {
+          "expect_published": {
+            "request_id": "11111111-1111-4111-8111-111111111118",
+            "terminal_state": "completed",
+            "terminal_count": 1
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111118",
+            "native_dispatches": 1,
+            "state": "completed"
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q19",
+      "title": "Crash at every persistence and native boundary reconciles without redispatch",
+      "boundaries": [
+        "before:received_commit",
+        "after:received_commit",
+        "before:dispatching_commit",
+        "after:dispatching_commit",
+        "before:native_submit",
+        "after:native_submit",
+        "before:result_commit",
+        "after:result_commit",
+        "before:native_ack",
+        "after:native_ack",
+        "before:publish",
+        "after:publish",
+        "before:published_revision_commit"
+      ],
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111119",
+            "input": {
+              "text": "x"
+            }
+          },
+          "may_crash": true
+        },
+        {
+          "native": "complete_if_admitted",
+          "request_id": "11111111-1111-4111-8111-111111111119",
+          "text": "r"
+        },
+        {
+          "restart": true
+        },
+        {
+          "native": "complete_if_admitted",
+          "request_id": "11111111-1111-4111-8111-111111111119",
+          "text": "r"
+        },
+        {
+          "restart": true
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111119",
+            "native_dispatches_max": 1,
+            "state_in": [
+              "absent",
+              "received",
+              "rejected",
+              "running",
+              "completed",
+              "uncertain"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "Q20",
+      "title": "Another authorized peer uses the original request reference",
+      "steps": [
+        {
+          "client": {
+            "op": "request.submit",
+            "request_id": "11111111-1111-4111-8111-111111111120",
+            "input": {
+              "text": "x"
+            }
+          },
+          "reply": {
+            "state": "running"
+          }
+        },
+        {
+          "client": {
+            "op": "request.get",
+            "request_ref_for": "11111111-1111-4111-8111-111111111120",
+            "creator_host": "hostB"
+          },
+          "reply": {
+            "state": "running",
+            "creator_host": "hostA"
+          }
+        },
+        {
+          "client": {
+            "op": "request.cancel",
+            "request_ref_for": "11111111-1111-4111-8111-111111111120",
+            "creator_host": "hostB"
+          },
+          "reply": {
+            "state": "cancelled"
+          }
+        },
+        {
+          "expect": {
+            "request_id": "11111111-1111-4111-8111-111111111120",
+            "creator_host": "hostA",
+            "records": 1
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What a user can now do
Run `amq-remote serve --fake` for an AMQ root, then from any shell: `amq-remote submit fake --text "..."` returns a durable receipt with a `request_ref`; `status`, `wait --timeout`, `cancel`, `requests` and `doctor` follow that request with the AMQ exit-code contract (0 ok, 1 failed or cancelled, 4 wait timed out, 6 busy/unsupported/uncertain). Another agent in the same root can send the same command as an ordinary AMQ message to handle `remote`; the endpoint imports it, claims it with a drained receipt, and replies with each request revision in the same thread.

Real harness adapters (Codex, Amit, Claude Code) are the next beads; this PR ships the contract they plug into.

## Contract evidence
- `testdata/remote/corpus.json` Q01–Q20 pass against the endpoint + fake runtime; Q19 runs at all 13 crash boundaries with no double dispatch.
- Live smoke on this machine: submit → running (0), wait 300ms → 4, second submit while busy → rejected busy (6), cancel → cancelled (0), status → 1, mail path from `codex` → drained receipt + "remote request running" reply.

Depends on #728 (ADR and seam register). Beads: agent-message-queue-611.4, .5, .6, .7, .8, .9, .10.

Review: pending. Codex peer has been idle since 2026-09-07; a fresh-context runtime/recovery review is in progress and its findings land as follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)