### PR TITLE
fix(remote/codex): bound writer acquisition + non-lossy reply-required + worker lifecycle (B14b)

### DIFF
--- a/internal/remote/codex/b14b_regression_test.go
+++ b/internal/remote/codex/b14b_regression_test.go
@@ -2,10 +2,12 @@ package codex
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -68,6 +70,51 @@ func newB14bClient(t *testing.T, onNotif func(), onReq func(ServerRequest)) (*Cl
 		c.OnServerRequest = onReq
 	}
 	t.Cleanup(func() { _ = c.Close(); _ = l.Close() })
+	return c, l
+}
+
+// newB14bClientWithServer builds a client whose stand-in server forwards the
+// FIRST frame the client sends back to the test via onFrame.
+func newB14bClientWithServer(t *testing.T, onFrame func([]byte)) (*Client, net.Listener) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "amqcx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "s.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		ws, err := acceptServerWS(conn)
+		if err != nil {
+			return
+		}
+		payload, err := ws.readText()
+		if err != nil {
+			return
+		}
+		onFrame(payload)
+		// Keep draining so further writes never wedge the client.
+		for {
+			if _, err := ws.readText(); err != nil {
+				return
+			}
+		}
+	}()
+	ws, err := dialUnixWS(sock, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	c := newClient(ws)
+	t.Cleanup(func() { _ = c.Close() })
 	return c, l
 }
 
@@ -213,4 +260,86 @@ func TestB14bCallWaitsBoundedBehindWedgedWriter(t *testing.T) {
 		t.Fatalf("call B err = %v, want context.DeadlineExceeded (or the connection-closed error under teardown)", err)
 	}
 	_ = writeADone // A stays wedged; the test ends and cleanup closes everything.
+}
+
+// TestB14bReplyRequiredNotDroppedAndPumpStaysLive pins B8: notifications may
+// drop on a full backlog, but reply-required server requests must never be
+// silently dropped — delivered via their own queue, or explicitly failed on
+// the should-be-impossible overflow — and the read pump never blocks on
+// handler latency.
+func TestB14bReplyRequiredNotDroppedAndPumpStaysLive(t *testing.T) {
+	var mu sync.Mutex
+	notifications := 0
+	approved := make(chan string, 8)
+	blockApproval := make(chan struct{}) // wedges the first approval handler
+	c, _ := newB14bClient(t, nil, nil)
+	c.OnNotification = func(n Notification) { mu.Lock(); notifications++; mu.Unlock() }
+	first := true
+	c.OnServerRequest = func(r ServerRequest) {
+		mu.Lock()
+		approved <- r.Method
+		mu.Unlock()
+		if first {
+			first = false
+			<-blockApproval // wedge AFTER recording: the pump must survive it
+		}
+	}
+
+	// Flood notifications (bounded queue of 64): drops are legal. Then a
+	// reply-required request: it MUST be delivered (own queue) even with the
+	// notification backlog full.
+	for i := 0; i < 100; i++ {
+		c.dispatch(func() { c.OnNotification(Notification{Method: "noise"}) })
+	}
+	c.dispatchServerRequest(ServerRequest{ID: json.RawMessage(`"srv-1"`), Method: "item/commandExecution/requestApproval"})
+	select {
+	case m := <-approved:
+		if m != "item/commandExecution/requestApproval" {
+			t.Fatalf("delivered method = %s", m)
+		}
+	case <-time.After(b14bDeadline):
+		t.Fatal("reply-required server request dropped (B8 regression)")
+	}
+	close(blockApproval)
+
+	// Overflow (should-be-impossible): fill reqQ past capacity with a wedged
+	// handler, the overflowed request must be EXPLICITLY FAILED, not dropped.
+	// c2's stand-in server echoes the first frame it reads, so respondError's
+	// explicit error is observable without touching the live client's socket
+	// (swapping it would race the readLoop).
+	release2 := make(chan struct{})
+	respCh := make(chan []byte, 1)
+	c2, _ := newB14bClientWithServer(t, func(payload []byte) { respCh <- payload })
+	headPicked := make(chan struct{})
+	c2.OnServerRequest = func(r ServerRequest) {
+		// Signal that the req worker has consumed the head from reqQ, then
+		// wedge: the queue below can now fill deterministically.
+		close(headPicked)
+		<-release2
+	}
+	c2.dispatchServerRequest(ServerRequest{ID: json.RawMessage(`"srv-head"`), Method: "m"})
+	<-headPicked // worker consumed the head; it is wedged in this handler
+	for i := 0; i < cap(c2.reqQ)+1; i++ {
+		c2.dispatchServerRequest(ServerRequest{ID: json.RawMessage(`"srv-x"`), Method: "m"})
+	}
+	select {
+	case payload := <-respCh:
+		var msg rpcMessage
+		if err := json.Unmarshal(payload, &msg); err != nil || msg.Error == nil {
+			t.Fatalf("overflow response not an explicit error: %s (%v)", payload, err)
+		}
+		if msg.ID == nil || string(*msg.ID) != `"srv-x"` {
+			t.Fatalf("error response id = %s, want srv-x", string(*msg.ID))
+		}
+	case <-time.After(b14bDeadline):
+		t.Fatal("overflowed reply-required request neither delivered nor explicitly failed (B8 regression)")
+	}
+	// Pump liveness while an approval handler was wedged: notifications kept
+	// flowing (delivered or dropped — the readLoop never stalled).
+	mu.Lock()
+	n := notifications
+	mu.Unlock()
+	if n == 0 && len(c.events) == 0 {
+		t.Fatal("notification worker never made progress while approval handler wedged")
+	}
 }

--- a/internal/remote/codex/b14b_regression_test.go
+++ b/internal/remote/codex/b14b_regression_test.go
@@ -1,6 +1,8 @@
 package codex
 
 import (
+	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -144,4 +146,71 @@ func TestB14bCloseTwiceSafe(t *testing.T) {
 	case <-time.After(b14bDeadline):
 		t.Fatal("second Close deadlocked")
 	}
+}
+
+// TestB14bCallWaitsBoundedBehindWedgedWriter pins B6: ctx must bound WAITING
+// for the writer slot, not just the write. A wedged writer (server never
+// reads) holds the slot; a second Call with a short deadline must return
+// ctx.Err within its deadline instead of blocking behind the wedged writer.
+func TestB14bCallWaitsBoundedBehindWedgedWriter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "amqcx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "s.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	// The server accepts but NEVER reads: the client's first big write wedges.
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = acceptServerWS(conn)
+		// deliberately never read or write
+	}()
+	ws, err := dialUnixWS(sock, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	c := newClient(ws)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Writer A: a large payload wedges in conn.Write (buffer full).
+	writeADone := make(chan error, 1)
+	go func() {
+		big := make([]byte, 512*1024) // exceeds any socket buffer
+		writeADone <- ws.writeText(big)
+	}()
+	// Give A time to acquire the slot and block inside Write.
+	time.Sleep(150 * time.Millisecond)
+
+	// Call B: small payload, 250ms deadline. The slot is held by A's
+	// writeText (uncontested under the old mutex: B waited unboundedly).
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	err = c.Call(ctx, "ping", map[string]any{}, nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("call B unexpectedly succeeded while writer wedged")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("call B blocked %v — ctx did not bound WAITING for the writer (B6 regression)", elapsed)
+	}
+	// Under -race scheduling, B's ctx race may lose to the read pump's EOF
+	// (Close tears the conn down when the test ends); the INVARIANT is that
+	// B returned within its deadline with a bounded error, never blocked
+	// behind A. DeadlineExceeded is the expected case on a live connection.
+	c.mu.Lock()
+	readErr := c.readErr
+	c.mu.Unlock()
+	if !errors.Is(err, context.DeadlineExceeded) && (readErr == nil || !errors.Is(err, readErr)) {
+		t.Fatalf("call B err = %v, want context.DeadlineExceeded (or the connection-closed error under teardown)", err)
+	}
+	_ = writeADone // A stays wedged; the test ends and cleanup closes everything.
 }

--- a/internal/remote/codex/b14b_regression_test.go
+++ b/internal/remote/codex/b14b_regression_test.go
@@ -1,0 +1,147 @@
+package codex
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// b14bDeadline bounds every blocking wait: a regression FAILS, never hangs CI.
+const b14bDeadline = 5 * time.Second
+
+// b14bWait polls cond until true or the deadline passes.
+func b14bWait(cond func() bool) bool {
+	deadline := time.Now().Add(b14bDeadline)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// newB14bClient dials a stand-in app-server over a unix socket and wires a
+// handler-invocation counter into both callback paths.
+func newB14bClient(t *testing.T, onNotif func(), onReq func(ServerRequest)) (*Client, net.Listener) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "amqcx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "s.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The stand-in server accepts one connection and then just reads
+	// (discarding) — it never sends anything unless a test writes itself.
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		ws, err := acceptServerWS(conn)
+		if err != nil {
+			return
+		}
+		for {
+			if _, err := ws.readText(); err != nil {
+				return
+			}
+		}
+	}()
+	ws, err := dialUnixWS(sock, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	c := newClient(ws)
+	if onNotif != nil {
+		c.OnNotification = func(n Notification) { onNotif() }
+	}
+	if onReq != nil {
+		c.OnServerRequest = onReq
+	}
+	t.Cleanup(func() { _ = c.Close(); _ = l.Close() })
+	return c, l
+}
+
+// sendNotif / sendReq let tests inject reader-side frames as if the server
+// sent them — but the real readLoop is the only writer-safe reader of the
+// socket, so tests instead deliver via a direct server frame over the conn.
+// Simplest deterministic injection: call the dispatch paths the readLoop
+// would call, since B9/B6/B8 target those paths' lifecycle, not the parse.
+
+// TestB14bCloseRunsWorkerStopAndWorkerExits pins B9: Close must run the
+// STOP lifecycle (previously the shared sync.Once meant close(events) never
+// ran and the worker leaked on every teardown). The worker closes
+// workerDone on exit; the test waits on it with a deadline.
+func TestB14bCloseRunsWorkerStopAndWorkerExits(t *testing.T) {
+	processed := make(chan struct{})
+	c, _ := newB14bClient(t, nil, nil)
+	c.OnNotification = func(n Notification) { close(processed) }
+
+	// Queue a callback so the worker is observably running, then Close.
+	c.dispatch(func() { c.OnNotification(Notification{Method: "x"}) })
+	select {
+	case <-processed:
+	case <-time.After(b14bDeadline):
+		t.Fatal("worker never processed the callback")
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Worker must exit: workerDone closed. Regression (leaked worker) FAILS
+	// here by deadline instead of hanging.
+	select {
+	case <-c.workerDone:
+	case <-time.After(b14bDeadline):
+		t.Fatal("worker did not exit after Close — close(events) never ran (B9 regression)")
+	}
+}
+
+// TestB14bWaitCallbacksCountsInFlight pins B9's second half: waitCallbacks
+// must await the EXECUTING callback (len(events) excludes it). A callback
+// that blocks is awaited until the deadline, then Close returns anyway.
+func TestB14bWaitCallbacksCountsInFlight(t *testing.T) {
+	release := make(chan struct{})
+	handlerRunning := make(chan struct{})
+	c, _ := newB14bClient(t, nil, nil)
+	c.OnNotification = func(n Notification) {
+		close(handlerRunning)
+		<-release
+	}
+	c.dispatch(func() { c.OnNotification(Notification{Method: "x"}) })
+	<-handlerRunning
+	done := make(chan struct{})
+	go func() { c.waitCallbacks(); close(done) }()
+	// waitCallbacks must NOT return while the callback is in flight.
+	select {
+	case <-done:
+		t.Fatal("waitCallbacks returned while callback still executing (in-flight not tracked)")
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(b14bDeadline):
+		t.Fatal("waitCallbacks never returned after in-flight callback finished")
+	}
+}
+
+// TestB14bCloseTwiceSafe pins B9 idempotency: Close twice must not panic
+// (separate stop-Once, idempotent ws close).
+func TestB14bCloseTwiceSafe(t *testing.T) {
+	c, _ := newB14bClient(t, nil, nil)
+	_ = c.Close()
+	done := make(chan struct{})
+	go func() { _ = c.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(b14bDeadline):
+		t.Fatal("second Close deadlocked")
+	}
+}

--- a/internal/remote/codex/b14b_regression_test.go
+++ b/internal/remote/codex/b14b_regression_test.go
@@ -15,18 +15,6 @@ import (
 // b14bDeadline bounds every blocking wait: a regression FAILS, never hangs CI.
 const b14bDeadline = 5 * time.Second
 
-// b14bWait polls cond until true or the deadline passes.
-func b14bWait(cond func() bool) bool {
-	deadline := time.Now().Add(b14bDeadline)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return cond()
-}
-
 // newB14bClient dials a stand-in app-server over a unix socket and wires a
 // handler-invocation counter into both callback paths.
 func newB14bClient(t *testing.T, onNotif func(), onReq func(ServerRequest)) (*Client, net.Listener) {

--- a/internal/remote/codex/rpc.go
+++ b/internal/remote/codex/rpc.go
@@ -297,19 +297,16 @@ func (c *Client) Call(ctx context.Context, method string, params any, result any
 	}
 	c.pending[id] = ch
 	c.mu.Unlock()
-	// Bound the write itself by the context: a blocked socket write must abort
-	// at the deadline, not hang until the connection is closed (Pro B14).
-	if dl, ok := ctx.Deadline(); ok {
-		c.ws.setWriteDeadline(dl)
-	}
-	if err := c.ws.writeText(data); err != nil {
-		c.ws.setWriteDeadline(time.Time{})
+	// Bound BOTH phases of the write by the context (B14b/B6): WAITING for
+	// the writer slot is acquired ctx-aware (the old wmu sync.Mutex waited
+	// unboundedly — ctx only bounded the write after acquisition), and the
+	// write itself carries the deadline under the slot.
+	if err := c.ws.writeTextCtx(ctx, data); err != nil {
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
 		return err
 	}
-	c.ws.setWriteDeadline(time.Time{})
 	select {
 	case resp, ok := <-ch:
 		if !ok {

--- a/internal/remote/codex/rpc.go
+++ b/internal/remote/codex/rpc.go
@@ -182,14 +182,12 @@ func (c *Client) dispatchServerRequest(sr ServerRequest) {
 	_ = c.respondError(sr.ID, "server request queue overflow: "+sr.Method)
 }
 
-// respondError answers a server request with an error result.
+// respondError answers a server request with an error result (JSON-RPC 2.0:
+// error responses carry error, never result — sending both would make the
+// server-side parser pick one arbitrarily).
 func (c *Client) respondError(id json.RawMessage, msg string) error {
 	errObj := rpcError{Code: -32000, Message: msg}
-	raw, err := json.Marshal(errObj)
-	if err != nil {
-		return err
-	}
-	msg2 := rpcMessage{JSONRPC: "2.0", ID: &id, Error: &errObj, Result: raw}
+	msg2 := rpcMessage{JSONRPC: "2.0", ID: &id, Error: &errObj}
 	data, err := json.Marshal(msg2)
 	if err != nil {
 		return err

--- a/internal/remote/codex/rpc.go
+++ b/internal/remote/codex/rpc.go
@@ -37,6 +37,19 @@ type ServerRequest struct {
 	Params json.RawMessage
 }
 
+// event carries one reader callback to the ordered worker. done is closed
+// after run returns, so Close can wait for the in-flight event.
+type event struct {
+	run  func()
+	done chan struct{}
+}
+
+// callbackBacklog bounds the ordered worker's queue. It is comfortably
+// above the notification rate the app-server produces; blocking the read
+// pump is not (a stalled pump starves every pending Call on the
+// connection).
+const callbackBacklog = 64
+
 // Notification is a server-initiated notification.
 type Notification struct {
 	Method string
@@ -55,9 +68,41 @@ type Client struct {
 	once    sync.Once
 	readErr error
 
+	// events is the ordered, bounded callback queue drained by the single
+	// worker goroutine (B14b/B9). Start and stop have SEPARATE lifecycles:
+	// sharing one sync.Once between newClient (start) and Close (stop) meant
+	// close(events) never ran and the worker leaked on every teardown.
+	events        chan event
+	workerStart   sync.Once
+	workerStop    sync.Once
+	workerStarted atomic.Bool
+	workerDone    chan struct{} // closed by the worker on exit (testable teardown)
+	// eventsInFlight counts callbacks currently executing in the worker, so
+	// waitCallbacks can await the in-flight event — len(events) alone
+	// excludes it.
+	eventsInFlight atomic.Int64
+
+	// reqQ is the reply-required server-request queue (B14b/B8). Server
+	// requests (approvals, user input) must never be silently dropped: the
+	// app-server waits for a response. The queue is bounded by the liveness
+	// invariant — at most one in-flight approval per live run — and dispatch
+	// to it NEVER blocks the read pump. On the should-be-impossible overflow
+	// the request is failed explicitly (Respond with an error) so the server
+	// never waits silently.
+	reqQ          chan ServerRequest
+	reqQCapacity  int
+	reqWorkerDone chan struct{} // closed by the req worker on exit
+
 	OnNotification  func(Notification)
 	OnServerRequest func(ServerRequest)
 }
+
+// reqQSlack is the slack above max live runs for the reply-required queue.
+const reqQSlack = 8
+
+// maxLiveRuns bounds the number of concurrent native runs the attachment
+// tracks; approvals are per-run, so this bounds reply-required in-flight.
+const maxLiveRuns = 16
 
 // Dial connects to the app-server unix socket and starts the read loop.
 func Dial(socketPath string) (*Client, error) {
@@ -69,9 +114,120 @@ func Dial(socketPath string) (*Client, error) {
 }
 
 func newClient(ws *wsConn) *Client {
-	c := &Client{ws: ws, pending: map[int64]chan rpcMessage{}, closed: make(chan struct{})}
+	c := &Client{
+		ws:            ws,
+		pending:       map[int64]chan rpcMessage{},
+		closed:        make(chan struct{}),
+		events:        make(chan event, callbackBacklog),
+		workerDone:    make(chan struct{}),
+		reqQ:          make(chan ServerRequest, maxLiveRuns+reqQSlack),
+		reqQCapacity:  maxLiveRuns + reqQSlack,
+		reqWorkerDone: make(chan struct{}),
+	}
 	go c.readLoop()
+	go c.reqWorker()
+	c.workerStart.Do(func() {
+		c.workerStarted.Store(true)
+		go c.startWorker()
+	})
 	return c
+}
+
+// startWorker runs the single ordered callback worker: events apply strictly
+// in arrival order — Question then QuestionResolved cannot invert — and the
+// read pump never blocks on handler latency. The worker recovers its own
+// panic so a callback bug cannot kill the read pump and every pending call
+// with it. It exits when the events channel is closed, then closes
+// workerDone so tests can observe the exit deterministically.
+func (c *Client) startWorker() {
+	defer close(c.workerDone)
+	for ev := range c.events {
+		c.eventsInFlight.Add(1)
+		func() {
+			defer func() { _ = recover() }()
+			defer close(ev.done)
+			ev.run()
+		}()
+		c.eventsInFlight.Add(-1)
+	}
+}
+
+// dispatch hands one reader callback to the ordered worker with a bounded,
+// non-blocking enqueue. Overflow drops the event rather than wedging the
+// pump (notifications may drop; reply-required frames never reach this path
+// — they go through dispatchServerRequest).
+func (c *Client) dispatch(run func()) {
+	ev := event{run: run, done: make(chan struct{})}
+	select {
+	case c.events <- ev:
+	default:
+		// Backlog full: drop. The endpoint re-derives dropped state via
+		// Reconcile; blocking here would stall the read pump.
+		close(ev.done)
+	}
+}
+
+// dispatchServerRequest enqueues a reply-required server request without
+// ever blocking the read pump (B14b/B8). Overflow must not happen — the
+// app-server has at most one in-flight approval per live run — but if it
+// ever does, the request is FAILED EXPLICITLY (Respond with an error) so
+// the app-server never waits for an answer that never comes.
+func (c *Client) dispatchServerRequest(sr ServerRequest) {
+	select {
+	case c.reqQ <- sr:
+		return
+	default:
+	}
+	// Overflow: explicit failure, never a silent drop, never a blocked pump.
+	_ = c.respondError(sr.ID, "server request queue overflow: "+sr.Method)
+}
+
+// respondError answers a server request with an error result.
+func (c *Client) respondError(id json.RawMessage, msg string) error {
+	errObj := rpcError{Code: -32000, Message: msg}
+	raw, err := json.Marshal(errObj)
+	if err != nil {
+		return err
+	}
+	msg2 := rpcMessage{JSONRPC: "2.0", ID: &id, Error: &errObj, Result: raw}
+	data, err := json.Marshal(msg2)
+	if err != nil {
+		return err
+	}
+	return c.ws.writeText(data)
+}
+
+// reqWorker drains the reply-required queue. It exits when reqQ is closed.
+func (c *Client) reqWorker() {
+	defer close(c.reqWorkerDone)
+	for sr := range c.reqQ {
+		func() {
+			defer func() { _ = recover() }()
+			if c.OnServerRequest != nil {
+				c.OnServerRequest(sr)
+			}
+		}()
+	}
+}
+
+// waitCallbacks drains both queues and waits for the in-flight callbacks,
+// so Close does not return while callbacks still touch app state. Bounded:
+// the deadline keeps Close responsive if a handler is wedged.
+func (c *Client) waitCallbacks() {
+	deadline := time.After(2 * time.Second)
+	for {
+		c.mu.Lock()
+		depth := len(c.events) + len(c.reqQ)
+		c.mu.Unlock()
+		if depth == 0 && c.eventsInFlight.Load() == 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			return
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
 }
 
 func (c *Client) readLoop() {
@@ -107,7 +263,7 @@ func (c *Client) readLoop() {
 			}
 		case msg.ID != nil:
 			if c.OnServerRequest != nil {
-				c.OnServerRequest(ServerRequest{ID: *msg.ID, Method: msg.Method, Params: msg.Params})
+				c.dispatchServerRequest(ServerRequest{ID: *msg.ID, Method: msg.Method, Params: msg.Params})
 			}
 		case msg.Method != "":
 			if c.OnNotification != nil {
@@ -188,5 +344,19 @@ func (c *Client) Respond(id json.RawMessage, result any) error {
 	return c.ws.writeText(data)
 }
 
-// Close closes the connection.
-func (c *Client) Close() error { return c.ws.close() }
+// Close tears the connection down and stops the callback workers (B14b/B9):
+// the events channel closes (worker exits after the in-flight event; Close
+// waits, bounded), then the conn closes — aborting any blocked read or
+// write immediately. The stop lifecycle is a separate sync.Once from the
+// start Once, so it actually runs: the previous single-once design leaked
+// the worker on every teardown. Safe to call twice.
+func (c *Client) Close() error {
+	c.workerStop.Do(func() {
+		if c.workerStarted.Load() {
+			close(c.events)
+		}
+		close(c.reqQ)
+	})
+	c.waitCallbacks()
+	return c.ws.close()
+}

--- a/internal/remote/codex/ws.go
+++ b/internal/remote/codex/ws.go
@@ -6,6 +6,7 @@ package codex
 
 import (
 	"bufio"
+	"context"
 	"crypto/rand"
 	"crypto/sha1" //nolint:gosec // RFC 6455 mandates SHA-1 for the accept key.
 	"encoding/base64"
@@ -16,7 +17,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -34,11 +34,38 @@ const (
 )
 
 // wsConn is one client WebSocket over an already-dialed connection.
+// wmu is a cap-1 channel semaphore (B14b/B6): acquisition is a select on
+// send vs ctx.Done(), so WAITING for the writer is context-bounded — the
+// old sync.Mutex acquisition was unbounded, and ctx only bounded the write
+// after it. Release is a receive. Zero extra goroutines, no lost unlocks.
 type wsConn struct {
 	conn net.Conn
 	br   *bufio.Reader
-	wmu  sync.Mutex
+	wmu  chan struct{}
 }
+
+func newWSConn(conn net.Conn, br *bufio.Reader) *wsConn {
+	return &wsConn{conn: conn, br: br, wmu: make(chan struct{}, 1)}
+}
+
+// lockWriteCtx acquires the writer slot or gives up on ctx.
+func (w *wsConn) lockWriteCtx(ctx context.Context) error {
+	select {
+	case w.wmu <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// lockWrite acquires the writer slot without a context (unbounded wait,
+// used only by pings/close-frames which must always land).
+func (w *wsConn) lockWrite() {
+	w.wmu <- struct{}{}
+}
+
+// unlockWrite releases the writer slot.
+func (w *wsConn) unlockWrite() { <-w.wmu }
 
 // dialUnixWS connects to a unix socket and performs the WebSocket upgrade.
 func dialUnixWS(path string, timeout time.Duration) (*wsConn, error) {
@@ -46,7 +73,7 @@ func dialUnixWS(path string, timeout time.Duration) (*wsConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	ws := &wsConn{conn: conn, br: bufio.NewReaderSize(conn, 64*1024)}
+	ws := newWSConn(conn, bufio.NewReaderSize(conn, 64*1024))
 	if err := ws.handshake(); err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -92,9 +119,33 @@ func (w *wsConn) writeText(payload []byte) error {
 	return w.writeFrame(opText, payload)
 }
 
+// writeTextCtx sends one masked text frame bounded by ctx in BOTH phases:
+// acquiring the writer slot (select on ctx.Done) and the write itself
+// (deadline installed+cleared under the slot, so concurrent writers cannot
+// clobber each other's deadline). This is Pro B14 recut #5's
+// deadline-under-mutex discipline with context-bounded acquisition added
+// (B14b/B6).
+func (w *wsConn) writeTextCtx(ctx context.Context, payload []byte) error {
+	if err := w.lockWriteCtx(ctx); err != nil {
+		return err
+	}
+	defer w.unlockWrite()
+	dl, ok := ctx.Deadline()
+	if ok {
+		_ = w.conn.SetWriteDeadline(dl)
+		defer func() { _ = w.conn.SetWriteDeadline(time.Time{}) }()
+	}
+	return w.writeFrameBody(opText, payload)
+}
+
+// writeFrame sends one frame, acquiring the writer slot without a context
+// (pings, pongs, close frames, and Respond must always land).
 func (w *wsConn) writeFrame(opcode byte, payload []byte) error {
-	w.wmu.Lock()
-	defer w.wmu.Unlock()
+	w.lockWrite()
+	defer w.unlockWrite()
+	return w.writeFrameBody(opcode, payload)
+}
+func (w *wsConn) writeFrameBody(opcode byte, payload []byte) error {
 	var mask [4]byte
 	if _, err := rand.Read(mask[:]); err != nil {
 		return err
@@ -196,7 +247,15 @@ func (w *wsConn) readFrame() (byte, []byte, error) {
 }
 
 func (w *wsConn) close() error {
-	_ = w.writeFrame(opClose, nil)
+	// Try to send a close frame without blocking forever behind a wedged
+	// writer: the conn.Close below aborts any in-flight write anyway, and
+	// close must never hang (a blocked close-frame send wedges teardown).
+	select {
+	case w.wmu <- struct{}{}:
+		_ = w.writeFrameBody(opClose, nil)
+		<-w.wmu
+	default:
+	}
 	return w.conn.Close()
 }
 
@@ -218,5 +277,5 @@ func acceptServerWS(conn net.Conn) (*wsConn, error) {
 	if _, err := io.WriteString(conn, resp); err != nil {
 		return nil, err
 	}
-	return &wsConn{conn: conn, br: br}, nil
+	return newWSConn(conn, br), nil
 }

--- a/internal/remote/codex/ws.go
+++ b/internal/remote/codex/ws.go
@@ -109,11 +109,6 @@ func (w *wsConn) handshake() error {
 	return nil
 }
 
-// setWriteDeadline bounds subsequent frame writes; zero clears it.
-func (w *wsConn) setWriteDeadline(t time.Time) {
-	_ = w.conn.SetWriteDeadline(t)
-}
-
 // writeText sends one masked text frame.
 func (w *wsConn) writeText(payload []byte) error {
 	return w.writeFrame(opText, payload)


### PR DESCRIPTION
Bead 611.22.15.2 (B14b). Codex transport I/O bounds + callback worker lifecycle, from the B14 decomposition.

- **B9** — separate workerStart/workerStop Onces (the old shared Once meant Close's close(events) never ran → worker leaked every teardown); explicit eventsInFlight counter (waitCallbacks awaits in-flight==0 AND queue empty under the 2s bound); double-Close safe.
- **B6** — wmu is now a cap-1 channel semaphore: acquire selects on ctx.Done() so a wedged writer can't block a control Call past its deadline; deadline install/write/clear under the held slot.
- **B8** — reply-required server requests get their own bounded queue + dedicated worker, non-blocking dispatch; overflow responds an explicit JSON-RPC error (never blocks the read pump, never silently drops). Notifications stay lossy.
- Two extra hardening fixes found during the build: close-frame no longer sent via the unbounded path (a wedged writer could wedge teardown); acceptServerWS builds wsConn via the constructor (a literal left wmu nil after the semaphore switch — nil-chan panic caught by the round-trip test).

Hard-deadline regression tests per blocker (a regression FAILS, never hangs CI). Full internal/remote -race, codex -race x3, vet, golangci-lint, gofmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)