### PR TITLE
fix(remote/ipc): bound every I/O boundary; a ctx error is not a failure

### DIFF
--- a/internal/remote/ipc/ipc.go
+++ b/internal/remote/ipc/ipc.go
@@ -24,6 +24,10 @@ import (
 // protocol, and replies carry at most one bounded result.
 const MaxRecordBytes = 1024 * 1024
 
+// callReadDeadline bounds a client's wait for the endpoint's response. A wait
+// request adds its own server-side timeout on top of this.
+const callReadDeadline = 30 * time.Second
+
 // LocalHost is the authenticated source recorded for commands that arrive
 // over the local socket: the OS user owning the socket.
 const LocalHost = "local"
@@ -135,7 +139,14 @@ func (s *Server) handle(ctx context.Context, conn net.Conn) {
 		wctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		snap, err := s.ep.Wait(wctx, req.Wait.RequestRef)
-		if errors.Is(err, context.DeadlineExceeded) {
+		// Wait never cancels work, so NO context error may be reported as
+		// failure. DeadlineExceeded is the caller's own timeout; Canceled is
+		// the endpoint shutting down underneath a live wait. Both mean "not
+		// observed yet" (exit 4), never "the work failed" (exit 1) — an
+		// orchestrator told its request failed during a routine endpoint
+		// restart would take a destructive recovery path for a request that
+		// is still running (agent-message-queue-611.22.27).
+		if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 			writeRecord(conn, Response{Reply: mustJSON(snap), TimedOut: true})
 			return
 		}
@@ -181,6 +192,15 @@ func Call(stateDir string, req Request) (*Response, error) {
 		return nil, protocol.Refuse(protocol.CodeEndpointUnreachable, "no endpoint at %s; start one with `amq-remote serve`", path)
 	}
 	defer func() { _ = conn.Close() }()
+	// DialTimeout bounds only the connect. Without a read deadline every CLI
+	// verb (submit, status, cancel, sessions, doctor) blocks forever against a
+	// wedged endpoint. A wait carries its own server-side timeout, so allow
+	// for it plus slack rather than cutting a legitimate long wait short.
+	readBound := callReadDeadline
+	if req.Wait != nil && req.Wait.TimeoutMS > 0 {
+		readBound = time.Duration(req.Wait.TimeoutMS)*time.Millisecond + callReadDeadline
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(readBound))
 	writeRecord(conn, req)
 	resp, err := readRecord[Response](conn)
 	if err != nil {
@@ -201,7 +221,12 @@ func (r *Response) AsError() error {
 }
 
 func readRecord[T any](r io.Reader) (*T, error) {
-	br := bufio.NewReaderSize(r, 64*1024)
+	// Cap at the BOUNDARY, not after the fact: ReadBytes grows without limit,
+	// so a peer streaming megabytes with no newline could allocate freely
+	// inside the read deadline before the size check ever ran. One extra byte
+	// is read so an over-long record is still detected rather than silently
+	// truncated into a parse error.
+	br := bufio.NewReaderSize(io.LimitReader(r, MaxRecordBytes+1), 64*1024)
 	line, err := br.ReadBytes('\n')
 	if err != nil && (!errors.Is(err, io.EOF) || len(line) == 0) {
 		return nil, fmt.Errorf("read record: %w", err)
@@ -216,11 +241,23 @@ func readRecord[T any](r io.Reader) (*T, error) {
 	return &v, nil
 }
 
+// writeResponseDeadline bounds one response write. A client that sends its
+// request and then stops reading (a stopped shell, a wedged reader) used to
+// block the handler goroutine forever on a full socket buffer, leaking the
+// goroutine and its fd for the life of the process.
+const writeResponseDeadline = 10 * time.Second
+
 func writeRecord(w io.Writer, v any) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return
 	}
 	data = append(data, '\n')
+	// Bound the write when the writer is a connection: an unread socket must
+	// not hold a handler (or a CLI) indefinitely.
+	if c, ok := w.(net.Conn); ok {
+		_ = c.SetWriteDeadline(time.Now().Add(writeResponseDeadline))
+		defer func() { _ = c.SetWriteDeadline(time.Time{}) }()
+	}
 	_, _ = w.Write(data)
 }

--- a/internal/remote/ipc/ipc.go
+++ b/internal/remote/ipc/ipc.go
@@ -24,9 +24,12 @@ import (
 // protocol, and replies carry at most one bounded result.
 const MaxRecordBytes = 1024 * 1024
 
-// callReadDeadline bounds a client's wait for the endpoint's response. A wait
-// request adds its own server-side timeout on top of this.
-const callReadDeadline = 30 * time.Second
+// callReadDeadline bounds a client's wait for the endpoint's response. It
+// protects the SHORT verbs (submit, status, cancel, sessions, doctor) from a
+// wedged endpoint. A wait request adds its own server-side timeout on top of
+// this, or opts out of a client deadline entirely; see Call.
+// A test shortens it to prove the wait path does not inherit it.
+var callReadDeadline = 30 * time.Second
 
 // LocalHost is the authenticated source recorded for commands that arrive
 // over the local socket: the OS user owning the socket.
@@ -197,10 +200,23 @@ func Call(stateDir string, req Request) (*Response, error) {
 	// wedged endpoint. A wait carries its own server-side timeout, so allow
 	// for it plus slack rather than cutting a legitimate long wait short.
 	readBound := callReadDeadline
-	if req.Wait != nil && req.Wait.TimeoutMS > 0 {
-		readBound = time.Duration(req.Wait.TimeoutMS)*time.Millisecond + callReadDeadline
+	if req.Wait != nil {
+		// A wait is the one verb whose duration the CALLER chose. Bounding it
+		// here at the short-verb deadline would report a request that is still
+		// running as a failed read, and `wait` maps a non-refusal error to
+		// exit 1 ("work failed or cancelled") — so an orchestrator would take
+		// the recovery path for untouched, running work. --timeout 0 means no
+		// limit (cmd/amq-remote: "0 = no limit"), and the server owns that
+		// bound, so the client sets no deadline at all.
+		if req.Wait.TimeoutMS <= 0 {
+			readBound = 0
+		} else {
+			readBound = time.Duration(req.Wait.TimeoutMS)*time.Millisecond + callReadDeadline
+		}
 	}
-	_ = conn.SetReadDeadline(time.Now().Add(readBound))
+	if readBound > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(readBound))
+	}
 	writeRecord(conn, req)
 	resp, err := readRecord[Response](conn)
 	if err != nil {

--- a/internal/remote/ipc/ipc_test.go
+++ b/internal/remote/ipc/ipc_test.go
@@ -159,3 +159,85 @@ func TestWaitReportsShutdownAsTimedOutNotFailure(t *testing.T) {
 		t.Fatal("wait did not return after endpoint shutdown")
 	}
 }
+
+// A wait with --timeout 0 ("no limit") must not inherit the SHORT-verb client
+// read deadline. Pre-merge review of agent-message-queue-611.22.28 (ipc
+// bounds) reproduced it live: Call bounded every read at callReadDeadline
+// while the server treats TimeoutMS<=0 as 24h, so the default `amq-remote
+// wait` died at 30s with "read endpoint response: i/o timeout" — a plain
+// error, not a refusal, which cmd/amq-remote maps to exit 1 ("work failed or
+// cancelled") for a request that is untouched and still running.
+func TestWaitWithoutTimeoutIgnoresTheShortVerbReadDeadline(t *testing.T) {
+	saved := callReadDeadline
+	callReadDeadline = 150 * time.Millisecond
+	t.Cleanup(func() { callReadDeadline = saved })
+
+	dir, err := os.MkdirTemp("", "amqr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	store, err := requests.Open(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	ep := core.New(core.Config{Store: store})
+	ep.Register(fake.New("fake", "e_1"))
+	ctx, cancel := context.WithCancel(context.Background())
+	srv, err := Listen(dir, ep)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ctx) }()
+	t.Cleanup(func() { cancel(); _ = ep.Close() })
+
+	id := "11111111-1111-4111-8111-1111111119b2"
+	submit := &protocol.Command{
+		Schema:    protocol.SchemaCommand,
+		Op:        protocol.OpRequestSubmit,
+		RequestID: id,
+		TargetID:  "fake",
+		Epoch:     "e_1",
+		NotAfter:  protocol.FormatTime(time.Now().Add(time.Minute)),
+		Input:     &protocol.SubmitInput{Text: "work"},
+	}
+	if _, err := Call(dir, Request{Command: submit}); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	ref := protocol.EncodeRef(LocalHost, "fake", id)
+
+	type result struct {
+		resp *Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		// TimeoutMS 0 is the CLI default: "no limit".
+		resp, err := Call(dir, Request{Wait: &WaitRequest{RequestRef: ref}})
+		done <- result{resp, err}
+	}()
+
+	// Well past the (shortened) short-verb deadline, the wait must still be
+	// waiting rather than have failed with a read timeout.
+	select {
+	case r := <-done:
+		t.Fatalf("wait returned after the short-verb deadline: resp=%+v err=%v", r.resp, r.err)
+	case <-time.After(600 * time.Millisecond):
+	}
+
+	// Shutting the endpoint down releases it, and that is a timeout, never a
+	// failure.
+	cancel()
+	_ = ep.Close()
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("wait error = %v, want a TimedOut response", r.err)
+		}
+		if !r.resp.TimedOut {
+			t.Fatalf("wait resp = %+v, want TimedOut", r.resp)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("wait did not return after endpoint shutdown")
+	}
+}

--- a/internal/remote/ipc/ipc_test.go
+++ b/internal/remote/ipc/ipc_test.go
@@ -84,3 +84,78 @@ func TestSubmitStatusWaitOverSocket(t *testing.T) {
 	cancel()
 	_ = ep.Close()
 }
+
+// TestWaitReportsShutdownAsTimedOutNotFailure reproduces
+// agent-message-queue-611.22.27: the wait handler special-cased only
+// context.DeadlineExceeded, so when the endpoint shut down under a live wait
+// the resulting context.Canceled fell through to errorResponse and the client
+// mapped it to exit 1 — "the work failed". Wait never cancels work: the
+// request was untouched and still running. An orchestrator told its request
+// failed during a routine endpoint restart takes a destructive recovery path.
+// Any context error means "not observed yet" (TimedOut, exit 4).
+func TestWaitReportsShutdownAsTimedOutNotFailure(t *testing.T) {
+	dir, err := os.MkdirTemp("", "amqr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	store, err := requests.Open(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	ep := core.New(core.Config{Store: store})
+	rt := fake.New("fake", "e_1")
+	ep.Register(rt)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	srv, err := Listen(dir, ep)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ctx) }()
+	t.Cleanup(func() { cancel(); _ = ep.Close() })
+
+	// Submit a request so there is something live to wait on.
+	id := "11111111-1111-4111-8111-1111111119a1"
+	submit := &protocol.Command{
+		Schema:    protocol.SchemaCommand,
+		Op:        protocol.OpRequestSubmit,
+		RequestID: id,
+		TargetID:  "fake",
+		Epoch:     "e_1",
+		NotAfter:  protocol.FormatTime(time.Now().Add(time.Minute)),
+		Input:     &protocol.SubmitInput{Text: "work"},
+	}
+	if _, err := Call(dir, Request{Command: submit}); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	// Wait with a generous client timeout, then shut the endpoint down under
+	// it: the wait's context is cancelled, not deadline-exceeded.
+	type result struct {
+		resp *Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := Call(dir, Request{Wait: &WaitRequest{RequestRef: protocol.EncodeRef(LocalHost, "fake", id), TimeoutMS: 30000}})
+		done <- result{resp, err}
+	}()
+	time.Sleep(150 * time.Millisecond) // let the wait register
+	cancel()                           // endpoint shutdown under the live wait
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("wait call errored: %v", r.err)
+		}
+		if r.resp.Error != nil {
+			t.Fatalf("shutdown reported as failure (%+v); a context error must never read as 'work failed'", r.resp.Error)
+		}
+		if !r.resp.TimedOut {
+			t.Fatal("shutdown under a live wait must be reported as not-yet-observed (TimedOut), so the caller maps it to exit 4")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("wait did not return after endpoint shutdown")
+	}
+}


### PR DESCRIPTION
Beads agent-message-queue-611.22.15.6 (B14f ipc deadlines) and agent-message-queue-611.22.27 (wait exit code). They ship together because they are one concern at one boundary.

The first three are the **IPC half of B14 that never reached main** — it existed only on the discarded mega-branch (`internal/remote/ipc` has a single commit, the initial feature).

- **`writeRecord` had no deadline.** A client that sends its request and stops reading (a stopped shell, a wedged reader) blocked the handler goroutine forever on a full socket buffer — goroutine and fd leaked for the life of the process.
- **`readRecord` checked the size cap *after* `bufio.ReadBytes` had already grown unbounded**, so a peer could stream megabytes with no newline inside the read deadline. The cap now sits at the boundary (`io.LimitReader`), reading one extra byte so an over-long record is *detected* rather than silently truncated into a parse error.
- **`Call` had no read deadline** — `DialTimeout` bounds only the connect — so every CLI verb blocked forever against a wedged endpoint. A wait carries its own server-side timeout, so the client bound is that timeout **plus slack**, never a flat cut that would abort a legitimate long wait.
- **`wait` reported endpoint shutdown as failure.** Only `DeadlineExceeded` was special-cased, so `context.Canceled` fell through to `errorResponse` → **exit 1, "the work failed"** — while the request was untouched and still running. An orchestrator told its request failed during a routine restart takes a destructive recovery path. Any context error now means "not observed yet" (exit 4), which `Wait`'s own contract already promised.

Regression verified RED without the fix (response carries `Code:error Message:context canceled`) and GREEN with it. Full `internal/remote` `-race`, lint 0, fmt clean.

**Noted, not fixed here** (audit W4): `ipc.MaxRecordBytes` (1MB) and `protocol.MaxRecordBytes` (704KB) diverge while a comment claims a single source of truth — numerically safe today, belongs with the protocol-hygiene bead 611.22.28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)