### PR TITLE
fix(remote/amqio): make the creator host injective

### DIFF
--- a/internal/remote/amqio/amqio.go
+++ b/internal/remote/amqio/amqio.go
@@ -5,6 +5,8 @@
 package amqio
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,17 +65,42 @@ func (c *Carrier) Handle() string { return c.me }
 // message header. The handle is attribution inside this root; a cross-project
 // sender keeps its project so two same-named handles never share a key.
 func SourceHost(h format.Header) string {
-	host := "amq:" + h.From
+	// The creator host is part of the request KEY, so it must be injective:
+	// two different senders may never derive the same host. Sanitizing the
+	// readable form alone is not — every illegal rune maps to '-', and the
+	// "@" joining handle and project is itself illegal, so From="a" with
+	// project "b" and a bare From="a-b" both collapsed to "amq:a-b". Two
+	// callers then shared one record: the second submit was answered with the
+	// first's snapshot, and a cancel from one terminated the other's run.
+	// Project names are unvalidated (a config string or a directory basename),
+	// so "web app" and "web-app" collapsed the same way.
+	//
+	// A readable prefix is kept for humans and logs, but identity rests on a
+	// digest of the EXACT (from, project) pair with an unambiguous separator,
+	// so the mapping is injective by construction.
+	readable := sanitizeHostPart(h.From)
 	if h.FromProject != "" {
-		host += "@" + h.FromProject
+		readable += "." + sanitizeHostPart(h.FromProject)
 	}
+	return "amq:" + readable + "." + hostDigest(h.From, h.FromProject)
+}
+
+// hostDigest is a short, collision-resistant tag over the exact identity
+// pair. The length prefix makes the encoding unambiguous: ("ab","c") and
+// ("a","bc") hash differently even though a plain concatenation would not.
+func hostDigest(from, project string) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s|%d:%s", len(from), from, len(project), project)))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+func sanitizeHostPart(s string) string {
 	return strings.Map(func(r rune) rune {
 		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '.', r == ':', r == '-':
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
 			return r
 		}
 		return '-'
-	}, host)
+	}, s)
 }
 
 // ImportOnce reads every message in the endpoint's inbox/new, hands each

--- a/internal/remote/amqio/amqio_test.go
+++ b/internal/remote/amqio/amqio_test.go
@@ -103,7 +103,7 @@ func TestImportCommandAndPublishResult(t *testing.T) {
 	if !states["running"] || !states["completed"] {
 		t.Fatalf("expected running and completed revisions, got %v", states)
 	}
-	rec, ok, err := store.Get(requests.Key{CreatorHost: "amq:codex", TargetID: "fake", RequestID: "11111111-1111-4111-8111-111111111301"})
+	rec, ok, err := store.Get(requests.Key{CreatorHost: SourceHost(format.Header{From: "codex"}), TargetID: "fake", RequestID: "11111111-1111-4111-8111-111111111301"})
 	if err != nil || !ok {
 		t.Fatalf("record: ok=%v err=%v", ok, err)
 	}
@@ -156,7 +156,7 @@ func TestImportLeavesCommandOnPlainError(t *testing.T) {
 	// Corrupt the on-disk record for this exact key so submit's store.Get
 	// fails to decode it and returns a plain (non-Refusal) error, the class
 	// the review found the carrier would wrongly drain.
-	hostDir := filepath.Join(stateDir, "v1", "requests", "amq:codex")
+	hostDir := filepath.Join(stateDir, "v1", "requests", SourceHost(format.Header{From: "codex"}))
 	if err := os.MkdirAll(hostDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -277,7 +277,7 @@ func TestImportNoopCancelRepliesToSender(t *testing.T) {
 	baseline, _ := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
 
 	// Deliver a cancel for the already-terminal record -> noop_already_terminal.
-	ref := protocol.EncodeRef("amq:codex", "fake", id)
+	ref := protocol.EncodeRef(SourceHost(format.Header{From: "codex"}), "fake", id)
 	body := `{"schema":"amq.remote.command/1","op":"request.cancel","request_ref":"` + ref + `","target_id":"fake","epoch":"e_1","not_after":"` + protocol.FormatTime(time.Now().Add(time.Minute)) + `"}`
 	now := time.Now()
 	mid, _ := format.NewMessageID(now)
@@ -305,5 +305,54 @@ func TestImportNoopCancelRepliesToSender(t *testing.T) {
 	}
 	if len(entries) <= len(baseline) || !sawNoop {
 		t.Fatalf("no-op terminal cancel did not reply to sender (entries %d, baseline %d, sawNoop %v)", len(entries), len(baseline), sawNoop)
+	}
+}
+
+// TestSourceHostIsInjective reproduces agent-message-queue-611.22.8 (B03
+// identities, host-collapse half): the creator host is part of the request
+// KEY, but it was derived by sanitizing a readable string — every illegal
+// rune mapped to '-', including the '@' that joined handle and project. So
+// From="a" with project "b" and a bare From="a-b" both produced "amq:a-b",
+// and unvalidated project names collapsed the same way ("web app" vs
+// "web-app"). Two distinct callers then shared ONE record: the second submit
+// was answered with the first's snapshot, and a cancel from one terminated
+// the other's run.
+func TestSourceHostIsInjective(t *testing.T) {
+	cases := []format.Header{
+		{From: "a", FromProject: "b"},
+		{From: "a-b"},
+		{From: "a", FromProject: "b-c"},
+		{From: "a-b", FromProject: "c"},
+		{From: "codex", FromProject: "web app"},
+		{From: "codex", FromProject: "web-app"},
+		{From: "codex"},
+		{From: "codex", FromProject: ""},
+	}
+	seen := map[string][]format.Header{}
+	for _, h := range cases {
+		got := SourceHost(h)
+		seen[got] = append(seen[got], h)
+	}
+	for host, headers := range seen {
+		// {From:"codex"} and {From:"codex", FromProject:""} are the SAME
+		// identity, so they may share a host; anything else may not.
+		distinct := map[[2]string]bool{}
+		for _, h := range headers {
+			distinct[[2]string{h.From, h.FromProject}] = true
+		}
+		if len(distinct) > 1 {
+			t.Fatalf("host %q is shared by %d distinct identities: %v", host, len(distinct), headers)
+		}
+	}
+	// The readable prefix must survive for humans and logs.
+	if got := SourceHost(format.Header{From: "codex", FromProject: "amq"}); !strings.HasPrefix(got, "amq:codex.amq.") {
+		t.Fatalf("host %q lost its readable prefix", got)
+	}
+	// And the derived host must still be usable as a path segment.
+	for _, h := range cases {
+		got := SourceHost(h)
+		if strings.ContainsAny(got, "/\\ ") {
+			t.Fatalf("host %q is not path-safe", got)
+		}
 	}
 }


### PR DESCRIPTION
Bead agent-message-queue-611.22.8 (B03 identities) — the host-collapse half. P1.

The creator host is part of the **request key**, so two senders must never derive the same one. It was built by sanitizing a readable string — every illegal rune maps to `-`, and the `@` joining handle and project **is itself illegal**, so:

| From | FromProject | old host |
|---|---|---|
| `a` | `b` | `amq:a-b` |
| `a-b` | — | `amq:a-b` |
| `codex` | `web app` | `amq:codex-web-app` |
| `codex` | `web-app` | `amq:codex-web-app` |

Two distinct callers shared **one record**: the second submit was answered with the first's snapshot, and a cancel from one **terminated the other's run**. Project names are unvalidated (a config string or a directory basename), so the collision is reachable without anything exotic.

Identity now rests on a digest of the exact `(from, project)` pair with a **length-prefixed** encoding, so `("ab","c")` and `("a","bc")` differ. The readable prefix survives for humans and logs; the result stays path-safe. Injective by construction, not by careful escaping.

The tests hardcoded the old derivation — they now **call** `SourceHost` rather than duplicate it, so a future change to the scheme cannot silently desync them. Verified RED without the fix (`host "amq:codex.web-app" is shared by 2 distinct identities`) and GREEN with it.

**Compatibility:** this changes how creator hosts, and therefore request keys, are derived. Remote is an unreleased preview (v0.78.0 is held), so no durable record in the field depends on the old scheme — doing this after release would have orphaned existing records.

**Not in scope** (rest of 611.22.8): the codex adapter's correlation also drops the host/target dimensions (`clientUserMessageId` and the `byClientID` index are the bare request id) — that one lives in `codex/attachment.go`, which PR #744 currently owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)