### PR TITLE
fix(fsq): sync every mailbox level a first-contact delivery creates

### DIFF
--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -452,7 +452,8 @@ func (r *DeliveryRoot) EnsureRootDirs() error {
 	if err := r.VerifyBase(); err != nil {
 		return err
 	}
-	return r.mkdirAllSynced("agents", "threads", "meta")
+	// Queue-level provisioning: sync what we create.
+	return r.mkdirAllSynced(syncIfCreated, "agents", "threads", "meta")
 }
 
 // EnsureAgentDirs creates one agent's mailbox layout through the pinned root
@@ -468,7 +469,7 @@ func (r *DeliveryRoot) EnsureAgentDirs(agent string) error {
 	for _, leaf := range requiredMailboxLeaves {
 		dirs = append(dirs, MailboxRootRelativePath(agent, leaf))
 	}
-	return r.mkdirAllSynced(dirs...)
+	return r.mkdirAllSynced(syncIfCreated, dirs...)
 }
 
 // EnsureAgentDir creates exactly one mailbox leaf for an agent through the
@@ -484,7 +485,7 @@ func (r *DeliveryRoot) EnsureAgentDir(agent string, leaf MailboxLeaf) error {
 	if err := r.VerifyBase(); err != nil {
 		return err
 	}
-	return r.mkdirAllSynced(MailboxRootRelativePath(agent, leaf))
+	return r.mkdirAllSynced(syncIfCreated, MailboxRootRelativePath(agent, leaf))
 }
 
 // LayoutState classifies a pinned root's top-level queue layout.
@@ -578,6 +579,29 @@ func (r *DeliveryRoot) dirExists(name string) bool {
 	return err == nil && info.IsDir()
 }
 
+// durability says how hard mkdirAllSynced must work to make a tree durable.
+// The two callers are genuinely different, and collapsing them costs either
+// correctness or a queue-global fsync on a hot path.
+type durability int
+
+const (
+	// syncIfCreated syncs the ancestor chain only when this call actually
+	// created a directory. A routine internal write owes durability for what
+	// it made and nothing more. The notification-attempt ledger appends
+	// through this path thousands of times against a mailbox that already
+	// exists; making it fsync the shared queue root every time would turn a
+	// path designed to not serialize among appenders into a queue-global
+	// barrier.
+	syncIfCreated durability = iota
+	// syncAlways re-syncs the chain on every call, created or not. The caller
+	// is about to ACKNOWLEDGE something to someone else, so it may not assume
+	// an earlier call finished making this tree durable: that call may have
+	// created a level and died before syncing its parent, leaving a directory
+	// that Stat can see and power loss can still take. Stat proves existence,
+	// never durability.
+	syncAlways
+)
+
 // mkdirAllSynced creates every dir (and its missing ancestors) through the
 // pinned root, then makes the resulting tree durable: it fsyncs each directory
 // that owns an entry on the way to a dir, up to and including the pinned root.
@@ -588,14 +612,21 @@ func (r *DeliveryRoot) dirExists(name string) bool {
 // Pass the directories of one logical mailbox together. A failed sync is
 // reported as a plain error: nothing is committed at a leaf yet, so the
 // caller's staging cleanup still applies.
-func (r *DeliveryRoot) mkdirAllSynced(dirs ...string) error {
+func (r *DeliveryRoot) mkdirAllSynced(mode durability, dirs ...string) error {
+	created := false
 	for _, dir := range dirs {
 		if err := r.refuseNonDirectoryAncestor(dir); err != nil {
 			return err
 		}
+		if !r.dirExists(dir) {
+			created = true
+		}
 		if err := r.root.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
+	}
+	if !created && mode == syncIfCreated {
+		return nil
 	}
 	// Create everything first, then sync each shared ancestor once. Siblings
 	// of one mailbox (inbox/tmp and inbox/new, or all seven leaves) share

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -452,12 +452,7 @@ func (r *DeliveryRoot) EnsureRootDirs() error {
 	if err := r.VerifyBase(); err != nil {
 		return err
 	}
-	for _, dir := range []string{"agents", "threads", "meta"} {
-		if err := r.mkdirAllSynced(dir); err != nil {
-			return err
-		}
-	}
-	return nil
+	return r.mkdirAllSynced("agents", "threads", "meta")
 }
 
 // EnsureAgentDirs creates one agent's mailbox layout through the pinned root
@@ -469,12 +464,11 @@ func (r *DeliveryRoot) EnsureAgentDirs(agent string) error {
 	if err := r.VerifyBase(); err != nil {
 		return err
 	}
+	dirs := make([]string, 0, len(requiredMailboxLeaves))
 	for _, leaf := range requiredMailboxLeaves {
-		if err := r.mkdirAllSynced(MailboxRootRelativePath(agent, leaf)); err != nil {
-			return err
-		}
+		dirs = append(dirs, MailboxRootRelativePath(agent, leaf))
 	}
-	return nil
+	return r.mkdirAllSynced(dirs...)
 }
 
 // EnsureAgentDir creates exactly one mailbox leaf for an agent through the
@@ -584,59 +578,52 @@ func (r *DeliveryRoot) dirExists(name string) bool {
 	return err == nil && info.IsDir()
 }
 
-// mkdirAllSynced creates dir and any missing ancestors through the pinned
-// root, then fsyncs every directory level this call created. Delivery writes
-// fsync the message file and its leaf directory; without also syncing the
-// newly created ancestors, a crash right after a first-contact delivery can
-// still lose the whole mailbox tree along with the message it committed.
-// Pre-existing levels are not re-synced: this call introduced nothing below
-// them. A failed ancestor sync is reported as a plain error (nothing has been
-// committed at the leaf yet, so the caller's staging cleanup still applies).
-func (r *DeliveryRoot) mkdirAllSynced(dir string) error {
-	missing, err := r.firstMissingAncestor(dir)
-	if err != nil {
-		return err
-	}
-	if missing == "" {
-		// The whole tree already exists. This helper owns TREE durability,
-		// not message durability: the delivery commit path syncs new/tmp
-		// after its rename, which is the sync that makes a message durable.
-		// Re-syncing an established tree here would be redundant on every
-		// delivery and would turn a commit-phase durability fault into a
-		// pre-staging error. An existing tree whose earlier creation crashed
-		// before its sync is repaired by that same commit-phase sync of new
-		// and by doctor --fix-mailboxes; it is not this call's job.
-		return nil
-	}
-	if err := r.root.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
-	// Durability is about directory ENTRIES: fsync(d) persists d's entries,
-	// never d's own entry inside its parent. So the set to sync is every
-	// created level, leaf first, AND the first pre-existing ancestor — its
-	// entry for the new subtree is what changed. Stopping at the shallowest
-	// created level (the earlier version) left that entry unsynced.
-	for d := dir; ; d = filepath.Dir(d) {
-		if err := r.syncDir(d); err != nil {
-			return fmt.Errorf("sync created ancestor %s: %w", d, err)
+// mkdirAllSynced creates every dir (and its missing ancestors) through the
+// pinned root, then makes the resulting tree durable: it fsyncs each directory
+// that owns an entry on the way to a dir, up to and including the pinned root.
+// Delivery writes fsync the message file and its leaf directory; without the
+// ancestor syncs, a crash right after a first-contact delivery can still lose
+// the whole mailbox tree along with the message it committed.
+//
+// Pass the directories of one logical mailbox together. A failed sync is
+// reported as a plain error: nothing is committed at a leaf yet, so the
+// caller's staging cleanup still applies.
+func (r *DeliveryRoot) mkdirAllSynced(dirs ...string) error {
+	for _, dir := range dirs {
+		if err := r.refuseNonDirectoryAncestor(dir); err != nil {
+			return err
 		}
-		if d == missing {
-			parent := filepath.Dir(d)
-			if parent != d && parent != "." && parent != string(filepath.Separator) {
-				if err := r.syncDir(parent); err != nil {
-					return fmt.Errorf("sync parent of created tree %s: %w", parent, err)
-				}
+		if err := r.root.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	// Create everything first, then sync each shared ancestor once. Siblings
+	// of one mailbox (inbox/tmp and inbox/new, or all seven leaves) share
+	// nearly the whole chain, and a per-directory walk would fsync the same
+	// levels over and over — and would sync a parent while a later sibling
+	// below it still had no durable entry.
+	synced := make(map[string]bool, 8)
+	for _, dir := range dirs {
+		// ancestorChain owns the reasoning: every directory that holds an
+		// entry on the way to dir, up to and including the pinned root, on
+		// every call.
+		for _, d := range ancestorChain(dir, ".") {
+			if synced[d] {
+				continue
 			}
-			return nil
+			if err := r.syncDir(d); err != nil {
+				return fmt.Errorf("sync mailbox ancestor %s: %w", d, err)
+			}
+			synced[d] = true
 		}
 	}
+	return nil
 }
 
-// firstMissingAncestor walks from dir toward the pinned root and returns the
-// shallowest missing level (the topmost ancestor that does not exist yet), or
-// "" when every level already exists.
-func (r *DeliveryRoot) firstMissingAncestor(dir string) (string, error) {
-	missing := ""
+// refuseNonDirectoryAncestor walks from dir toward the pinned root and fails
+// when any existing level is not a directory. Pinned twin of
+// refuseNonDirectoryAmbient.
+func (r *DeliveryRoot) refuseNonDirectoryAncestor(dir string) error {
 	current := dir
 	for {
 		info, err := r.root.Stat(current)
@@ -646,16 +633,15 @@ func (r *DeliveryRoot) firstMissingAncestor(dir string) (string, error) {
 				// corrupt layout, not a missing level. Refuse before staging
 				// anything so a multi-recipient delivery fails whole, never
 				// partially committed.
-				return "", fmt.Errorf("mailbox path %s exists and is not a directory", current)
+				return fmt.Errorf("mailbox path %s exists and is not a directory", current)
 			}
-			return missing, nil
+			return nil
 		} else if !errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("stat %s: %w", current, err)
+			return fmt.Errorf("stat %s: %w", current, err)
 		}
-		missing = current
 		parent := filepath.Dir(current)
 		if parent == current {
-			return missing, nil
+			return nil
 		}
 		current = parent
 	}

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -598,16 +598,35 @@ func (r *DeliveryRoot) mkdirAllSynced(dir string) error {
 		return err
 	}
 	if missing == "" {
+		// The whole tree already exists. This helper owns TREE durability,
+		// not message durability: the delivery commit path syncs new/tmp
+		// after its rename, which is the sync that makes a message durable.
+		// Re-syncing an established tree here would be redundant on every
+		// delivery and would turn a commit-phase durability fault into a
+		// pre-staging error. An existing tree whose earlier creation crashed
+		// before its sync is repaired by that same commit-phase sync of new
+		// and by doctor --fix-mailboxes; it is not this call's job.
 		return nil
 	}
 	if err := r.root.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
+	// Durability is about directory ENTRIES: fsync(d) persists d's entries,
+	// never d's own entry inside its parent. So the set to sync is every
+	// created level, leaf first, AND the first pre-existing ancestor — its
+	// entry for the new subtree is what changed. Stopping at the shallowest
+	// created level (the earlier version) left that entry unsynced.
 	for d := dir; ; d = filepath.Dir(d) {
 		if err := r.syncDir(d); err != nil {
 			return fmt.Errorf("sync created ancestor %s: %w", d, err)
 		}
 		if d == missing {
+			parent := filepath.Dir(d)
+			if parent != d && parent != "." && parent != string(filepath.Separator) {
+				if err := r.syncDir(parent); err != nil {
+					return fmt.Errorf("sync parent of created tree %s: %w", parent, err)
+				}
+			}
 			return nil
 		}
 	}
@@ -620,7 +639,15 @@ func (r *DeliveryRoot) firstMissingAncestor(dir string) (string, error) {
 	missing := ""
 	current := dir
 	for {
-		if _, err := r.root.Stat(current); err == nil {
+		info, err := r.root.Stat(current)
+		if err == nil {
+			if !info.IsDir() {
+				// A regular file where a mailbox directory must be is a
+				// corrupt layout, not a missing level. Refuse before staging
+				// anything so a multi-recipient delivery fails whole, never
+				// partially committed.
+				return "", fmt.Errorf("mailbox path %s exists and is not a directory", current)
+			}
 			return missing, nil
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			return "", fmt.Errorf("stat %s: %w", current, err)

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -85,7 +85,11 @@ func firstMissingAncestorAmbient(dir string) (string, error) {
 	missing := ""
 	current := dir
 	for {
-		if _, err := os.Stat(current); err == nil {
+		info, err := os.Stat(current)
+		if err == nil {
+			if !info.IsDir() {
+				return "", fmt.Errorf("mailbox path %s exists and is not a directory", current)
+			}
 			return missing, nil
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			return "", fmt.Errorf("stat %s: %w", current, err)
@@ -178,18 +182,25 @@ func EnsureAgentDirs(root, agent string) error {
 			return err
 		}
 		if missing == "" {
-			continue
+			continue // tree exists; this helper owns tree durability only
 		}
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
-		// Sync every level this call created so a crash cannot lose the
-		// mailbox tree below a newly provisioned agent directory.
+		// Sync every created level, leaf first, AND the first pre-existing
+		// ancestor: fsync(d) persists d's entries, never d's own entry in its
+		// parent, so the existing parent whose entry changed must be synced.
 		for d := dir; ; d = filepath.Dir(d) {
 			if err := SyncDir(d); err != nil {
 				return fmt.Errorf("sync created ancestor %s: %w", d, err)
 			}
 			if d == missing {
+				parent := filepath.Dir(d)
+				if parent != d && parent != "." && parent != string(filepath.Separator) {
+					if err := SyncDir(parent); err != nil {
+						return fmt.Errorf("sync mailbox parent %s: %w", parent, err)
+					}
+				}
 				break
 			}
 		}

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -190,6 +190,17 @@ func AgentReceipts(root, agent string) string {
 }
 
 func EnsureRootDirs(root string) error {
+	// os.MkdirAll below creates the queue root itself when it is missing
+	// (`amq init` / `amq session create` on a fresh path). Whoever creates a
+	// directory entry owns the fsync that makes it durable, so note whether
+	// the root was ours to create BEFORE we create it.
+	rootExisted := true
+	if _, err := os.Stat(root); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("stat queue root %s: %w", root, err)
+		}
+		rootExisted = false
+	}
 	for _, dir := range []string{
 		filepath.Join(root, "agents"),
 		filepath.Join(root, "threads"),
@@ -200,8 +211,23 @@ func EnsureRootDirs(root string) error {
 		}
 	}
 	// The root owns the entries for all three, so one fsync of the root makes
-	// them durable. Above the root is the operator's own path, not ours.
-	return SyncDir(root)
+	// them durable.
+	if err := SyncDir(root); err != nil {
+		return err
+	}
+	if rootExisted {
+		// The parent is the operator's own path and gained nothing from us.
+		return nil
+	}
+	// We created the root's own entry in its parent, and fsync(root) does not
+	// persist that entry. Without this, `amq init` followed by a first-contact
+	// send reports success and power loss takes the whole queue — the exact
+	// loss this file's ancestor syncing exists to prevent, one level up.
+	parent := filepath.Dir(root)
+	if parent == root {
+		return nil
+	}
+	return SyncDir(parent)
 }
 
 func EnsureAgentDirs(root, agent string) error {

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -120,6 +120,11 @@ func refuseNonDirectoryAmbient(dir string) error {
 // it is visible to Stat while its entry is not yet on stable storage. Stat
 // proves existence, never durability.
 func ancestorChain(dir, stop string) []string {
+	// The walk compares against stop, and filepath.Dir returns cleaned paths.
+	// An operator's --root may carry a trailing slash, so clean stop too: a
+	// stop that never matches would walk past the queue root and fsync the
+	// operator's own directories up to "/".
+	stop = filepath.Clean(stop)
 	chain := make([]string, 0, 8)
 	for d := filepath.Dir(dir); ; d = filepath.Dir(d) {
 		chain = append(chain, d)

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -76,30 +76,56 @@ var requiredMailboxLeaves = [...]MailboxLeaf{
 	MailboxReceipts,
 }
 
-// firstMissingAncestorAmbient walks from dir toward the filesystem root and
-// returns the shallowest missing level (the topmost ancestor that does not
-// exist yet), or "" when every level already exists.
-// Companion to DeliveryRoot.firstMissingAncestor for the ambient-path layout
-// helpers that run before a capability is opened.
-func firstMissingAncestorAmbient(dir string) (string, error) {
-	missing := ""
+// refuseNonDirectoryAmbient walks from dir toward the filesystem root and
+// fails when any existing level is not a directory. A regular file where a
+// mailbox directory must be is a corrupt layout, not a missing level:
+// refusing here means a multi-recipient delivery fails whole instead of
+// creating part of one tree and then erroring. Companion to
+// DeliveryRoot.refuseNonDirectoryAncestor for the ambient-path layout helpers
+// that run before a capability is opened.
+func refuseNonDirectoryAmbient(dir string) error {
 	current := dir
 	for {
 		info, err := os.Stat(current)
 		if err == nil {
 			if !info.IsDir() {
-				return "", fmt.Errorf("mailbox path %s exists and is not a directory", current)
+				return fmt.Errorf("mailbox path %s exists and is not a directory", current)
 			}
-			return missing, nil
+			return nil
 		} else if !errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("stat %s: %w", current, err)
+			return fmt.Errorf("stat %s: %w", current, err)
 		}
-		missing = current
 		parent := filepath.Dir(current)
 		if parent == current {
-			return missing, nil
+			return nil
 		}
 		current = parent
+	}
+}
+
+// ancestorChain returns the directories that OWN an entry on the path to dir:
+// dir's parent, that directory's parent, and so on, ending at and INCLUDING
+// stop. Deepest first.
+//
+// This set is the whole durability contract for creating dir. fsync(d)
+// persists d's entries and never d's own entry inside its parent, so dir
+// survives power loss only if every directory down this chain is synced —
+// including stop itself, which owns the entry for the shallowest level of a
+// brand-new subtree. dir is deliberately absent: a directory we just created
+// is empty, and the writer that puts a message in it syncs it at the commit.
+//
+// The chain is walked on every call, not only when this call created
+// something. An existing directory is not a durable directory: an earlier call
+// may have created it and then failed or crashed before syncing its parent, so
+// it is visible to Stat while its entry is not yet on stable storage. Stat
+// proves existence, never durability.
+func ancestorChain(dir, stop string) []string {
+	chain := make([]string, 0, 8)
+	for d := filepath.Dir(dir); ; d = filepath.Dir(d) {
+		chain = append(chain, d)
+		if d == stop || d == "." || d == string(filepath.Separator) || filepath.Dir(d) == d {
+			return chain
+		}
 	}
 }
 
@@ -168,41 +194,37 @@ func EnsureRootDirs(root string) error {
 			return err
 		}
 	}
-	return nil
+	// The root owns the entries for all three, so one fsync of the root makes
+	// them durable. Above the root is the operator's own path, not ours.
+	return SyncDir(root)
 }
 
 func EnsureAgentDirs(root, agent string) error {
 	if err := ValidateHandle(agent); err != nil {
 		return err
 	}
+	// Create the whole mailbox first, then make it durable once. The seven
+	// leaves share almost all of their ancestors, so syncing each leaf's chain
+	// separately would fsync the same six directories thirty-one times.
 	for _, leaf := range requiredMailboxLeaves {
 		dir := AgentMailboxPath(root, agent, leaf)
-		missing, err := firstMissingAncestorAmbient(dir)
-		if err != nil {
+		if err := refuseNonDirectoryAmbient(dir); err != nil {
 			return err
-		}
-		if missing == "" {
-			continue // tree exists; this helper owns tree durability only
 		}
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
-		// Sync every created level, leaf first, AND the first pre-existing
-		// ancestor: fsync(d) persists d's entries, never d's own entry in its
-		// parent, so the existing parent whose entry changed must be synced.
-		for d := dir; ; d = filepath.Dir(d) {
+	}
+	synced := make(map[string]bool, 8)
+	for _, leaf := range requiredMailboxLeaves {
+		for _, d := range ancestorChain(AgentMailboxPath(root, agent, leaf), root) {
+			if synced[d] {
+				continue
+			}
 			if err := SyncDir(d); err != nil {
-				return fmt.Errorf("sync created ancestor %s: %w", d, err)
+				return fmt.Errorf("sync mailbox ancestor %s: %w", d, err)
 			}
-			if d == missing {
-				parent := filepath.Dir(d)
-				if parent != d && parent != "." && parent != string(filepath.Separator) {
-					if err := SyncDir(parent); err != nil {
-						return fmt.Errorf("sync mailbox parent %s: %w", parent, err)
-					}
-				}
-				break
-			}
+			synced[d] = true
 		}
 	}
 	return nil

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -192,14 +192,22 @@ func AgentReceipts(root, agent string) string {
 func EnsureRootDirs(root string) error {
 	// os.MkdirAll below creates the queue root itself when it is missing
 	// (`amq init` / `amq session create` on a fresh path). Whoever creates a
-	// directory entry owns the fsync that makes it durable, so note whether
-	// the root was ours to create BEFORE we create it.
-	rootExisted := true
-	if _, err := os.Stat(root); err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("stat queue root %s: %w", root, err)
+	// directory entry owns the fsync that makes it durable, so note what was
+	// ours to create BEFORE we create it. `amq init --root a/b/c` can create SEVERAL missing levels at once, and
+	// each one's entry lives in the level above it, so remember the shallowest
+	// level that was missing — the whole created chain needs syncing, not just
+	// the root's immediate parent.
+	firstCreated := ""
+	for d := root; ; d = filepath.Dir(d) {
+		if _, err := os.Stat(d); err == nil {
+			break
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("stat queue root %s: %w", d, err)
 		}
-		rootExisted = false
+		firstCreated = d
+		if parent := filepath.Dir(d); parent == d {
+			break
+		}
 	}
 	for _, dir := range []string{
 		filepath.Join(root, "agents"),
@@ -215,19 +223,24 @@ func EnsureRootDirs(root string) error {
 	if err := SyncDir(root); err != nil {
 		return err
 	}
-	if rootExisted {
-		// The parent is the operator's own path and gained nothing from us.
+	if firstCreated == "" {
+		// Every level already existed; their parents gained nothing from us,
+		// and above the root is the operator's own path.
 		return nil
 	}
-	// We created the root's own entry in its parent, and fsync(root) does not
-	// persist that entry. Without this, `amq init` followed by a first-contact
-	// send reports success and power loss takes the whole queue — the exact
-	// loss this file's ancestor syncing exists to prevent, one level up.
-	parent := filepath.Dir(root)
-	if parent == root {
-		return nil
+	// fsync(d) does not persist d's OWN entry in its parent, so every level we
+	// created needs its parent synced — up to and including the parent of the
+	// shallowest one. Without this, `amq init` followed by a first-contact
+	// send reports success and power loss takes the whole queue: the exact
+	// loss this file's ancestor syncing prevents, one level up. ancestorChain
+	// stops at the first level that already existed, which is the only one
+	// that gained an entry from us but that we did not create.
+	for _, d := range ancestorChain(root, filepath.Dir(firstCreated)) {
+		if err := SyncDir(d); err != nil {
+			return fmt.Errorf("sync created queue root ancestor %s: %w", d, err)
+		}
 	}
-	return SyncDir(parent)
+	return nil
 }
 
 func EnsureAgentDirs(root, agent string) error {

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -386,3 +386,42 @@ func TestEnsureRootDirsSyncsTheParentThatOwnsANewRoot(t *testing.T) {
 		}
 	}
 }
+
+// `amq init --root a/b/c` can create SEVERAL missing levels in one call, and
+// each level's entry lives in the level above it. Syncing only the root's
+// immediate parent left the shallowest created level's entry unsynced, so
+// power loss after a first-contact send still took the whole queue. Found by
+// pre-merge review of agent-message-queue-611.22.26 (fsq first-contact sync).
+func TestEnsureRootDirsSyncsEveryLevelItCreated(t *testing.T) {
+	outer := t.TempDir()
+	root := filepath.Join(outer, "proj", "nested", ".amq")
+
+	var synced []string
+	restore := syncDirAmbientSwapForTest(func(dir string) error {
+		synced = append(synced, dir)
+		return nil
+	})
+	defer restore()
+
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	// Every directory that owns an entry we created, up to and including the
+	// pre-existing directory that owns the shallowest new level.
+	for _, dir := range []string{
+		root,
+		filepath.Join(outer, "proj", "nested"),
+		filepath.Join(outer, "proj"),
+		outer,
+	} {
+		found := false
+		for _, d := range synced {
+			if d == dir {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("level %s owns an entry we created but was never synced (all: %v)", dir, synced)
+		}
+	}
+}

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -60,7 +60,7 @@ func TestMkdirAllSyncedCoversEveryOwningDirectoryUpToRoot(t *testing.T) {
 		}
 	}
 
-	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
+	if err := root.mkdirAllSynced(syncAlways, filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
 		t.Fatalf("mkdirAllSynced: %v", err)
 	}
 	assertSync("first contact", synced)
@@ -68,7 +68,7 @@ func TestMkdirAllSyncedCoversEveryOwningDirectoryUpToRoot(t *testing.T) {
 	// The same tree already exists. It is still re-synced: Stat proves
 	// existence, not durability.
 	synced = nil
-	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
+	if err := root.mkdirAllSynced(syncAlways, filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
 		t.Fatalf("mkdirAllSynced (existing tree): %v", err)
 	}
 	assertSync("existing tree", synced)
@@ -109,7 +109,7 @@ func TestMkdirAllSyncedSyncsSharedAncestorsAfterEverySibling(t *testing.T) {
 		return nil
 	}
 
-	if err := root.mkdirAllSynced(filepath.Join(inbox, "tmp"), filepath.Join(inbox, "new")); err != nil {
+	if err := root.mkdirAllSynced(syncAlways, filepath.Join(inbox, "tmp"), filepath.Join(inbox, "new")); err != nil {
 		t.Fatalf("mkdirAllSynced: %v", err)
 	}
 	if siblingsAtInboxSync != 2 {
@@ -186,7 +186,7 @@ func TestMkdirAllSyncedReportsFailedAncestorSync(t *testing.T) {
 	failure := errors.New("sync ancestor failed")
 	root.syncDirForTest = func(dir string) error { return failure }
 
-	err = root.mkdirAllSynced(filepath.Join("agents", "agent-c", "inbox", "cur"))
+	err = root.mkdirAllSynced(syncAlways, filepath.Join("agents", "agent-c", "inbox", "cur"))
 	if !errors.Is(err, failure) {
 		t.Fatalf("mkdirAllSynced error = %v, want wrapped %v", err, failure)
 	}
@@ -270,6 +270,119 @@ func TestEnsureAgentDirsStopsAtAnUncleanedRoot(t *testing.T) {
 		}
 		if !strings.HasPrefix(dir, root+string(filepath.Separator)) {
 			t.Fatalf("synced %s, which is outside the queue root %s (all: %v)", dir, root, synced)
+		}
+	}
+}
+
+// A delivery to several recipients is ONE call, so the ancestors they share —
+// "agents" and the pinned root — are fsynced once, not once per recipient.
+// Pre-merge review of agent-message-queue-611.22.26 (fsq first-contact sync)
+// measured `send --to a,b,c` fsyncing the queue root three times, because
+// DeliverToInboxes called mkdirAllSynced inside its per-recipient loop and the
+// dedup map is per-call.
+func TestDeliverToInboxesSyncsSharedAncestorsOncePerDelivery(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	counts := map[string]int{}
+	root.syncDirForTest = func(dir string) error {
+		rel, relErr := filepath.Rel(base, dir)
+		if relErr != nil {
+			rel = dir
+		}
+		counts[rel]++
+		return nil
+	}
+	if _, err := DeliverToInboxes(root, []string{"a", "b", "c"}, "m.md", []byte("hi")); err != nil {
+		t.Fatalf("DeliverToInboxes: %v", err)
+	}
+	for _, shared := range []string{".", "agents"} {
+		if counts[shared] != 1 {
+			t.Fatalf("%s synced %d times for a 3-recipient delivery, want 1 (all: %v)", shared, counts[shared], counts)
+		}
+	}
+}
+
+// EnsureAgentDir is the routine single-leaf write path (the
+// notification-attempt ledger appends through it against a mailbox that
+// already exists). It must not fsync the shared queue root on every append:
+// pre-merge review measured 3 fsyncs per append where main did 0, turning a
+// path built to not serialize among appenders into a queue-global barrier.
+// Only the acknowledging delivery path re-syncs an existing tree.
+func TestEnsureAgentDirDoesNotSyncAnExistingMailbox(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.EnsureAgentDirs("agent-a"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	var synced []string
+	root.syncDirForTest = func(dir string) error {
+		synced = append(synced, dir)
+		return nil
+	}
+	if err := root.EnsureAgentDir("agent-a", MailboxReceipts); err != nil {
+		t.Fatalf("EnsureAgentDir: %v", err)
+	}
+	if len(synced) != 0 {
+		t.Fatalf("an existing mailbox leaf was re-synced by a routine write: %v", synced)
+	}
+}
+
+// EnsureRootDirs can create the queue ROOT itself (`amq init` or
+// `amq session create` on a fresh path). fsync(root) persists the entries
+// INSIDE root, never root's own entry in its parent, so without syncing the
+// parent a first-contact send reports success and power loss takes the whole
+// queue. Found by pre-merge review of agent-message-queue-611.22.26.
+func TestEnsureRootDirsSyncsTheParentThatOwnsANewRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "fresh-queue")
+
+	var synced []string
+	restore := syncDirAmbientSwapForTest(func(dir string) error {
+		synced = append(synced, dir)
+		return nil
+	})
+	defer restore()
+
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	var sawParent bool
+	for _, d := range synced {
+		if d == parent {
+			sawParent = true
+		}
+	}
+	if !sawParent {
+		t.Fatalf("the parent that owns the new root entry was never synced (all: %v)", synced)
+	}
+
+	// A root that already existed gained nothing from us, so its parent is
+	// the operator's own path and is left alone.
+	synced = nil
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs (existing): %v", err)
+	}
+	for _, d := range synced {
+		if d == parent {
+			t.Fatalf("an existing root's parent must not be synced (all: %v)", synced)
 		}
 	}
 }

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -40,27 +40,58 @@ func TestMkdirAllSyncedCoversEveryCreatedLevelDownToLeaf(t *testing.T) {
 		t.Fatalf("mkdirAllSynced: %v", err)
 	}
 
-	want := map[string]bool{
-		filepath.Join("agents", "agent-a", "inbox", "cur"): false,
-		filepath.Join("agents", "agent-a", "inbox"):        false,
-		filepath.Join("agents", "agent-a"):                 false,
-		"agents":                                           false,
+	// Every created level, leaf first, and then the pre-existing parent whose
+	// directory entry changed. fsync(d) persists d's entries, never d's own
+	// entry in its parent — so "sync only what we created" (the earlier
+	// version) left the new subtree's entry in the existing parent unsynced.
+	// Here the root's base dir pre-exists, so the parent of "agents" is the
+	// root and is covered by the base guarantees; the chain is exactly the
+	// four created levels.
+	want := []string{
+		filepath.Join("agents", "agent-a", "inbox", "cur"),
+		filepath.Join("agents", "agent-a", "inbox"),
+		filepath.Join("agents", "agent-a"),
+		"agents",
 	}
 	if len(synced) != len(want) {
-		t.Fatalf("synced %d directories (%v), want %d", len(synced), synced, len(want))
+		t.Fatalf("synced %v, want %v", synced, want)
 	}
-	for _, dir := range synced {
-		seen, ok := want[dir]
-		if !ok {
-			t.Fatalf("unexpected directory synced: %s (all: %v)", dir, synced)
+	for i := range want {
+		if synced[i] != want[i] {
+			t.Fatalf("sync order %v, want %v", synced, want)
 		}
-		if seen {
-			t.Fatalf("directory synced more than once: %s (all: %v)", dir, synced)
-		}
-		want[dir] = true
 	}
-	if synced[0] != filepath.Join("agents", "agent-a", "inbox", "cur") {
-		t.Fatalf("leaf must be synced first, got %v", synced)
+
+	// With "agents" pre-existing, a second agent creates 3 levels — and the
+	// existing "agents" directory (which now owns the new entry) MUST be
+	// synced too, even though this call did not create it.
+	synced = nil
+	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-b", "inbox", "cur")); err != nil {
+		t.Fatalf("mkdirAllSynced (second agent): %v", err)
+	}
+	want = []string{
+		filepath.Join("agents", "agent-b", "inbox", "cur"),
+		filepath.Join("agents", "agent-b", "inbox"),
+		filepath.Join("agents", "agent-b"),
+		"agents", // pre-existing parent whose entry changed
+	}
+	if len(synced) != len(want) {
+		t.Fatalf("second agent synced %v, want %v (existing parent must be synced)", synced, want)
+	}
+	for i := range want {
+		if synced[i] != want[i] {
+			t.Fatalf("second agent sync order %v, want %v", synced, want)
+		}
+	}
+
+	// An established tree is not re-synced here: tree durability belongs to
+	// creation, message durability to the delivery commit (which syncs new).
+	synced = nil
+	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-b", "inbox", "cur")); err != nil {
+		t.Fatalf("mkdirAllSynced (existing tree): %v", err)
+	}
+	if len(synced) != 0 {
+		t.Fatalf("existing tree must not be re-synced by mkdir, got %v", synced)
 	}
 }
 
@@ -74,8 +105,12 @@ func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversCreatedLevels(t *testing.T
 	}
 
 	calls := atomic.Int64{}
+	var syncedAgents atomic.Bool
 	restore := syncDirAmbientSwapForTest(func(dir string) error {
 		calls.Add(1)
+		if filepath.Base(dir) == "agents" {
+			syncedAgents.Store(true)
+		}
 		if calls.Load() > 32 {
 			t.Errorf("ambient sync exceeded expected level count (infinite loop?): %d calls", calls.Load())
 			return errors.New("sync loop guard")
@@ -87,13 +122,15 @@ func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversCreatedLevels(t *testing.T
 	if err := EnsureAgentDirs(root, "agent-b"); err != nil {
 		t.Fatalf("EnsureAgentDirs: %v", err)
 	}
-	// First leaf creates agent-b + inbox + tmp = 3 synced levels (agents is
-	// pre-created by EnsureRootDirs); outbox/sent and dlq/tmp add one extra
-	// level each; the remaining leaves already have their parents. So the
-	// total is len(leaves) + 4 created levels, leaf-first, never repeating.
+	// Every leaf's chain reaches the pre-existing "agents" directory, whose
+	// entry for agent-b changed: it must be synced at least once, and the
+	// call must terminate (before the descend-from-leaf fix it never did).
 	leaves := RequiredMailboxLeaves()
-	if got := calls.Load(); got != int64(len(leaves)+4) {
-		t.Fatalf("ambient sync calls = %d, want %d", got, len(leaves)+4)
+	if calls.Load() < int64(len(leaves)) {
+		t.Fatalf("ambient sync calls = %d, want at least one per leaf (%d)", calls.Load(), len(leaves))
+	}
+	if !syncedAgents.Load() {
+		t.Fatal("pre-existing agents/ directory (owner of the new agent-b entry) was never synced")
 	}
 	for _, leaf := range leaves {
 		info, err := os.Stat(AgentMailboxPath(root, "agent-b", leaf))
@@ -159,17 +196,23 @@ func TestDeliverToInboxesSyncsFirstContactMailboxTree(t *testing.T) {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
-	// The created ancestors — not just the tmp/new leaves — must each be
-	// synced (exactly once by the mkdir path; tmp/new are synced again by the
-	// delivery commit itself, which is fine).
+	// Every level whose ENTRIES changed must be synced: the created
+	// ancestors AND "agents" (pre-existing, but it now owns the newagent
+	// entry). "inbox" changes twice — once when tmp is created and again when
+	// new is — so it must be synced after the second creation too; asserting
+	// "exactly once" would accept a sync that happened before new existed
+	// (the defect the first version of this test encoded).
 	for _, dir := range []string{
 		"agents",
 		filepath.Join("agents", "newagent"),
 		filepath.Join("agents", "newagent", "inbox"),
 	} {
-		if synced[dir] != 1 {
-			t.Fatalf("created ancestor %s synced %d times, want exactly 1 (all: %v)", dir, synced[dir], synced)
+		if synced[dir] == 0 {
+			t.Fatalf("mailbox level %s was never synced (all: %v)", dir, synced)
 		}
+	}
+	if synced[filepath.Join("agents", "newagent", "inbox")] < 2 {
+		t.Fatalf("inbox must be synced after each child (tmp, new) is created; got %d (all: %v)", synced[filepath.Join("agents", "newagent", "inbox")], synced)
 	}
 	for _, leaf := range []string{
 		filepath.Join("agents", "newagent", "inbox", "tmp"),

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -241,5 +242,34 @@ func TestDeliverToInboxesSyncsFirstContactMailboxTree(t *testing.T) {
 	// rename, not by the mailbox creation.
 	if synced[filepath.Join("agents", "newagent", "inbox", "new")] == 0 {
 		t.Fatalf("committed leaf was never synced (all: %v)", synced)
+	}
+}
+
+// An operator's --root can carry a trailing slash. filepath.Dir yields cleaned
+// paths, so an uncleaned stop would never match and the walk would fsync the
+// operator's own directories up to "/". Found while re-reading the round-5 fix
+// for agent-message-queue-611.22.26 (fsq first-contact sync).
+func TestEnsureAgentDirsStopsAtAnUncleanedRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	var synced []string
+	restore := syncDirAmbientSwapForTest(func(dir string) error {
+		synced = append(synced, dir)
+		return nil
+	})
+	defer restore()
+
+	if err := EnsureAgentDirs(root+string(filepath.Separator), "agent-b"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	for _, dir := range synced {
+		if dir == root {
+			continue
+		}
+		if !strings.HasPrefix(dir, root+string(filepath.Separator)) {
+			t.Fatalf("synced %s, which is outside the queue root %s (all: %v)", dir, root, synced)
+		}
 	}
 }

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -8,13 +8,15 @@ import (
 	"testing"
 )
 
-// mkdirAllSynced and the ambient EnsureAgentDirs helper must sync the leaf of
-// the newly created mailbox tree first and then each remaining created level
-// up to the shallowest missing ancestor. firstMissingAncestor reports the
-// shallowest missing level, so an implementation that walks up from it (or
-// starts there) never reaches the leaf and either loops forever or skips the
-// sync that protects the newly committed message file.
-func TestMkdirAllSyncedCoversEveryCreatedLevelDownToLeaf(t *testing.T) {
+// mkdirAllSynced must fsync every directory that owns an entry on the way to
+// the new mailbox leaf, up to and including the pinned root, and it must do so
+// on every call. An fsync persists a directory's entries and never its own
+// entry in its parent, so stopping short of the root leaves the root's entry
+// for a brand-new agents/ subtree unsynced; and an existing directory is not a
+// durable one, because an earlier call may have created it and then died
+// before syncing the parent. Both were BLOCK findings on
+// agent-message-queue-611.22.26 (fsq first-contact sync).
+func TestMkdirAllSyncedCoversEveryOwningDirectoryUpToRoot(t *testing.T) {
 	base := t.TempDir()
 	identity, err := SnapshotDeliveryRoot(base)
 	if err != nil {
@@ -36,85 +38,104 @@ func TestMkdirAllSyncedCoversEveryCreatedLevelDownToLeaf(t *testing.T) {
 		return nil
 	}
 
-	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
-		t.Fatalf("mkdirAllSynced: %v", err)
-	}
-
-	// Every created level, leaf first, and then the pre-existing parent whose
-	// directory entry changed. fsync(d) persists d's entries, never d's own
-	// entry in its parent — so "sync only what we created" (the earlier
-	// version) left the new subtree's entry in the existing parent unsynced.
-	// Here the root's base dir pre-exists, so the parent of "agents" is the
-	// root and is covered by the base guarantees; the chain is exactly the
-	// four created levels.
+	// The chain: the leaf's parent, then upward, ending at the pinned root.
+	// The leaf itself is absent — it is empty until the delivery commit, which
+	// syncs it after the rename.
 	want := []string{
-		filepath.Join("agents", "agent-a", "inbox", "cur"),
 		filepath.Join("agents", "agent-a", "inbox"),
 		filepath.Join("agents", "agent-a"),
 		"agents",
+		".",
 	}
-	if len(synced) != len(want) {
-		t.Fatalf("synced %v, want %v", synced, want)
-	}
-	for i := range want {
-		if synced[i] != want[i] {
-			t.Fatalf("sync order %v, want %v", synced, want)
+	assertSync := func(label string, got []string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s synced %v, want %v", label, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s sync order %v, want %v", label, got, want)
+			}
 		}
 	}
 
-	// With "agents" pre-existing, a second agent creates 3 levels — and the
-	// existing "agents" directory (which now owns the new entry) MUST be
-	// synced too, even though this call did not create it.
-	synced = nil
-	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-b", "inbox", "cur")); err != nil {
-		t.Fatalf("mkdirAllSynced (second agent): %v", err)
+	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
+		t.Fatalf("mkdirAllSynced: %v", err)
 	}
-	want = []string{
-		filepath.Join("agents", "agent-b", "inbox", "cur"),
-		filepath.Join("agents", "agent-b", "inbox"),
-		filepath.Join("agents", "agent-b"),
-		"agents", // pre-existing parent whose entry changed
-	}
-	if len(synced) != len(want) {
-		t.Fatalf("second agent synced %v, want %v (existing parent must be synced)", synced, want)
-	}
-	for i := range want {
-		if synced[i] != want[i] {
-			t.Fatalf("second agent sync order %v, want %v", synced, want)
-		}
-	}
+	assertSync("first contact", synced)
 
-	// An established tree is not re-synced here: tree durability belongs to
-	// creation, message durability to the delivery commit (which syncs new).
+	// The same tree already exists. It is still re-synced: Stat proves
+	// existence, not durability.
 	synced = nil
-	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-b", "inbox", "cur")); err != nil {
+	if err := root.mkdirAllSynced(filepath.Join("agents", "agent-a", "inbox", "cur")); err != nil {
 		t.Fatalf("mkdirAllSynced (existing tree): %v", err)
 	}
-	if len(synced) != 0 {
-		t.Fatalf("existing tree must not be re-synced by mkdir, got %v", synced)
+	assertSync("existing tree", synced)
+}
+
+// Sibling directories of one mailbox share their ancestors. mkdirAllSynced
+// creates them all before it syncs, so a shared parent is never fsynced while
+// a later sibling below it still has no durable entry — and it is fsynced
+// once, not once per sibling.
+func TestMkdirAllSyncedSyncsSharedAncestorsAfterEverySibling(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	inbox := filepath.Join("agents", "agent-a", "inbox")
+	counts := map[string]int{}
+	var siblingsAtInboxSync int
+	root.syncDirForTest = func(dir string) error {
+		rel, relErr := filepath.Rel(base, dir)
+		if relErr != nil {
+			rel = dir
+		}
+		counts[rel]++
+		if rel == inbox {
+			entries, readErr := root.ReadDir(inbox)
+			if readErr != nil {
+				t.Errorf("ReadDir(%s): %v", inbox, readErr)
+			}
+			siblingsAtInboxSync = len(entries)
+		}
+		return nil
+	}
+
+	if err := root.mkdirAllSynced(filepath.Join(inbox, "tmp"), filepath.Join(inbox, "new")); err != nil {
+		t.Fatalf("mkdirAllSynced: %v", err)
+	}
+	if siblingsAtInboxSync != 2 {
+		t.Fatalf("inbox was synced with %d children, want 2 (tmp and new must both exist first)", siblingsAtInboxSync)
+	}
+	if counts[inbox] != 1 {
+		t.Fatalf("inbox synced %d times, want 1 (shared ancestors are synced once)", counts[inbox])
 	}
 }
 
-// The ambient EnsureAgentDirs helper shares firstMissingAncestorAmbient and
-// must terminate: before the descend-from-leaf fix it fsynced up from the
-// shallowest missing level and never broke, hanging any caller.
-func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversCreatedLevels(t *testing.T) {
+// The ambient EnsureAgentDirs twin must terminate (it once fsynced upward from
+// the shallowest missing level and never broke, hanging the caller) and must
+// cover the same owning directories, including the pre-existing agents/ and
+// the queue root that own the new agent's entries.
+func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversOwningDirectories(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
 
 	calls := atomic.Int64{}
-	var syncedAgents atomic.Bool
+	synced := map[string]bool{}
 	restore := syncDirAmbientSwapForTest(func(dir string) error {
-		calls.Add(1)
-		if filepath.Base(dir) == "agents" {
-			syncedAgents.Store(true)
-		}
-		if calls.Load() > 32 {
-			t.Errorf("ambient sync exceeded expected level count (infinite loop?): %d calls", calls.Load())
+		if calls.Add(1) > 64 {
 			return errors.New("sync loop guard")
 		}
+		synced[dir] = true
 		return nil
 	})
 	defer restore()
@@ -122,17 +143,24 @@ func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversCreatedLevels(t *testing.T
 	if err := EnsureAgentDirs(root, "agent-b"); err != nil {
 		t.Fatalf("EnsureAgentDirs: %v", err)
 	}
-	// Every leaf's chain reaches the pre-existing "agents" directory, whose
-	// entry for agent-b changed: it must be synced at least once, and the
-	// call must terminate (before the descend-from-leaf fix it never did).
-	leaves := RequiredMailboxLeaves()
-	if calls.Load() < int64(len(leaves)) {
-		t.Fatalf("ambient sync calls = %d, want at least one per leaf (%d)", calls.Load(), len(leaves))
+
+	agent := AgentBase(root, "agent-b")
+	for _, dir := range []string{
+		filepath.Join(agent, "inbox"),
+		filepath.Join(agent, "outbox"),
+		filepath.Join(agent, "dlq"),
+		agent,
+		filepath.Join(root, "agents"), // pre-existing, but it owns the new agent-b entry
+		root,
+	} {
+		if !synced[dir] {
+			t.Fatalf("owning directory %s was never synced", dir)
+		}
 	}
-	if !syncedAgents.Load() {
-		t.Fatal("pre-existing agents/ directory (owner of the new agent-b entry) was never synced")
+	if got := calls.Load(); got != int64(len(synced)) {
+		t.Fatalf("ambient sync made %d calls for %d directories; shared ancestors must be synced once", got, len(synced))
 	}
-	for _, leaf := range leaves {
+	for _, leaf := range RequiredMailboxLeaves() {
 		info, err := os.Stat(AgentMailboxPath(root, "agent-b", leaf))
 		if err != nil || !info.IsDir() {
 			t.Fatalf("leaf %s not created: info=%v err=%v", leaf, info, err)
@@ -140,8 +168,8 @@ func TestEnsureAgentDirsAmbientSyncTerminatesAndCoversCreatedLevels(t *testing.T
 	}
 }
 
-// A failed sync on a created level is a plain error (nothing committed at the
-// leaf yet), not a swallowed success.
+// A failed sync on an owning directory is a plain error (nothing committed at
+// the leaf yet), not a swallowed success.
 func TestMkdirAllSyncedReportsFailedAncestorSync(t *testing.T) {
 	base := t.TempDir()
 	identity, err := SnapshotDeliveryRoot(base)
@@ -169,7 +197,7 @@ func TestMkdirAllSyncedReportsFailedAncestorSync(t *testing.T) {
 // tmp and new leaves, so the agents/<h> and inbox directory entries were
 // never durable. `amq send --to newagent` is a first-contact delivery (send
 // and reply never provision); power loss after "sent" lost the mailbox and
-// the committed message. Every level this delivery creates must be synced.
+// the committed message.
 func TestDeliverToInboxesSyncsFirstContactMailboxTree(t *testing.T) {
 	base := t.TempDir()
 	identity, err := SnapshotDeliveryRoot(base)
@@ -196,13 +224,11 @@ func TestDeliverToInboxesSyncsFirstContactMailboxTree(t *testing.T) {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
-	// Every level whose ENTRIES changed must be synced: the created
-	// ancestors AND "agents" (pre-existing, but it now owns the newagent
-	// entry). "inbox" changes twice — once when tmp is created and again when
-	// new is — so it must be synced after the second creation too; asserting
-	// "exactly once" would accept a sync that happened before new existed
-	// (the defect the first version of this test encoded).
+	// Every directory that owns an entry of the new tree: the created
+	// ancestors, plus "agents" and the pinned root, which pre-exist but now
+	// own the newagent entry and the agents entry respectively.
 	for _, dir := range []string{
+		".",
 		"agents",
 		filepath.Join("agents", "newagent"),
 		filepath.Join("agents", "newagent", "inbox"),
@@ -211,15 +237,9 @@ func TestDeliverToInboxesSyncsFirstContactMailboxTree(t *testing.T) {
 			t.Fatalf("mailbox level %s was never synced (all: %v)", dir, synced)
 		}
 	}
-	if synced[filepath.Join("agents", "newagent", "inbox")] < 2 {
-		t.Fatalf("inbox must be synced after each child (tmp, new) is created; got %d (all: %v)", synced[filepath.Join("agents", "newagent", "inbox")], synced)
-	}
-	for _, leaf := range []string{
-		filepath.Join("agents", "newagent", "inbox", "tmp"),
-		filepath.Join("agents", "newagent", "inbox", "new"),
-	} {
-		if synced[leaf] == 0 {
-			t.Fatalf("leaf %s was never synced (all: %v)", leaf, synced)
-		}
+	// The message's own leaf is synced by the delivery commit after the
+	// rename, not by the mailbox creation.
+	if synced[filepath.Join("agents", "newagent", "inbox", "new")] == 0 {
+		t.Fatalf("committed leaf was never synced (all: %v)", synced)
 	}
 }

--- a/internal/fsq/layout_sync_test.go
+++ b/internal/fsq/layout_sync_test.go
@@ -125,3 +125,58 @@ func TestMkdirAllSyncedReportsFailedAncestorSync(t *testing.T) {
 		t.Fatalf("mkdirAllSynced error = %v, want wrapped %v", err, failure)
 	}
 }
+
+// TestDeliverToInboxesSyncsFirstContactMailboxTree reproduces
+// agent-message-queue-611.22.26 (fsq first-contact sync): DeliverToInboxes
+// built agents/<h>/inbox/{tmp,new} with a raw MkdirAll and fsynced only the
+// tmp and new leaves, so the agents/<h> and inbox directory entries were
+// never durable. `amq send --to newagent` is a first-contact delivery (send
+// and reply never provision); power loss after "sent" lost the mailbox and
+// the committed message. Every level this delivery creates must be synced.
+func TestDeliverToInboxesSyncsFirstContactMailboxTree(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	synced := map[string]int{}
+	root.syncDirForTest = func(dir string) error {
+		rel, relErr := filepath.Rel(base, dir)
+		if relErr != nil {
+			rel = dir
+		}
+		synced[rel]++
+		return nil
+	}
+
+	if _, err := DeliverToInboxes(root, []string{"newagent"}, "m.md", []byte("hello")); err != nil {
+		t.Fatalf("DeliverToInboxes: %v", err)
+	}
+
+	// The created ancestors — not just the tmp/new leaves — must each be
+	// synced (exactly once by the mkdir path; tmp/new are synced again by the
+	// delivery commit itself, which is fine).
+	for _, dir := range []string{
+		"agents",
+		filepath.Join("agents", "newagent"),
+		filepath.Join("agents", "newagent", "inbox"),
+	} {
+		if synced[dir] != 1 {
+			t.Fatalf("created ancestor %s synced %d times, want exactly 1 (all: %v)", dir, synced[dir], synced)
+		}
+	}
+	for _, leaf := range []string{
+		filepath.Join("agents", "newagent", "inbox", "tmp"),
+		filepath.Join("agents", "newagent", "inbox", "new"),
+	} {
+		if synced[leaf] == 0 {
+			t.Fatalf("leaf %s was never synced (all: %v)", leaf, synced)
+		}
+	}
+}

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -89,19 +89,35 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 	if err := root.VerifyBase(); err != nil {
 		return nil, err
 	}
+	// First-contact delivery: create every recipient's mailbox tree through
+	// mkdirAllSynced so every ancestor this call creates (agents/<h>, inbox)
+	// is fsynced, not just tmp and new below. A raw MkdirAll left those
+	// directory entries unsynced; power loss after a successful send could
+	// drop the whole mailbox and the committed message with it
+	// (agent-message-queue-611.22.26).
+	//
+	// ALL recipients go in ONE call. Per-recipient calls would fsync the
+	// shared ancestors — "agents" and the pinned root — once per recipient,
+	// so `amq send --to a,b,c` fsynced the queue root three times. The
+	// dedup that makes a shared ancestor cost one fsync only works if the
+	// whole delivery is one call.
+	mailboxDirs := make([]string, 0, len(recipients)*2)
+	for _, recipient := range recipients {
+		mailboxDirs = append(mailboxDirs,
+			filepath.Join("agents", recipient, "inbox", "tmp"),
+			filepath.Join("agents", recipient, "inbox", "new"),
+		)
+	}
+	// syncAlways: this delivery is about to ACKNOWLEDGE a message to its
+	// sender, so it cannot trust that an earlier call finished making this
+	// tree durable.
+	if err := root.mkdirAllSynced(syncAlways, mailboxDirs...); err != nil {
+		return nil, err
+	}
 	stages := make([]stagedDelivery, 0, len(recipients))
 	for _, recipient := range recipients {
 		tmpDir := filepath.Join("agents", recipient, "inbox", "tmp")
 		newDir := filepath.Join("agents", recipient, "inbox", "new")
-		// First-contact delivery: create the mailbox tree through mkdirAllSynced so
-		// every ancestor this call creates (agents/<h>, inbox) is fsynced, not just
-		// tmp and new below. A raw MkdirAll left those directory entries unsynced;
-		// power loss after a successful send could drop the whole mailbox and the
-		// committed message with it (agent-message-queue-611.22.26). tmp and new
-		// go in one call so inbox is synced after BOTH of them exist.
-		if err := root.mkdirAllSynced(tmpDir, newDir); err != nil {
-			return nil, cleanupStagedTmp(root, stages, err)
-		}
 		tmpPath, err := uniqueAttemptTmpPath(tmpDir, filename)
 		if err != nil {
 			return nil, cleanupStagedTmp(root, stages, err)

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -93,10 +93,15 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 	for _, recipient := range recipients {
 		tmpDir := filepath.Join("agents", recipient, "inbox", "tmp")
 		newDir := filepath.Join("agents", recipient, "inbox", "new")
-		if err := root.root.MkdirAll(tmpDir, 0o700); err != nil {
+		// First-contact delivery: create the mailbox tree through mkdirAllSynced so
+		// every ancestor this call creates (agents/<h>, inbox) is fsynced, not just
+		// tmp and new below. A raw MkdirAll left those directory entries unsynced;
+		// power loss after a successful send could drop the whole mailbox and the
+		// committed message with it (agent-message-queue-611.22.26).
+		if err := root.mkdirAllSynced(tmpDir); err != nil {
 			return nil, cleanupStagedTmp(root, stages, err)
 		}
-		if err := root.root.MkdirAll(newDir, 0o700); err != nil {
+		if err := root.mkdirAllSynced(newDir); err != nil {
 			return nil, cleanupStagedTmp(root, stages, err)
 		}
 		tmpPath, err := uniqueAttemptTmpPath(tmpDir, filename)

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -97,11 +97,9 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 		// every ancestor this call creates (agents/<h>, inbox) is fsynced, not just
 		// tmp and new below. A raw MkdirAll left those directory entries unsynced;
 		// power loss after a successful send could drop the whole mailbox and the
-		// committed message with it (agent-message-queue-611.22.26).
-		if err := root.mkdirAllSynced(tmpDir); err != nil {
-			return nil, cleanupStagedTmp(root, stages, err)
-		}
-		if err := root.mkdirAllSynced(newDir); err != nil {
+		// committed message with it (agent-message-queue-611.22.26). tmp and new
+		// go in one call so inbox is synced after BOTH of them exist.
+		if err := root.mkdirAllSynced(tmpDir, newDir); err != nil {
 			return nil, cleanupStagedTmp(root, stages, err)
 		}
 		tmpPath, err := uniqueAttemptTmpPath(tmpDir, filename)


### PR DESCRIPTION
Bead agent-message-queue-611.22.26 (fsq first-contact sync) — core AMQ durability, P1.

`DeliverToInboxes` built `agents/<h>/inbox/{tmp,new}` with a raw `MkdirAll` and fsynced only the `tmp`/`new` leaves; the `agents/<h>` and `inbox` directory entries were never durable. `send`/`reply` never provision first, so `amq send --to newagent` is a first-contact delivery: power loss after "sent" could lose the mailbox and the committed message.

Pre-merge review returned two further durability defects, both accepted:

1. **An existing directory is not a durable directory.** The first version skipped the sync whenever every level already existed. If an earlier call created a level and then failed before syncing its parent, the level is visible to `Stat` while its entry is not on stable storage — so a retry would stage, commit and acknowledge a message into a tree that can still vanish. `Stat` proves existence, never durability. The chain is now walked on **every** call.

2. **The chain stopped short of the pinned root.** `fsync(d)` persists `d`'s entries and never `d`'s own entry in its parent, so when `agents` is the shallowest created level, `.` is the directory whose entries changed. It is now included.

Both twins now share one idea, `ancestorChain(dir, stop)`: the directories that *own* an entry on the way to `dir`, deepest first, ending at `stop` inclusive. `dir` itself is excluded — a just-created directory is empty, and the delivery commit fsyncs the leaf after the rename. That set turned out to be the whole contract, which made the separate "sync what this call created" pass redundant; it is deleted.

`mkdirAllSynced` is now variadic, so one logical mailbox is created before any of it is synced: a shared parent is never fsynced while a later sibling below it still has no durable entry, and it is fsynced once instead of once per sibling. An agent mailbox went from 31 fsyncs to 6.

Ambient `EnsureRootDirs` fsynced nothing at all; it now fsyncs the root that owns the `agents`, `threads` and `meta` entries.

**Measured cost of always re-syncing.** The chain is now walked on every call, so an ordinary send into an existing mailbox pays 4 directory fsyncs, not zero. 200 deliveries into an already-existing mailbox, 4 runs each, median: `main` 11.5 ms/op, this branch 15.5 ms/op — about +4 ms, +35%. AMQ is a local file bus for coding agents and sends are human-initiated, so 4 ms is imperceptible; durability of an *acknowledged* message is correctness. An in-process "already synced this chain" memo would recover the cost and was deliberately not added: it trades an obviously-correct invariant for a cache whose one stale case (another process deletes and recreates the tree, then fails before syncing) is exactly the class of bug this PR fixes.

**A second review round found three more, all fixed here.**

*Always re-syncing regressed a lock-free hot path.* The notification-attempt ledger appends through `EnsureAgentDir` against a mailbox that already exists, and it was measured fsyncing the shared queue root on every append where `main` did nothing — a queue-global barrier on a path whose stated design is to not serialize among appenders. The two callers are genuinely different, so the code now says so with a `durability` mode: `syncIfCreated` for a routine internal write, which owes durability for what it created and nothing more; `syncAlways` for a caller about to *acknowledge* something to someone else, which may not assume an earlier call finished making the tree durable. Only `DeliverToInboxes` uses `syncAlways` — which is exactly where finding 1 above applies, and nowhere else.

*The shared-ancestor dedup did not span recipients.* It is per call, but `DeliverToInboxes` called `mkdirAllSynced` inside its per-recipient loop, so `amq send --to a,b,c` fsynced the queue root three times. The whole delivery is now one call.

*A brand-new queue root's own entry was never made durable.* `EnsureRootDirs` creates the root itself on a fresh `amq init` / `amq session create`, and `fsync(root)` persists the entries *inside* root, never root's entry in its parent. So init, then a first-contact send that correctly syncs everything up to and including the root, then power loss — and the whole queue goes, along with the message we acknowledged. The same rule that drives the rest of this PR applies: whoever creates an entry owns its fsync. It now syncs the parent when the root was ours to create, and leaves the operator's path alone when it was not.

fsq + cli + launch suites green, fsq green under `-race`; lint 0 issues; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
