### PR TITLE
fix(remote/amqio): a store refusal is not a durable answer

### DIFF
--- a/internal/remote/amqio/amqio.go
+++ b/internal/remote/amqio/amqio.go
@@ -146,14 +146,21 @@ func (c *Carrier) importOne(root *fsq.DeliveryRoot, name string) error {
 		// command whose record may not exist.
 		return nil
 	}
-	// A request-op reply carries an Outcome. A transient storage failure means
-	// the record could not be persisted, so leave the command in new for the
-	// next import rather than draining it without a durable record (Pro B09).
+	// A typed Refusal is not automatically a DURABLE one. The store refuses
+	// with storage_full (ENOSPC, EPERM, oversize) and store_closed (shutdown),
+	// and on every op except submit-create those travel as an ERROR from
+	// Handle rather than as an Outcome on a Reply — so checking only
+	// Outcome.Code (the previous guard) missed them, and classifying by TYPE
+	// answered "refused" and CLAIMED the command for a failure that says
+	// nothing about the request. Worst case: a cancel whose tombstone could
+	// not be written was answered as refused and claimed, and the later
+	// submit then EXECUTED the request the caller had cancelled. Classify by
+	// CODE, from either channel (agent-message-queue-611.22.13).
 	var outcome protocol.Outcome
 	if rep, ok := reply.(protocol.Reply); ok {
 		outcome = rep.Outcome
 	}
-	if outcome.Code == protocol.CodeStorageFull {
+	if transientRefusal(refusal, outcome.Code) {
 		return nil
 	}
 	// Reply once here for: every refusal; every non-request op; and a request
@@ -255,6 +262,29 @@ func (c *Carrier) reply(root *fsq.DeliveryRoot, origin map[string]string, subjec
 		return err
 	}
 	return nil
+}
+
+// transientRefusal reports whether a refusal describes the STORE's inability
+// to persist rather than a decision about the request. Such a command must
+// stay in inbox/new: it has no durable record, and claiming it would consume
+// the caller's request with neither an outcome nor a retry. The code can
+// arrive either as a Refusal error (most ops) or as a Reply Outcome
+// (submit-create), so both channels are checked.
+func transientRefusal(refusal *protocol.Refusal, outcome protocol.Code) bool {
+	for _, code := range []protocol.Code{outcome, refusalCode(refusal)} {
+		switch code {
+		case protocol.CodeStorageFull, protocol.CodeStoreClosed:
+			return true
+		}
+	}
+	return false
+}
+
+func refusalCode(r *protocol.Refusal) protocol.Code {
+	if r == nil {
+		return ""
+	}
+	return r.Code
 }
 
 func refsFrom(origin map[string]string) []string {

--- a/internal/remote/amqio/amqio_test.go
+++ b/internal/remote/amqio/amqio_test.go
@@ -307,3 +307,100 @@ func TestImportNoopCancelRepliesToSender(t *testing.T) {
 		t.Fatalf("no-op terminal cancel did not reply to sender (entries %d, baseline %d, sawNoop %v)", len(entries), len(baseline), sawNoop)
 	}
 }
+
+// TestImportStoreRefusalLeavesCommandInNew reproduces the blocker inside
+// agent-message-queue-611.22.13 (B09 carrier): the carrier classified
+// refusals by TYPE (errors.As *protocol.Refusal), but the store itself
+// refuses with storage_full (ENOSPC, EPERM, oversize) and store_closed
+// (shutdown). On every op EXCEPT submit-create those travel as an ERROR from
+// Handle rather than as a Reply Outcome, so the previous Outcome.Code guard
+// never saw them: the command was answered "refused" and CLAIMED. A cancel
+// whose tombstone could not be written was consumed, and the later submit
+// then executed the request the caller had cancelled. A store refusal must
+// leave the command in inbox/new for the next import.
+func TestImportStoreRefusalLeavesCommandInNew(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []string{"codex", DefaultHandle} {
+		if err := fsq.EnsureAgentDirs(root, h); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := requests.Open(filepath.Join(root, "extensions", "remote"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	var carrier *Carrier
+	ep := core.New(core.Config{Store: store, Publish: func(s protocol.Snapshot, origin map[string]string) error {
+		return carrier.Publish(s, origin)
+	}})
+	carrier, err = New(root, DefaultHandle, ep)
+	if err != nil {
+		t.Fatalf("carrier: %v", err)
+	}
+	ep.Register(fake.New("fake", "e_1"))
+	t.Cleanup(func() { _ = ep.Close() })
+
+	// A cancel for a request that was never submitted: the endpoint answers by
+	// writing a cancel-before-submit tombstone, so the store write IS the
+	// operation, and its refusal arrives as an error from Handle.
+	reqID := "11111111-1111-4111-8111-111111111390"
+	ref := protocol.EncodeRef("amq:codex", "fake", reqID)
+	body := `{"schema":"amq.remote.command/1","op":"request.cancel","request_ref":"` + ref + `","target_id":"fake","epoch":"e_1","not_after":"` + protocol.FormatTime(time.Now().Add(time.Minute)) + `"}`
+	now := time.Now()
+	id, err := format.NewMessageID(now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := format.Message{Header: format.Header{
+		Schema: format.CurrentSchema, ID: id, From: "codex", To: []string{DefaultHandle},
+		Thread: "p2p/codex__remote", Subject: "cancel", Created: now.UTC().Format(time.RFC3339Nano), Kind: "todo",
+	}, Body: body}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	droot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fsq.DeliverToInboxes(droot, []string{DefaultHandle}, id+".md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	_ = droot.Close()
+
+	// Force every store write to refuse with storage_full, exactly as a full
+	// disk does. The refusal is a *protocol.Refusal, so the old type-based
+	// classification accepted it as a durable answer and claimed the command.
+	saved := requests.MaxRecordBytes
+	requests.MaxRecordBytes = 1
+	t.Cleanup(func() { requests.MaxRecordBytes = saved })
+
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if entries, _ := os.ReadDir(fsq.AgentInboxNew(root, DefaultHandle)); len(entries) != 1 {
+		t.Fatalf("storage-refused cancel not left in new: %d", len(entries))
+	}
+	if entries, _ := os.ReadDir(fsq.AgentInboxCur(root, DefaultHandle)); len(entries) != 0 {
+		t.Fatalf("storage-refused cancel was CLAIMED: %d (the cancelled request would later execute)", len(entries))
+	}
+
+	// With storage restored the retry succeeds and the command is claimed.
+	requests.MaxRecordBytes = saved
+	if _, err := carrier.ImportOnce(); err != nil {
+		t.Fatalf("retry import: %v", err)
+	}
+	if entries, _ := os.ReadDir(fsq.AgentInboxNew(root, DefaultHandle)); len(entries) != 0 {
+		t.Fatalf("cancel still in new after storage recovered: %d", len(entries))
+	}
+	if entries, _ := os.ReadDir(fsq.AgentInboxCur(root, DefaultHandle)); len(entries) != 1 {
+		t.Fatalf("recovered cancel not claimed: %d", len(entries))
+	}
+}


### PR DESCRIPTION
Bead agent-message-queue-611.22.13 (B09 carrier) — the P1 blocker inside it.

The carrier decided whether a command had been durably answered by the **type** of the failure (`errors.As(herr, *protocol.Refusal)`). But the store refuses with `storage_full` and `store_closed`, which say nothing about the request. A guard existed for submit, keyed on `Reply.Outcome.Code` — and on **every op except submit-create** the store refusal arrives as an *error* with an empty Outcome, so that guard never saw it. The command was answered "refused" and **claimed**.

**The dangerous instance:** cancel-before-submit is answered by *writing a tombstone*, so the store write **is** the operation. On a full disk the tombstone was never created, the cancel was claimed as refused, and the later submit — finding no tombstone — **executed the request the caller had cancelled**.

Fix: classify by **code**, from either channel. Transient store refusal ⇒ leave the command in `inbox/new` for the next import.

I verified the test actually earns its keep: it **fails without the fix** (`storage-refused cancel not left in new: 0` — the cancel is claimed) and passes with it, including the recovery half (once storage returns, the retry claims normally). An earlier draft of this test used the *submit* path and passed with and without the fix — it proved nothing, so it was rewritten against the cancel/error channel the bug actually lives in.

Full `internal/remote` `-race`, lint 0, vet, fmt clean.

**Not in scope** (rest of 611.22.13, still open): `ImportOnce` aborts the whole pass on one message's error, and the cur-recovery gap (a command claimed into `cur` that crashed before its drained receipt is never re-examined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)