### PR TITLE
fix(remote): disable busy=queue and deliver=steer for v1 (B05/D1)

### DIFF
--- a/internal/remote/core/disabled_modes_test.go
+++ b/internal/remote/core/disabled_modes_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/remote/core"
@@ -24,9 +25,10 @@ func TestDisabledQueueAndSteerModesAreRefused(t *testing.T) {
 		name  string
 		busy  protocol.Busy
 		deliv protocol.Deliver
+		want  string
 	}{
-		{"busy-queue", protocol.BusyQueue, protocol.DeliverTurn},
-		{"deliver-steer", protocol.BusyReject, protocol.DeliverSteer},
+		{"busy-queue", protocol.BusyQueue, protocol.DeliverTurn, "busy=queue"},
+		{"deliver-steer", protocol.BusyReject, protocol.DeliverSteer, "deliver=steer"},
 	} {
 		id := "11111111-1111-4111-8111-1111111111f1"
 		cmd := submitCmd(id)
@@ -36,6 +38,9 @@ func TestDisabledQueueAndSteerModesAreRefused(t *testing.T) {
 		refusal := protocol.RefusalCode(err)
 		if refusal != protocol.CodeUnsupported {
 			t.Fatalf("%s: err = %v, want unsupported refusal", tc.name, err)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: refusal %q does not name the disabled mode %q", tc.name, err.Error(), tc.want)
 		}
 		if code := protocol.ExitForCode(refusal); code != 6 {
 			t.Fatalf("%s: exit code = %d, want 6 (action required)", tc.name, code)

--- a/internal/remote/core/disabled_modes_test.go
+++ b/internal/remote/core/disabled_modes_test.go
@@ -1,0 +1,60 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/remote/core"
+	"github.com/avivsinai/agent-message-queue/internal/remote/fake"
+	"github.com/avivsinai/agent-message-queue/internal/remote/protocol"
+	"github.com/avivsinai/agent-message-queue/internal/remote/requests"
+)
+
+// TestDisabledQueueAndSteerModesAreRefused pins the D1 gate (bead 611.22.10 /
+// 611.22.23): busy=queue and deliver=steer are disabled in v1 until their
+// ownership+evidence models exist. A submit carrying either is refused
+// unsupported (exit 6 via ExitForCode) BEFORE any durable write — no record
+// is created — and the identical submit with reject/turn succeeds.
+func TestDisabledQueueAndSteerModesAreRefused(t *testing.T) {
+	store, now := openStore(t)
+	rt := fake.New("fake", "e_1")
+	ep := core.New(core.Config{Store: store, Now: now})
+	ep.Register(rt)
+
+	for _, tc := range []struct {
+		name  string
+		busy  protocol.Busy
+		deliv protocol.Deliver
+	}{
+		{"busy-queue", protocol.BusyQueue, protocol.DeliverTurn},
+		{"deliver-steer", protocol.BusyReject, protocol.DeliverSteer},
+	} {
+		id := "11111111-1111-4111-8111-1111111111f1"
+		cmd := submitCmd(id)
+		cmd.Input.Busy = tc.busy
+		cmd.Input.Deliver = tc.deliv
+		_, err := ep.Handle(cmd, core.Source{Host: "local"})
+		refusal := protocol.RefusalCode(err)
+		if refusal != protocol.CodeUnsupported {
+			t.Fatalf("%s: err = %v, want unsupported refusal", tc.name, err)
+		}
+		if code := protocol.ExitForCode(refusal); code != 6 {
+			t.Fatalf("%s: exit code = %d, want 6 (action required)", tc.name, code)
+		}
+		if _, ok, _ := store.Get(requests.Key{CreatorHost: "local", TargetID: "fake", RequestID: id}); ok {
+			t.Fatalf("%s: refused submit created a durable record", tc.name)
+		}
+	}
+
+	// The plain reject/turn submit still works.
+	id := "11111111-1111-4111-8111-1111111111f1"
+	if _, err := ep.Handle(submitCmd(id), core.Source{Host: "local"}); err != nil {
+		t.Fatalf("reject/turn submit: %v", err)
+	}
+	rec, ok, err := store.Get(requests.Key{CreatorHost: "local", TargetID: "fake", RequestID: id})
+	if err != nil || !ok {
+		t.Fatalf("reject/turn record missing: ok=%v err=%v", ok, err)
+	}
+	if rec.State != protocol.StateDispatching && rec.State != protocol.StateRunning {
+		t.Fatalf("reject/turn submit did not dispatch: state=%s", rec.State)
+	}
+}

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -185,12 +185,12 @@ func (e *Endpoint) submit(cmd *protocol.Command, src Source) (protocol.Reply, er
 	// and a plain retry with reject/turn succeeds. Full model deferred to a
 	// follow-up.
 	if cmd.Input != nil && (cmd.Input.Busy == protocol.BusyQueue || cmd.Input.Deliver == protocol.DeliverSteer) {
-		disabled := "busy"
+		mode, value := "busy", string(cmd.Input.Busy)
 		if cmd.Input.Deliver == protocol.DeliverSteer {
-			disabled = "deliver"
+			mode, value = "deliver", string(cmd.Input.Deliver)
 		}
 		return protocol.Reply{}, protocol.Refuse(protocol.CodeUnsupported,
-			"%s=%s is disabled in v1; full ownership/evidence model deferred — use busy=reject deliver=turn", disabled, cmd.Input.Busy)
+			"%s=%s is disabled in v1; full ownership/evidence model deferred — use busy=reject deliver=turn", mode, value)
 	}
 	key := requests.Key{CreatorHost: src.Host, TargetID: cmd.TargetID, RequestID: cmd.RequestID}
 	digest := protocol.CommandDigest(cmd)

--- a/internal/remote/core/endpoint.go
+++ b/internal/remote/core/endpoint.go
@@ -177,6 +177,21 @@ func InputDigest(in *protocol.SubmitInput) string {
 }
 
 func (e *Endpoint) submit(cmd *protocol.Command, src Source) (protocol.Reply, error) {
+	// D1 (bead 611.22.23): busy=queue and deliver=steer are disabled in v1 —
+	// their ownership+evidence models do not exist yet (steer would overwrite
+	// the running run's byTurn mapping; queue would admit without a NotAfter
+	// check at native admission or a per-runtime reservation). The gate sits
+	// BEFORE any durable write, so a disabled-mode submit consumes nothing
+	// and a plain retry with reject/turn succeeds. Full model deferred to a
+	// follow-up.
+	if cmd.Input != nil && (cmd.Input.Busy == protocol.BusyQueue || cmd.Input.Deliver == protocol.DeliverSteer) {
+		disabled := "busy"
+		if cmd.Input.Deliver == protocol.DeliverSteer {
+			disabled = "deliver"
+		}
+		return protocol.Reply{}, protocol.Refuse(protocol.CodeUnsupported,
+			"%s=%s is disabled in v1; full ownership/evidence model deferred — use busy=reject deliver=turn", disabled, cmd.Input.Busy)
+	}
 	key := requests.Key{CreatorHost: src.Host, TargetID: cmd.TargetID, RequestID: cmd.RequestID}
 	digest := protocol.CommandDigest(cmd)
 


### PR DESCRIPTION
Beads agent-message-queue-611.22.10 (B05) + 611.22.23 (D1). Base = main@fec0b516 (carries B06 049c18bd + B07 fec0b516) — no stacking.

**Why gate rather than fix:** queue and steer have no ownership+evidence model yet — steer would overwrite the running run's `byTurn` mapping; queue would admit without NotAfter enforced at native admission or a per-runtime reservation covering dispatching+unresolved+unacked. D1's decision: disable in v1, defer the full model to a follow-up.

**The change (15 lines in endpoint.go):** `submit()` refuses `busy=queue` / `deliver=steer` with a typed `CodeUnsupported` BEFORE any durable write — no record created, nothing consumed. `ExitForCode(CodeUnsupported)` already maps to exit 6 (action required), so the CLI falls out with zero changes. The refusal message carries the defer note: 'full ownership/evidence model deferred — use busy=reject deliver=turn'.

**Regression (one test, per the no-duplicates bar):** queue submit → unsupported + exit-6 path + store stays empty; steer same; then the identical submit with reject/turn dispatches. Deterministic, <1s. (Grepped first: no existing test covers a disabled-mode submit refusal.)

Full internal/... green (one unrelated keepalive/hookinstall timing flake re-ran green), vet clean, golangci-lint 0 issues, fmt-check pass.